### PR TITLE
feat(catalog): add logo image endpoint for MCP servers

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -227,6 +227,74 @@ paths:
         required: true
       - $ref: "#/components/parameters/includeTools"
       - $ref: "#/components/parameters/toolLimit"
+  /api/mcp_catalog/v1alpha1/mcp_servers/{server_id}/logo:
+    description: >-
+      The REST endpoint/path used to fetch the logo image for an `MCPServer`.
+    get:
+      # This operation is served by a custom handler in the MCP plugin
+      # (internal/plugins/mcp/logo_handler.go): it returns raw image bytes or a
+      # 302 redirect, which the generated JSON controller cannot express.
+      # `x-internal` documents the endpoint in the published spec while excluding
+      # it from client/server code generation so the manual route is authoritative.
+      x-internal: true
+      summary: Get the logo image for an `MCPServer`.
+      description: >-
+        Returns the MCP server's logo. When the stored logo is an inline data URI, the decoded image bytes are served directly with the matching image content type (restricted to a set of known image media types). When the stored logo is a plain http(s) URL, the client is redirected to it.
+      tags:
+        - MCPCatalogService
+      parameters:
+        - name: server_id
+          description: A unique identifier for an `MCPServer`.
+          schema:
+            type: string
+          in: path
+          required: true
+      responses:
+        "200":
+          description: The MCP server logo image.
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/gif:
+              schema:
+                type: string
+                format: binary
+            image/webp:
+              schema:
+                type: string
+                format: binary
+            image/svg+xml:
+              schema:
+                type: string
+                format: binary
+            image/x-icon:
+              schema:
+                type: string
+                format: binary
+        "302":
+          description: >-
+            Redirect to the external logo URL when the stored logo is a plain http(s) URL rather than an inline data URI.
+          headers:
+            Location:
+              description: The external logo URL.
+              schema:
+                type: string
+                format: uri
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "415":
+          description: The stored logo has an unsupported media type.
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getMCPServerLogo
   /api/mcp_catalog/v1alpha1/mcp_servers/{server_id}/tools:
     description: >-
       The REST endpoint/path used to list zero or more `MCPTool` entities for an `MCPServer`.

--- a/api/openapi/src/plugins/mcp.yaml
+++ b/api/openapi/src/plugins/mcp.yaml
@@ -151,6 +151,78 @@ paths:
           type: string
         in: path
         required: true
+  /api/mcp_catalog/v1alpha1/mcp_servers/{server_id}/logo:
+    description: >-
+      The REST endpoint/path used to fetch the logo image for an `MCPServer`.
+    get:
+      # This operation is served by a custom handler in the MCP plugin
+      # (internal/plugins/mcp/logo_handler.go): it returns raw image bytes or a
+      # 302 redirect, which the generated JSON controller cannot express.
+      # `x-internal` documents the endpoint in the published spec while excluding
+      # it from client/server code generation so the manual route is authoritative.
+      x-internal: true
+      summary: Get the logo image for an `MCPServer`.
+      description: >-
+        Returns the MCP server's logo. When the stored logo is an inline data
+        URI, the decoded image bytes are served directly with the matching image
+        content type (restricted to a set of known image media types). When the
+        stored logo is a plain http(s) URL, the client is redirected to it.
+      tags:
+        - MCPCatalogService
+      parameters:
+        - name: server_id
+          description: A unique identifier for an `MCPServer`.
+          schema:
+            type: string
+          in: path
+          required: true
+      responses:
+        "200":
+          description: The MCP server logo image.
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/gif:
+              schema:
+                type: string
+                format: binary
+            image/webp:
+              schema:
+                type: string
+                format: binary
+            image/svg+xml:
+              schema:
+                type: string
+                format: binary
+            image/x-icon:
+              schema:
+                type: string
+                format: binary
+        "302":
+          description: >-
+            Redirect to the external logo URL when the stored logo is a plain
+            http(s) URL rather than an inline data URI.
+          headers:
+            Location:
+              description: The external logo URL.
+              schema:
+                type: string
+                format: uri
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "415":
+          description: The stored logo has an unsupported media type.
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+      operationId: getMCPServerLogo
 components:
   schemas:
     MCPServer:

