### PR TITLE
fix(async-upload): scope S3 downloads to directory prefix

### DIFF
--- a/jobs/async-upload/job/download.py
+++ b/jobs/async-upload/job/download.py
@@ -47,7 +47,7 @@ def download_from_s3(config: S3StorageConfig, storage_path: str):
     )
 
     bucket_name = config.bucket
-    prefix = config.key
+    prefix = config.key if config.key.endswith("/") else f"{config.key}/"
 
     # TODO: It might make sense to check if the provided key points to a single file first before assuming the directory needs to be traversed
 

--- a/jobs/async-upload/tests/test_download.py
+++ b/jobs/async-upload/tests/test_download.py
@@ -113,8 +113,11 @@ def test_unpack_archive_file(dummy_archive, tmp_path):
     assert result == DUMMY_FILE_DATA
 
 
-def test_download_from_s3(minimal_update_artifact_env_source_dest_vars):
-    """Test download_from_s3 now that it pages through prefixes."""
+@pytest.mark.parametrize("source_key", ["test-key", "test-key/"])
+def test_download_from_s3(minimal_update_artifact_env_source_dest_vars, source_key):
+    """Test download_from_s3 pages through a directory prefix."""
+
+    os.environ["MODEL_SYNC_SOURCE_AWS_KEY"] = source_key
 
     # load config from your fixture
     config = get_config([])
@@ -122,7 +125,7 @@ def test_download_from_s3(minimal_update_artifact_env_source_dest_vars):
     # sanity-check config
     assert isinstance(config.source, S3StorageConfig)
     assert config.source.bucket == "test-bucket"
-    assert config.source.key == "test-key"
+    assert config.source.key == source_key
 
     # use whatever path came back in config
     storage_path = config.storage.path
@@ -172,7 +175,7 @@ def test_download_from_s3(minimal_update_artifact_env_source_dest_vars):
         mock_s3.get_paginator.assert_called_once_with("list_objects_v2")
         mock_paginator.paginate.assert_called_once_with(
             Bucket="test-bucket",
-            Prefix="test-key",
+            Prefix="test-key/",
         )
 
         # build expected download calls using the real storage_path


### PR DESCRIPTION
## Description

S3 treats `Prefix` as a raw string. With `my-model`, a bucket containing `my-model/model.onnx` and `my-model-backup/unrelated.bin` returns both
The second path lands outside the staging dir, pretty easy to hit in shared buckets 

This adds the trailing `/` for directory listings. Keys already ending in `/` stay unchanged.

## How Has This Been Tested?

Repro:
1. Add the two keys above to MinIO.
2. Run the job with `MODEL_SYNC_SOURCE_AWS_KEY=my-model`.
3. Before this fix both objects are downloaded, now only `my-model/model.onnx` is.

Passed all 55 async upload unit tests, `make build/compile`, `make lint`, and `make vet`
A real MinIO check passed too

Broad `make test` was also run, but unrelated MySQL testcontainers timed out on startup

## Merge criteria:

- [x] All commits are signed off.
- [x] The commit has a meaningful message.
- [x] Automated tests are included.
- [x] The change was manually tested with MinIO.
- [x] Code follows the contribution guidelines.