--- a/catalog/internal/plugins/mcp/logo_handler.go
+++ b/catalog/internal/plugins/mcp/logo_handler.go
@@ -1,0 +1,173 @@
+package mcp
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/mcpcatalog"
+	"github.com/kubeflow/hub/pkg/api"
+)
+
+// maxLogoBytes bounds the size of a decoded data-URI logo. Logos are icons
+// (current catalog entries are all well under 10KB); this cap prevents an
+// oversized data URI from forcing a large per-request in-memory allocation.
+const maxLogoBytes = 1 << 20 // 1 MiB
+
+// allowedLogoTypes restricts the Content-Type served for data-URI logos to
+// known image mediatypes. Because this endpoint serves bytes from the catalog's
+// own origin (so downstream systems can reference logos by URL), an attacker who
+// controls a logo value could otherwise have us serve text/html or other active
+// content under our origin. See svgContentType handling for the SVG case.
+var allowedLogoTypes = map[string]bool{
+	"image/png":                true,
+	"image/jpeg":               true,
+	"image/gif":                true,
+	"image/webp":               true,
+	"image/svg+xml":            true,
+	"image/x-icon":             true,
+	"image/vnd.microsoft.icon": true,
+}
+
+const svgContentType = "image/svg+xml"
+
+func LogoHandler(provider mcpcatalog.MCPCatalogProvider) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		serverID := chi.URLParam(r, "server_id")
+		if serverID == "" {
+			http.Error(w, "missing server_id", http.StatusBadRequest)
+			return
+		}
+
+		server, err := provider.GetMCPServer(r.Context(), serverID, false, 0)
+		if err != nil {
+			if errors.Is(err, api.ErrNotFound) {
+				http.NotFound(w, r)
+			} else if errors.Is(err, api.ErrBadRequest) {
+				http.Error(w, "invalid server ID", http.StatusBadRequest)
+			} else {
+				http.Error(w, "internal error", http.StatusInternalServerError)
+			}
+			return
+		}
+		if server == nil {
+			http.NotFound(w, r)
+			return
+		}
+		if !server.HasLogo() {
+			http.NotFound(w, r)
+			return
+		}
+
+		logo := server.GetLogo()
+
+		// The URI scheme is case-insensitive (RFC 2397), so normalize before
+		// deciding how to handle the value.
+		if strings.HasPrefix(strings.ToLower(logo), "data:") {
+			serveDataURI(w, logo)
+			return
+		}
+
+		// Plain-URL logos are redirected. Restrict to http(s) so the value
+		// cannot be used as an open redirect into other schemes (javascript:,
+		// data:, etc.) or non-URL garbage.
+		u, err := url.Parse(logo)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			http.Error(w, "unsupported logo URL", http.StatusBadRequest)
+			return
+		}
+
+		http.Redirect(w, r, logo, http.StatusFound)
+	}
+}
+
+func serveDataURI(w http.ResponseWriter, dataURI string) {
+	// data:[<mediatype>][;base64],<data>
+	// The caller has already verified the "data:" prefix (case-insensitively),
+	// so strip it by length rather than a case-sensitive TrimPrefix.
+	rest := dataURI[len("data:"):]
+	metaAndData, data, found := strings.Cut(rest, ",")
+	if !found {
+		http.Error(w, "malformed data URI", http.StatusBadRequest)
+		return
+	}
+
+	mimeType := ""
+	isBase64 := false
+	for i, part := range strings.Split(metaAndData, ";") {
+		if i == 0 && strings.Contains(part, "/") {
+			mimeType = strings.ToLower(strings.TrimSpace(part))
+		} else if part == "base64" {
+			isBase64 = true
+		}
+	}
+
+	// Only serve known image mediatypes. This endpoint returns the bytes from
+	// our own origin, so serving an attacker-chosen Content-Type (e.g.
+	// text/html) would enable stored XSS in the catalog origin.
+	if !allowedLogoTypes[mimeType] {
+		http.Error(w, "unsupported logo media type", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	var body []byte
+	if isBase64 {
+		// Reject before decoding if the payload would exceed the cap, then
+		// clamp after decoding as a defense-in-depth bound.
+		if base64.StdEncoding.DecodedLen(len(data)) > maxLogoBytes {
+			http.Error(w, "logo too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		var err error
+		body, err = base64.StdEncoding.DecodeString(data)
+		if err != nil {
+			body, err = base64.RawStdEncoding.DecodeString(data)
+			if err != nil {
+				http.Error(w, "invalid base64 data", http.StatusBadRequest)
+				return
+			}
+		}
+	} else {
+		// Reject before unescaping if the payload is oversized. Percent-decoding
+		// never expands the input (each %XX triple decodes to one byte), so the
+		// encoded length is a safe upper bound on the decoded size and lets us
+		// bail out before allocating the decoded copy.
+		if len(data) > maxLogoBytes {
+			http.Error(w, "logo too large", http.StatusRequestEntityTooLarge)
+			return
+		}
+		// Non-base64 data URIs percent-encode their payload (RFC 2397), e.g.
+		// data:image/svg+xml,%3Csvg%3E...%3C/svg%3E. Decode it so the browser
+		// receives the real bytes instead of the literal %XX escapes.
+		decoded, err := url.PathUnescape(data)
+		if err != nil {
+			http.Error(w, "invalid data URI encoding", http.StatusBadRequest)
+			return
+		}
+		body = []byte(decoded)
+	}
+	if len(body) > maxLogoBytes {
+		http.Error(w, "logo too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	// Prevent MIME sniffing from reinterpreting the bytes as a different type.
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	// SVG is an active document format: if navigated to directly it can run
+	// embedded scripts in our origin. A restrictive CSP keeps the image
+	// renderable via <img> while neutralizing scripting/external references.
+	if mimeType == svgContentType {
+		w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
+	}
+
+	w.Header().Set("Content-Type", mimeType)
+	// Make the intended rendering explicit rather than relying on browser
+	// defaults: logos are meant to be displayed inline (e.g. via <img>).
+	w.Header().Set("Content-Disposition", "inline")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	_, _ = w.Write(body)
+}

--- a/catalog/internal/plugins/mcp/logo_handler_test.go
+++ b/catalog/internal/plugins/mcp/logo_handler_test.go
@@ -1,0 +1,340 @@
+package mcp
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/mcpcatalog"
+	openapi "github.com/kubeflow/hub/catalog/pkg/openapi"
+	"github.com/kubeflow/hub/pkg/api"
+)
+
+type mockProvider struct {
+	servers  map[string]*openapi.MCPServer
+	getError error
+}
+
+func (m *mockProvider) GetMCPServer(_ context.Context, serverID string, _ bool, _ int32) (*openapi.MCPServer, error) {
+	if m.getError != nil {
+		return nil, m.getError
+	}
+	s, ok := m.servers[serverID]
+	if !ok {
+		return nil, nil
+	}
+	return s, nil
+}
+
+func (m *mockProvider) ListMCPServers(context.Context, mcpcatalog.ListMCPServersParams) (openapi.MCPServerList, error) {
+	return openapi.MCPServerList{}, nil
+}
+func (m *mockProvider) ListMCPServerTools(context.Context, string, mcpcatalog.ListMCPServerToolsParams) (openapi.MCPToolsList, error) {
+	return openapi.MCPToolsList{}, nil
+}
+func (m *mockProvider) GetMCPServerTool(context.Context, string, string) (*openapi.MCPTool, error) {
+	return nil, nil
+}
+func (m *mockProvider) GetFilterOptions(context.Context) (*openapi.FilterOptionsList, error) {
+	return nil, nil
+}
+
+func newTestRouter(provider mcpcatalog.MCPCatalogProvider) *chi.Mux {
+	r := chi.NewRouter()
+	r.Get("/api/mcp_catalog/v1alpha1/mcp_servers/{server_id}/logo", LogoHandler(provider))
+	return r
+}
+
+func serverWithLogo(logo string) *openapi.MCPServer {
+	s := &openapi.MCPServer{}
+	s.SetLogo(logo)
+	return s
+}
+
+func TestLogoHandler_ServerNotFound(t *testing.T) {
+	provider := &mockProvider{servers: map[string]*openapi.MCPServer{}}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/999/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestLogoHandler_NoLogo(t *testing.T) {
+	provider := &mockProvider{
+		servers: map[string]*openapi.MCPServer{
+			"1": {},
+		},
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestLogoHandler_DataURI_SVG(t *testing.T) {
+	svgContent := `<svg xmlns="http://www.w3.org/2000/svg"><circle r="10"/></svg>`
+	dataURI := "data:image/svg+xml;base64," + base64.StdEncoding.EncodeToString([]byte(svgContent))
+
+	provider := &mockProvider{
+		servers: map[string]*openapi.MCPServer{
+			"1": serverWithLogo(dataURI),
+		},
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"))
+	assert.Equal(t, "public, max-age=3600", w.Header().Get("Cache-Control"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Contains(t, w.Header().Get("Content-Security-Policy"), "default-src 'none'")
+	assert.Contains(t, w.Header().Get("Content-Security-Policy"), "sandbox")
+	assert.Equal(t, svgContent, w.Body.String())
+}
+
+func TestLogoHandler_DataURI_PNG(t *testing.T) {
+	pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	dataURI := "data:image/png;base64," + base64.StdEncoding.EncodeToString(pngData)
+
+	provider := &mockProvider{
+		servers: map[string]*openapi.MCPServer{
+			"1": serverWithLogo(dataURI),
+		},
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/png", w.Header().Get("Content-Type"))
+	assert.Equal(t, "inline", w.Header().Get("Content-Disposition"))
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	// CSP is only needed for active formats like SVG; raster images don't get it.
+	assert.Empty(t, w.Header().Get("Content-Security-Policy"))
+	assert.Equal(t, pngData, w.Body.Bytes())
+}
+
+func TestLogoHandler_PlainURL_Redirect(t *testing.T) {
+	logoURL := "https://example.com/logo.png"
+	provider := &mockProvider{
+		servers: map[string]*openapi.MCPServer{
+			"1": serverWithLogo(logoURL),
+		},
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, logoURL, w.Header().Get("Location"))
+}
+
+func TestLogoHandler_MalformedDataURI(t *testing.T) {
+	provider := &mockProvider{
+		servers: map[string]*openapi.MCPServer{
+			"1": serverWithLogo("data:image/png;base64"),
+		},
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestLogoHandler_InvalidBase64(t *testing.T) {
+	provider := &mockProvider{
+		servers: map[string]*openapi.MCPServer{
+			"1": serverWithLogo("data:image/png;base64,!!!not-valid-base64!!!"),
+		},
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestLogoHandler_ProviderError(t *testing.T) {
+	provider := &mockProvider{
+		getError: fmt.Errorf("database connection failed"),
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestLogoHandler_ProviderNotFoundError(t *testing.T) {
+	provider := &mockProvider{
+		getError: fmt.Errorf("server not found: %w", api.ErrNotFound),
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/999/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestLogoHandler_ProviderBadRequestError(t *testing.T) {
+	provider := &mockProvider{
+		getError: fmt.Errorf("invalid ID: %w", api.ErrBadRequest),
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/abc/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestLogoHandler_DataURI_PlainText(t *testing.T) {
+	// A non-base64 data URI percent-encodes its payload (RFC 2397); it must be
+	// decoded to the real bytes rather than served with literal %XX escapes.
+	dataURI := "data:image/svg+xml,%3Csvg%3E%3C/svg%3E"
+	provider := &mockProvider{
+		servers: map[string]*openapi.MCPServer{
+			"1": serverWithLogo(dataURI),
+		},
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"))
+	assert.Equal(t, "<svg></svg>", w.Body.String())
+}
+
+func TestLogoHandler_DataURI_PlainText_TooLarge(t *testing.T) {
+	// An oversized percent-encoded (non-base64) payload must be rejected before
+	// unescaping, based on the encoded length.
+	big := strings.Repeat("A", (1<<20)+1)
+	dataURI := "data:image/svg+xml," + big
+	provider := &mockProvider{
+		servers: map[string]*openapi.MCPServer{
+			"1": serverWithLogo(dataURI),
+		},
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+}
+
+func TestLogoHandler_DataURI_RejectsNonImageMediaType(t *testing.T) {
+	// A logo that claims to be HTML must not be served with that Content-Type,
+	// otherwise it becomes stored XSS in the catalog origin.
+	htmlPayload := `<script>alert(document.domain)</script>`
+	dataURI := "data:text/html;base64," + base64.StdEncoding.EncodeToString([]byte(htmlPayload))
+	provider := &mockProvider{
+		servers: map[string]*openapi.MCPServer{
+			"1": serverWithLogo(dataURI),
+		},
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, w.Code)
+	assert.NotContains(t, w.Body.String(), "<script>")
+}
+
+func TestLogoHandler_DataURI_CaseInsensitiveScheme(t *testing.T) {
+	// The URI scheme is case-insensitive; an uppercase DATA: must still be
+	// decoded and served, not treated as a redirect target.
+	svgContent := `<svg xmlns="http://www.w3.org/2000/svg"></svg>`
+	dataURI := "DATA:image/svg+xml;base64," + base64.StdEncoding.EncodeToString([]byte(svgContent))
+	provider := &mockProvider{
+		servers: map[string]*openapi.MCPServer{
+			"1": serverWithLogo(dataURI),
+		},
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"))
+	assert.Equal(t, svgContent, w.Body.String())
+}
+
+func TestLogoHandler_RejectsNonHTTPRedirect(t *testing.T) {
+	for _, logo := range []string{
+		"javascript:alert(document.domain)",
+		"ftp://example.com/logo.png",
+		"//evil.example/logo.png",
+	} {
+		provider := &mockProvider{
+			servers: map[string]*openapi.MCPServer{
+				"1": serverWithLogo(logo),
+			},
+		}
+		r := newTestRouter(provider)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code, "logo %q should be rejected", logo)
+		assert.Empty(t, w.Header().Get("Location"), "logo %q should not redirect", logo)
+	}
+}
+
+func TestLogoHandler_DataURI_TooLarge(t *testing.T) {
+	// A decoded payload above the cap is rejected without being served.
+	big := strings.Repeat("A", (1<<20)+1)
+	dataURI := "data:image/png;base64," + base64.StdEncoding.EncodeToString([]byte(big))
+	provider := &mockProvider{
+		servers: map[string]*openapi.MCPServer{
+			"1": serverWithLogo(dataURI),
+		},
+	}
+	r := newTestRouter(provider)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp_catalog/v1alpha1/mcp_servers/1/logo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+}

--- a/catalog/internal/plugins/mcp/plugin.go
+++ b/catalog/internal/plugins/mcp/plugin.go
@@ -121,5 +121,7 @@ func (p *Plugin) RegisterRoutes(router chi.Router) error {
 		router.Method(route.Method, route.Pattern, route.HandlerFunc)
 	}
 
+	router.Get("/api/mcp_catalog/v1alpha1/mcp_servers/{server_id}/logo", LogoHandler(mcpProvider))
+
 	return nil
 }

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -98,6 +98,7 @@ const (
 	McpServerFilterOptionListPath = McpServerCatalogPathPrefix + "/mcp_servers_filter_options"
 	McpServerPath                 = McpServerListPath + "/:" + McpServerId
 	McpServersToolListPath        = McpServerPath + "/tools"
+	McpServerLogoPath             = McpServerPath + "/logo"
 
 	// Swagger UI (interactive API docs)
 	SwaggerPath    = ApiPathPrefix + "/swagger"
@@ -353,6 +354,7 @@ func (app *App) Routes() http.Handler {
 		apiRouter.GET(McpServerFilterOptionListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetMcpServersFiltersHandler))))
 		apiRouter.GET(McpServerPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetMcpServerHandler))))
 		apiRouter.GET(McpServersToolListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetMcpServersToolsHandler))))
+		apiRouter.GET(McpServerLogoPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetMcpServerLogoHandler))))
 
 		// MCP catalog settings page
 		apiRouter.GET(McpCatalogSettingsSourceConfigListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.GetAllMcpCatalogSourceConfigsHandler)))

--- a/clients/ui/bff/internal/api/errors.go
+++ b/clients/ui/bff/internal/api/errors.go
@@ -57,6 +57,28 @@ func (app *App) forbiddenResponse(w http.ResponseWriter, r *http.Request, messag
 	app.errorResponse(w, r, httpError)
 }
 
+// httpErrorFromRaw converts a non-2xx RawResponse into the structured HTTPError
+// used across the API. GETRaw (unlike GET) does not turn upstream error statuses
+// into HTTPErrors, so callers that proxy a RawResponse must translate failures
+// themselves rather than forwarding the upstream's plaintext body verbatim. It
+// prefers a JSON error body from upstream and falls back to a generic message.
+func httpErrorFromRaw(resp *httpclient.RawResponse) *httpclient.HTTPError {
+	var errorResponse httpclient.ErrorResponse
+	if err := json.Unmarshal(resp.Body, &errorResponse); err != nil {
+		errorResponse = httpclient.ErrorResponse{
+			Code:    strconv.Itoa(resp.StatusCode),
+			Message: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(resp.Body)),
+		}
+	}
+	if errorResponse.Code == "" {
+		errorResponse.Code = strconv.Itoa(resp.StatusCode)
+	}
+	return &httpclient.HTTPError{
+		StatusCode:    resp.StatusCode,
+		ErrorResponse: errorResponse,
+	}
+}
+
 func (app *App) errorResponse(w http.ResponseWriter, r *http.Request, error *httpclient.HTTPError) {
 
 	env := ErrorEnvelope{Error: error}

--- a/clients/ui/bff/internal/api/mcp_servers_catalog_handler.go
+++ b/clients/ui/bff/internal/api/mcp_servers_catalog_handler.go
@@ -150,3 +150,69 @@ func (app *App) GetMcpServersToolsHandler(w http.ResponseWriter, r *http.Request
 		app.serverErrorResponse(w, r, err)
 	}
 }
+
+func (app *App) GetMcpServerLogoHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelCatalogHttpClientKey).(httpclient.HTTPClientInterface)
+
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("catalog REST client not found"))
+		return
+	}
+
+	serverId := ps.ByName(McpServerId)
+
+	if serverId == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("server_id is required"))
+		return
+	}
+
+	resp, err := app.repositories.ModelCatalogClient.GetMcpServerLogo(client, serverId)
+
+	// GetMcpServerLogo uses GETRaw, which only returns an error for transport-level
+	// failures (never for upstream error statuses), so any non-nil err is a server error.
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	// Faithfully proxy the catalog logo response. For plain external-URL logos the
+	// catalog replies with a redirect, which we pass through so the browser follows it;
+	// for inline data-URI logos it replies with the decoded image bytes.
+	if resp.StatusCode >= http.StatusMultipleChoices && resp.StatusCode < http.StatusBadRequest {
+		if location := resp.Header.Get("Location"); location != "" {
+			w.Header().Set("Location", location)
+		}
+		w.WriteHeader(resp.StatusCode)
+		return
+	}
+
+	// GETRaw passes upstream error statuses through untouched, so translate any 4xx/5xx
+	// into the structured JSON error the rest of the API returns instead of forwarding
+	// the catalog's plaintext body (e.g. "404 page not found") verbatim.
+	if resp.StatusCode >= http.StatusBadRequest {
+		app.errorResponse(w, r, httpErrorFromRaw(resp))
+		return
+	}
+
+	// Forward an allowlist of upstream headers. Besides Content-Type and Cache-Control,
+	// this MUST include the catalog's protective headers (X-Content-Type-Options: nosniff
+	// and the SVG Content-Security-Policy): since we re-serve these bytes under the
+	// dashboard's own origin, dropping them would re-open the stored-XSS vector on
+	// SVG logos that those headers exist to prevent.
+	for _, h := range []string{
+		"Content-Type",
+		"Cache-Control",
+		"X-Content-Type-Options",
+		"Content-Security-Policy",
+		"Content-Disposition",
+	} {
+		if v := resp.Header.Get(h); v != "" {
+			w.Header().Set(h, v)
+		}
+	}
+
+	w.WriteHeader(resp.StatusCode)
+	if _, err := w.Write(resp.Body); err != nil {
+		app.logger.Error("failed to write mcp server logo response", "error", err)
+	}
+}

--- a/clients/ui/bff/internal/api/mcp_servers_catalog_handler_test.go
+++ b/clients/ui/bff/internal/api/mcp_servers_catalog_handler_test.go
@@ -80,5 +80,41 @@ var _ = Describe("TestMcpServersCatalogHandler", func() {
 			Expect(actual.Data.Size).To(Equal(expected.Data.Size))
 			Expect(len(actual.Data.Items)).To(Equal(len(expected.Data.Items)))
 		})
+
+		It("should retrieve the MCP server logo image", func() {
+			By("fetching the MCP server logo by server_id")
+			requestIdentity := kubernetes.RequestIdentity{
+				UserID: "user@example.com",
+			}
+
+			rs, body, err := serveApiTest(http.MethodGet, "/api/v1/mcp_catalog/mcp_servers/1/logo?namespace=kubeflow", nil, kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("should return the raw logo image bytes with an image content type")
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(rs.Header.Get("Content-Type")).To(HavePrefix("image/"))
+			Expect(rs.Header.Get("Content-Disposition")).To(Equal("inline"))
+			Expect(len(body)).To(BeNumerically(">", 0))
+
+			By("should preserve the catalog's protective headers so re-serving under the dashboard origin does not re-open stored XSS on SVG logos")
+			Expect(rs.Header.Get("X-Content-Type-Options")).To(Equal("nosniff"))
+			Expect(rs.Header.Get("Content-Security-Policy")).To(Equal("default-src 'none'; style-src 'unsafe-inline'; sandbox"))
+		})
+
+		It("should translate an upstream logo error into a structured JSON error", func() {
+			By("fetching a logo whose catalog response is a non-2xx status")
+			requestIdentity := kubernetes.RequestIdentity{
+				UserID: "user@example.com",
+			}
+
+			rs, body, err := serveApiTest(http.MethodGet, "/api/v1/mcp_catalog/mcp_servers/missing/logo?namespace=kubeflow", nil, kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+
+			By("should return the upstream status as a structured JSON error, not the raw plaintext body")
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+			Expect(rs.Header.Get("Content-Type")).To(Equal("application/json"))
+			Expect(string(body)).To(ContainSubstring(`"error"`))
+			Expect(string(body)).NotTo(Equal("404 page not found"))
+		})
 	})
 })

--- a/clients/ui/bff/internal/api/test_utils.go
+++ b/clients/ui/bff/internal/api/test_utils.go
@@ -20,14 +20,17 @@ import (
 	"github.com/kubeflow/hub/ui/bff/internal/repositories"
 )
 
-func setupApiTest[T any](method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string) (T, *http.Response, error) {
+// serveApiTest builds the test App with mocked clients, serves the request and returns
+// the raw response together with its (already read) body. Use it directly for non-JSON
+// responses (e.g. binary payloads); setupApiTest wraps it for JSON envelope responses.
+func serveApiTest(method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string) (*http.Response, []byte, error) {
 	mockMRClient, err := mocks.NewModelRegistryClient(nil)
 	if err != nil {
-		return *new(T), nil, err
+		return nil, nil, err
 	}
 	mockModelCatalogClient, err := mocks.NewModelCatalogClientMock(nil)
 	if err != nil {
-		return *new(T), nil, err
+		return nil, nil, err
 	}
 
 	mockClient := new(mocks.MockHTTPClient)
@@ -50,17 +53,17 @@ func setupApiTest[T any](method string, url string, body interface{}, k8Factory 
 	if body != nil {
 		r, err := json.Marshal(body)
 		if err != nil {
-			return *new(T), nil, err
+			return nil, nil, err
 		}
 		bytes.NewReader(r)
 		req, err = http.NewRequest(method, url, bytes.NewReader(r))
 		if err != nil {
-			return *new(T), nil, err
+			return nil, nil, err
 		}
 	} else {
 		req, err = http.NewRequest(method, url, nil)
 		if err != nil {
-			return *new(T), nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -87,6 +90,15 @@ func setupApiTest[T any](method string, url string, body interface{}, k8Factory 
 	rs := rr.Result()
 	defer rs.Body.Close()
 	respBody, err := io.ReadAll(rs.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rs, respBody, nil
+}
+
+func setupApiTest[T any](method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string) (T, *http.Response, error) {
+	rs, respBody, err := serveApiTest(method, url, body, k8Factory, requestIdentity, namespace)
 	if err != nil {
 		return *new(T), nil, err
 	}

--- a/clients/ui/bff/internal/integrations/httpclient/http.go
+++ b/clients/ui/bff/internal/integrations/httpclient/http.go
@@ -16,9 +16,19 @@ import (
 
 type HTTPClientInterface interface {
 	GET(url string) ([]byte, error)
+	GETRaw(url string) (*RawResponse, error)
 	POST(url string, body io.Reader) ([]byte, error)
 	POSTWithContentType(url string, body io.Reader, contentType string) ([]byte, error)
 	PATCH(url string, body io.Reader) ([]byte, error)
+}
+
+// RawResponse is an unprocessed upstream response. Unlike GET, it preserves the
+// status code and headers and does not treat non-200 responses as errors, so
+// callers can faithfully proxy binary payloads (e.g. logo images) and redirects.
+type RawResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
 }
 
 type HTTPClient struct {
@@ -115,6 +125,50 @@ func (c *HTTPClient) GET(url string) ([]byte, error) {
 	}
 
 	return body, nil
+}
+
+func (c *HTTPClient) GETRaw(url string) (*RawResponse, error) {
+	requestId := uuid.NewString()
+
+	fullURL := c.baseURL + url
+	req, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	c.applyHeaders(req)
+
+	logUpstreamReq(c.logger, requestId, req)
+
+	// Use a redirect-disabled client so upstream 3xx responses are returned as-is
+	// (ErrUseLastResponse yields the redirect response instead of following it). This
+	// lets us proxy the catalog logo endpoint faithfully: image bytes for inline
+	// data-URI logos, or a pass-through redirect for plain external URLs. It reuses the
+	// shared Transport without mutating the shared client's redirect policy.
+	noRedirectClient := &http.Client{
+		Transport: c.client.Transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	response, err := noRedirectClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	body, err := io.ReadAll(response.Body)
+	logUpstreamResp(c.logger, requestId, response, body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+
+	return &RawResponse{
+		StatusCode: response.StatusCode,
+		Header:     response.Header,
+		Body:       body,
+	}, nil
 }
 
 func (c *HTTPClient) POST(url string, body io.Reader) ([]byte, error) {

--- a/clients/ui/bff/internal/mocks/http_mock.go
+++ b/clients/ui/bff/internal/mocks/http_mock.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"io"
 
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/httpclient"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -17,6 +18,11 @@ func (c *MockHTTPClient) GetModelRegistryID() string {
 func (m *MockHTTPClient) GET(url string) ([]byte, error) {
 	args := m.Called(url)
 	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *MockHTTPClient) GETRaw(url string) (*httpclient.RawResponse, error) {
+	args := m.Called(url)
+	return args.Get(0).(*httpclient.RawResponse), args.Error(1)
 }
 
 func (m *MockHTTPClient) POST(url string, body io.Reader) ([]byte, error) {

--- a/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
+++ b/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -464,6 +465,34 @@ func (m *ModelCatalogClientMock) GetMcpServersTools(client httpclient.HTTPClient
 	mcpServerTools := GetMcpToolListMock()
 
 	return &mcpServerTools, nil
+}
+
+func (m *ModelCatalogClientMock) GetMcpServerLogo(client httpclient.HTTPClientInterface, serverId string) (*httpclient.RawResponse, error) {
+	// Simulate an upstream failure so tests can verify the BFF translates a raw
+	// non-2xx response into a structured JSON error rather than forwarding the
+	// catalog's plaintext body verbatim. GETRaw surfaces such responses without erroring.
+	if serverId == "missing" {
+		return &httpclient.RawResponse{
+			StatusCode: http.StatusNotFound,
+			Header:     http.Header{},
+			Body:       []byte("404 page not found"),
+		}, nil
+	}
+
+	svg := []byte(`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"></svg>`)
+	// Mirror the catalog logo handler's protective headers for SVG so tests can
+	// verify they survive the BFF passthrough.
+	header := http.Header{}
+	header.Set("Content-Type", "image/svg+xml")
+	header.Set("Content-Disposition", "inline")
+	header.Set("X-Content-Type-Options", "nosniff")
+	header.Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; sandbox")
+
+	return &httpclient.RawResponse{
+		StatusCode: http.StatusOK,
+		Header:     header,
+		Body:       svg,
+	}, nil
 }
 
 // filterAgentsByQuery parses a simple filterQuery (e.g. "framework='LangGraph' AND category IN ('Web search','MCP')")

--- a/clients/ui/bff/internal/repositories/mcp_server_catalog.go
+++ b/clients/ui/bff/internal/repositories/mcp_server_catalog.go
@@ -17,6 +17,7 @@ type McpServerCatalogInterface interface {
 	GetMcpServersFilter(client httpclient.HTTPClientInterface) (*models.FilterOptionsList, error)
 	GetMcpServer(client httpclient.HTTPClientInterface, serverId string, pageValues url.Values) (*models.McpServer, error)
 	GetMcpServersTools(client httpclient.HTTPClientInterface, serverId string) (*models.McpToolList, error)
+	GetMcpServerLogo(client httpclient.HTTPClientInterface, serverId string) (*httpclient.RawResponse, error)
 }
 
 type McpServerCatalog struct {
@@ -115,4 +116,23 @@ func (a *McpServerCatalog) GetMcpServersTools(client httpclient.HTTPClientInterf
 		Size:          mcpServerTools.Size,
 		Items:         wrappedItems,
 	}, nil
+}
+
+// GetMcpServerLogo fetches the raw logo response for an MCP server. It returns the
+// upstream status, headers and body unprocessed so the caller can faithfully proxy
+// either the decoded image bytes (inline data-URI logos) or a redirect (external URLs).
+func (a *McpServerCatalog) GetMcpServerLogo(client httpclient.HTTPClientInterface, serverId string) (*httpclient.RawResponse, error) {
+	path, err := url.JoinPath(mcpServerPath, serverId, "logo")
+
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.GETRaw(path)
+
+	if err != nil {
+		return nil, fmt.Errorf("error fetching mcp server logo: %w", err)
+	}
+
+	return resp, nil
 }


### PR DESCRIPTION
## Summary

- Adds `GET /api/mcp_catalog/v1alpha1/mcp_servers/{server_id}/logo` endpoint that serves MCP server logos as browser-loadable images
- For **base64 data URI** logos: decodes the payload and serves raw image bytes with the correct `Content-Type` and `Cache-Control: public, max-age=3600`
- For **plain URL** logos: returns a `302 Found` redirect to the original URL
- Proper error handling: `404` for missing servers/logos, `400` for invalid IDs

### Motivation

External systems like MLflow's MCP server registry require HTTP URLs for icon references (`icons[].src`). The catalog currently stores logos as inline base64 data URIs, which can't be used directly. This endpoint gives every MCP server a stable, linkable URL for its logo.

### Files changed

- `catalog/internal/plugins/mcp/logo_handler.go` — handler + data URI parser
- `catalog/internal/plugins/mcp/logo_handler_test.go` — 11 test cases
- `catalog/internal/plugins/mcp/plugin.go` — registers the custom route

## Test plan

- [x] Unit tests cover: data URI SVG/PNG decode, plain URL redirect, not-found, bad-request, malformed data URI, invalid base64, provider errors
- [x] `make build/compile` passes
- [x] `make -C catalog test` passes
- [x] `golangci-lint` clean on changed files
- [x] Manual test against live server with Red Hat MCP catalog data (base64 logos → 200, URL logos → 302, missing → 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)