### PR TITLE
Add serverJson section to MCP details page

### DIFF
--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -3512,6 +3512,13 @@ components:
           $ref: "#/components/schemas/McpEndpoints"
         runtimeMetadata:
           $ref: "#/components/schemas/McpRuntimeMetadata"
+        serverJson:
+          type: object
+          description: |-
+            MCP server.json conformant structure. Opaque to this API; the
+            schema is defined by the MCP specification and may evolve independently.
+            See https://registry.modelcontextprotocol.io/docs#/schemas/ServerJSON for details.
+          additionalProperties: true
     McpServerList:
       description: List of McpServer entities.
       allOf:

--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -2744,9 +2744,116 @@ func CreateMcpCatalogSourcePreviewMockWithFilter(filterStatus string, pageSize i
 	return filterAndPaginatePreviewItems(GetMcpServersWithInclusionStatusListMocks(), GetMcpCatalogSourcePreviewSummaryMock(), filterStatus, pageSize, nextPageToken)
 }
 
+func mustParseServerJson(raw string) map[string]interface{} {
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		panic(fmt.Sprintf("invalid serverJson mock: %v", err))
+	}
+	return result
+}
+
 func GetMcpServerMocks() []models.McpServer {
 	trueVal := true
 	falseVal := false
+	prometheusServerJson := mustParseServerJson(`{
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+		"name": "org.mariadb/mariadb-mcp",
+		"description": "A standard interface for managing and querying MariaDB databases. Supports SQL operations and schema inspection.",
+		"title": "MariaDB MCP Server",
+		"version": "1.0.0",
+		"websiteUrl": "https://github.com/mariadb/mcp",
+		"packages": [
+			{
+				"environmentVariables": [
+					{
+						"description": "MariaDB username (from secret mariadb-credentials)",
+						"isRequired": true,
+						"isSecret": true,
+						"name": "DB_USER"
+					},
+					{
+						"description": "MariaDB password (from secret mariadb-credentials)",
+						"isRequired": true,
+						"isSecret": true,
+						"name": "DB_PASSWORD"
+					},
+					{
+						"description": "MariaDB server hostname",
+						"isRequired": true,
+						"name": "DB_HOST"
+					},
+					{
+						"description": "MariaDB database name (optional; can be set per query)",
+						"isRequired": false,
+						"name": "DB_NAME"
+					},
+					{
+						"default": "3306",
+						"description": "MariaDB server port (default 3306)",
+						"isRequired": false,
+						"name": "DB_PORT"
+					},
+					{
+						"default": "true",
+						"description": "Enforce read-only mode for SQL queries (default true)",
+						"isRequired": false,
+						"name": "MCP_READ_ONLY"
+					},
+					{
+						"description": "Comma-separated list of allowed Host header values",
+						"isRequired": true,
+						"name": "ALLOWED_HOSTS"
+					}
+				],
+				"identifier": "quay.io/rhoai-partner-mcp/ubi10-mariadb-mcp:f94b043241c702c607e88274da83f8482e3e7d56",
+				"packageArguments": [
+					{ "type": "positional", "value": "python" },
+					{ "type": "positional", "value": "src/server.py" },
+					{ "name": "--host", "type": "named", "value": "0.0.0.0" },
+					{ "name": "--transport", "type": "named", "value": "http" },
+					{ "name": "--port", "type": "named", "value": "9001" }
+				],
+				"registryType": "oci",
+				"runtimeHint": "docker",
+				"transport": {
+					"type": "streamable-http",
+					"url": "http://localhost:9001/mcp"
+				}
+			}
+		],
+		"repository": {
+			"source": "github",
+			"url": "https://github.com/mariadb/mcp"
+		}
+	}`)
+	kubernetesServerJson := mustParseServerJson(`{
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+		"name": "kubernetes-mcp-server",
+		"description": "Manage Kubernetes resources and query cluster state",
+		"title": "Kubernetes",
+		"version": "1.2.0",
+		"websiteUrl": "https://github.com/cncf/kubernetes-mcp-server",
+		"remotes": [
+			{
+				"type": "streamable-http",
+				"url": "https://kubernetes-mcp-server.demo-namespace.svc.cluster.local:8080"
+			}
+		]
+	}`)
+	dynatraceServerJson := mustParseServerJson(`{
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+		"name": "dynatrace-mcp-server",
+		"description": "Official Dynatrace-OSS project exposing DQL queries, problem feeds, and vulnerability data. Gives agents real-time service health, letting them recommend rollbacks or capacity fixes inside OpenShift.",
+		"title": "Dynatrace",
+		"version": "2.0.4",
+		"websiteUrl": "https://github.com/dynatrace-oss/dynatrace-mcp",
+		"remotes": [
+			{
+				"type": "streamable-http",
+				"url": "https://dynatrace-mcp-server.demo-namespace.svc.cluster.local:8080"
+			}
+		]
+	}`)
 
 	prometheusMcp := models.McpServer{
 		ID:          "1",
@@ -2796,6 +2903,7 @@ func GetMcpServerMocks() []models.McpServer {
 		SourceCode:    stringToPointer("prometheus-community/prometheus-mcp"),
 		RepositoryURL: stringToPointer("https://github.com/prometheus-community/prometheus-mcp"),
 		LastUpdated:   stringToPointer("1706745600000"),
+		ServerJson:    prometheusServerJson,
 	}
 
 	kubernetesMcp := models.McpServer{
@@ -2830,6 +2938,7 @@ func GetMcpServerMocks() []models.McpServer {
 		SourceCode:    stringToPointer("cncf/kubernetes-mcp-server"),
 		RepositoryURL: stringToPointer("https://github.com/cncf/kubernetes-mcp-server"),
 		LastUpdated:   stringToPointer("1709913600000"),
+		ServerJson:    kubernetesServerJson,
 	}
 
 	elasticMcp := models.McpServer{
@@ -2884,6 +2993,7 @@ func GetMcpServerMocks() []models.McpServer {
 		DocumentationURL: stringToPointer("https://github.com/dynatrace-oss/dynatrace-mcp-server/blob/main/README.md"),
 		Readme:           stringToPointer("# Dynatrace MCP Server\n\nThe local Dynatrace MCP server allows AI Assistants to interact with the Dynatrace observability platform, bringing real-time observability data directly into your development workflow.\n\n**Note:** This product is not officially supported by Dynatrace.\n\nIf you need help, please contact us via GitHub Issues if you have feature requests, questions, or need help.\n\n## Quickstart\n\nYou can add this MCP server to your MCP Client like VSCode, Claude, Cursor, Amazon Q, Windsurf, ChatGPT, or GitHub Copilot via the command `npx -y @dynatrace-oss/dynatrace-mcp-server` (type: stdio). For more details, please refer to the configuration section below.\n\nFurthermore, you need to configure the URL to a Dynatrace environment:\n\n- `DT_ENVIRONMENT` (string, e.g., https://abc12345.apps.dynatrace.com) - URL to your Dynatrace Platform (do not use Dynatrace classic URLs like abc12345.live.dynatrace.com)\n\nOnce we are done, we recommend looking into example prompts, like \"Get all details of the entity 'my-service'\" or \"Show me error logs\". Please mind that these prompts lead to executing DQL statements which may incur costs in accordance to your licence.\n\n## Use Cases\n\n- **Real-time observability** - Fetch production-level data for early detection and proactive monitoring\n- **Contextual debugging** - Fix issues with full context from monitored exceptions, logs, and anomalies\n- **Security insights** - Get detailed vulnerability analysis and security problem tracking\n- **Natural language queries** - Use AI-powered DQL generation and explanation\n- **Multi-phase incident investigation** - Systematic 4-phase approach with automated impact assessment\n\n## Tools\n\n| Tool | Description |\n|------|-------------|\n| `execute_dql` | Execute Dynatrace Query Language (DQL) queries |\n| `get_problems` | Retrieve current problems and incidents |\n| `get_service_health` | Get health status of services |\n| `get_vulnerabilities` | Retrieve security vulnerability data |\n| `create_maintenance_window` | Create a maintenance window to suppress alerts |\n"),
 		LastUpdated:      stringToPointer("1704067200000"),
+		ServerJson:       dynatraceServerJson,
 	}
 
 	grafanaMcp := models.McpServer{

--- a/clients/ui/bff/internal/models/mcp_server_catalog.go
+++ b/clients/ui/bff/internal/models/mcp_server_catalog.go
@@ -175,6 +175,7 @@ type McpServer struct {
 	Endpoints          *McpEndpoints                     `json:"endpoints,omitempty"`
 	RuntimeMetadata    *McpRuntimeMetadata               `json:"runtimeMetadata,omitempty"`
 	CustomProperties   *map[string]openapi.MetadataValue `json:"customProperties,omitempty"`
+	ServerJson         map[string]interface{}            `json:"serverJson,omitempty"`
 }
 
 type McpServerList struct {

--- a/clients/ui/frontend/src/__mocks__/mockMcpCatalogTestData.ts
+++ b/clients/ui/frontend/src/__mocks__/mockMcpCatalogTestData.ts
@@ -26,6 +26,42 @@ export const mockMcpServer = (partial?: Partial<McpServer>): McpServer => ({
   transports: ['http'],
   tags: ['kubernetes', 'infrastructure'],
   readme: '# Kubernetes MCP Server\n\n### Overview\n\nManage clusters with `kubectl`.',
+  serverJson: {
+    $schema: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
+    name: 'kubernetes-mcp-server',
+    description: 'Control and inspect Kubernetes clusters.',
+    title: 'Kubernetes',
+    version: '1.0.0',
+    websiteUrl: 'https://github.com/kubernetes/mcp-server',
+    packages: [
+      {
+        environmentVariables: [
+          {
+            description: 'Path to kubeconfig',
+            isRequired: true,
+            isSecret: true,
+            name: 'KUBECONFIG',
+          },
+        ],
+        identifier: 'ghcr.io/kubernetes/mcp-server:latest',
+        packageArguments: [
+          { type: 'positional', value: 'npx' },
+          { type: 'positional', value: '-y' },
+          { type: 'positional', value: '@cncf/kubernetes-mcp-server' },
+        ],
+        registryType: 'oci',
+        runtimeHint: 'docker',
+        transport: {
+          type: 'streamable-http',
+          url: 'https://kubernetes-mcp-server.demo-namespace.svc.cluster.local:8080',
+        },
+      },
+    ],
+    repository: {
+      source: 'github',
+      url: 'https://github.com/kubernetes/mcp-server',
+    },
+  },
   ...partial,
 });
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/mcpCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/mcpCatalog.ts
@@ -118,6 +118,14 @@ class McpServerDetails {
     return cy.findByTestId('mcp-server-no-readme');
   }
 
+  findServerJsonCard() {
+    return cy.findByTestId('mcp-server-json-card');
+  }
+
+  findServerJsonCode() {
+    return cy.findByTestId('mcp-server-json-code');
+  }
+
   findVersion() {
     return cy.findByTestId('mcp-server-version');
   }

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalog/mcpServerDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalog/mcpServerDetails.cy.ts
@@ -21,6 +21,7 @@ const customServer = mockMcpServer({
   source_id: 'sample', // eslint-disable-line camelcase
   toolCount: 0,
   readme: undefined,
+  serverJson: undefined,
 });
 
 describe('MCP Server Details Page', () => {
@@ -119,6 +120,32 @@ describe('MCP Server Details Page', () => {
       mcpServerDetails.visit(customServer.id);
       mcpServerDetails.findNoReadme().should('be.visible');
       mcpServerDetails.findNoReadme().should('contain.text', 'No README available');
+    });
+  });
+
+  describe('Server.json card', () => {
+    it('should render mapped remotes from backend packages serverJson', () => {
+      initServerDetailIntercept(kubernetesServer);
+      mcpServerDetails.visit(kubernetesServer.id);
+      mcpServerDetails.findServerJsonCard().should('be.visible');
+      mcpServerDetails.findServerJsonCode().should('contain.text', 'kubernetes-mcp-server');
+      mcpServerDetails.findServerJsonCode().should('contain.text', '$schema');
+      mcpServerDetails.findServerJsonCode().should('contain.text', 'remotes');
+      mcpServerDetails
+        .findServerJsonCode()
+        .should(
+          'contain.text',
+          'https://kubernetes-mcp-server.demo-namespace.svc.cluster.local:8080',
+        );
+      mcpServerDetails.findServerJsonCode().should('not.contain.text', 'environmentVariables');
+      mcpServerDetails.findServerJsonCode().should('not.contain.text', 'packageArguments');
+      mcpServerDetails.findServerJsonCode().should('not.contain.text', 'repository');
+    });
+
+    it('should hide Server.json card when serverJson is absent', () => {
+      initServerDetailIntercept(customServer);
+      mcpServerDetails.visit(customServer.id);
+      mcpServerDetails.findServerJsonCard().should('not.exist');
     });
   });
 

--- a/clients/ui/frontend/src/app/mcpServerCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/mcpServerCatalogTypes.ts
@@ -151,6 +151,7 @@ export type McpServer = {
   deploymentMode?: McpDeploymentMode;
   endpoints?: McpEndpoints;
   runtimeMetadata?: McpRuntimeMetadata;
+  serverJson?: Record<string, unknown>;
 };
 
 export type McpServerList = PaginationParams & { items?: McpServer[] };

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpServerDetailsView.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/screens/McpServerDetailsView.tsx
@@ -23,10 +23,14 @@ import {
 import { GithubIcon, OutlinedClockIcon } from '@patternfly/react-icons';
 import type { McpServer } from '~/app/mcpServerCatalogTypes';
 import ExternalLink from '~/app/shared/components/ExternalLink';
+import CodeBlockComponent from '~/app/shared/markdown/components/CodeBlockComponent';
 import MarkdownComponent from '~/app/shared/markdown/MarkdownComponent';
 import ModelTimestamp from '~/app/pages/modelRegistry/screens/components/ModelTimestamp';
 import McpServerToolsSection from '~/app/pages/mcpCatalog/screens/McpServerToolsSection';
-import { getMcpServerPrimaryEndpoint } from '~/app/pages/mcpCatalog/utils/mcpCatalogUtils';
+import {
+  getMcpServerPrimaryEndpoint,
+  toDisplayServerJson,
+} from '~/app/pages/mcpCatalog/utils/mcpCatalogUtils';
 
 type McpServerDetailsViewProps = {
   server: McpServer;
@@ -65,6 +69,9 @@ const McpServerDetailsView: React.FC<McpServerDetailsViewProps> = ({ server }) =
   const deploymentModeLabel = getDeploymentModeLabel(server.deploymentMode);
   const transportTypeLabel = getTransportTypeLabel(server.transports);
   const primaryEndpoint = getMcpServerPrimaryEndpoint(server.endpoints);
+  const serverJsonContent = server.serverJson
+    ? JSON.stringify(toDisplayServerJson(server.serverJson), null, 2)
+    : undefined;
 
   return (
     <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'noPadding' }}>
@@ -90,6 +97,22 @@ const McpServerDetailsView: React.FC<McpServerDetailsViewProps> = ({ server }) =
             <StackItem>
               <McpServerToolsSection serverId={server.id} />
             </StackItem>
+            {serverJsonContent && (
+              <StackItem>
+                <Card data-testid="mcp-server-json-card">
+                  <CardHeader>
+                    <Title headingLevel="h2" size="lg">
+                      Server.json
+                    </Title>
+                  </CardHeader>
+                  <CardBody>
+                    <div data-testid="mcp-server-json-code">
+                      <CodeBlockComponent>{serverJsonContent}</CodeBlockComponent>
+                    </div>
+                  </CardBody>
+                </Card>
+              </StackItem>
+            )}
             <StackItem>
               <Card>
                 <CardHeader>

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/utils/__tests__/mcpCatalogUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/utils/__tests__/mcpCatalogUtils.spec.ts
@@ -3,6 +3,7 @@ import {
   getSecurityIndicatorLabels,
   hasMcpFiltersApplied,
   isMcpRemoteDeploymentMode,
+  toDisplayServerJson,
 } from '~/app/pages/mcpCatalog/utils/mcpCatalogUtils';
 import type { McpCatalogFiltersState } from '~/app/pages/mcpCatalog/types/mcpCatalogFilterOptions';
 
@@ -118,5 +119,89 @@ describe('hasMcpFiltersApplied', () => {
     expect(hasMcpFiltersApplied({ deploymentMode: 'Local' as unknown as string[] }, '')).toBe(
       false,
     );
+  });
+});
+
+describe('toDisplayServerJson', () => {
+  it('maps packages.transport into remotes and drops heavy fields', () => {
+    expect(
+      toDisplayServerJson({
+        $schema: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
+        name: 'org.mariadb/mariadb-mcp',
+        description: 'MariaDB MCP',
+        title: 'MariaDB MCP Server',
+        version: '1.0.0',
+        websiteUrl: 'https://github.com/mariadb/mcp',
+        packages: [
+          {
+            identifier: 'quay.io/example/mariadb-mcp:latest',
+            environmentVariables: [{ name: 'DB_USER', isRequired: true }],
+            packageArguments: [{ type: 'positional', value: 'python' }],
+            registryType: 'oci',
+            runtimeHint: 'docker',
+            transport: {
+              type: 'streamable-http',
+              url: 'http://localhost:9001/mcp',
+            },
+          },
+        ],
+        repository: { source: 'github', url: 'https://github.com/mariadb/mcp' },
+      }),
+    ).toEqual({
+      $schema: 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json',
+      name: 'org.mariadb/mariadb-mcp',
+      description: 'MariaDB MCP',
+      title: 'MariaDB MCP Server',
+      version: '1.0.0',
+      websiteUrl: 'https://github.com/mariadb/mcp',
+      remotes: [
+        {
+          type: 'streamable-http',
+          url: 'http://localhost:9001/mcp',
+        },
+      ],
+    });
+  });
+
+  it('prefers existing remotes over packages', () => {
+    expect(
+      toDisplayServerJson({
+        name: 'dynatrace-mcp-server',
+        remotes: [
+          {
+            type: 'streamable-http',
+            url: 'https://dynatrace-mcp-server.demo-namespace.svc.cluster.local:8080',
+          },
+        ],
+        packages: [
+          {
+            transport: {
+              type: 'streamable-http',
+              url: 'http://should-not-use',
+            },
+          },
+        ],
+      }),
+    ).toEqual({
+      name: 'dynatrace-mcp-server',
+      remotes: [
+        {
+          type: 'streamable-http',
+          url: 'https://dynatrace-mcp-server.demo-namespace.svc.cluster.local:8080',
+        },
+      ],
+    });
+  });
+
+  it('omits remotes when neither remotes nor package transports are present', () => {
+    expect(
+      toDisplayServerJson({
+        name: 'example',
+        packages: [{ identifier: 'quay.io/example' }],
+        repository: { source: 'github', url: 'https://example.com' },
+      }),
+    ).toEqual({
+      name: 'example',
+    });
   });
 });

--- a/clients/ui/frontend/src/app/pages/mcpCatalog/utils/mcpCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/mcpCatalog/utils/mcpCatalogUtils.ts
@@ -63,3 +63,81 @@ const FRONTEND_TO_BACKEND_FILTER_KEY: Record<string, string> = Object.fromEntrie
 export function mcpFiltersToFilterQuery(filters: McpCatalogFiltersState): string {
   return stringFiltersToFilterQuery(filters, FRONTEND_TO_BACKEND_FILTER_KEY);
 }
+
+type McpServerJsonRemote = {
+  type: string;
+  url: string;
+};
+
+const DISPLAY_SERVER_JSON_KEYS = [
+  '$schema',
+  'name',
+  'description',
+  'title',
+  'version',
+  'websiteUrl',
+] as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const getRemotesFromPackages = (packages: unknown): McpServerJsonRemote[] => {
+  if (!Array.isArray(packages)) {
+    return [];
+  }
+
+  return packages.flatMap((pkg) => {
+    if (!isRecord(pkg)) {
+      return [];
+    }
+    const { transport } = pkg;
+    if (!isRecord(transport)) {
+      return [];
+    }
+    const { type, url } = transport;
+    if (typeof type !== 'string' || typeof url !== 'string' || !type || !url) {
+      return [];
+    }
+    return [{ type, url }];
+  });
+};
+
+const getExistingRemotes = (remotes: unknown): McpServerJsonRemote[] => {
+  if (!Array.isArray(remotes)) {
+    return [];
+  }
+
+  return remotes.flatMap((remote) => {
+    if (!isRecord(remote)) {
+      return [];
+    }
+    const { type, url } = remote;
+    if (typeof type !== 'string' || typeof url !== 'string' || !type || !url) {
+      return [];
+    }
+    return [{ type, url }];
+  });
+};
+
+/** Maps opaque catalog serverJson into the compact remotes display shape. */
+export const toDisplayServerJson = (
+  serverJson: Record<string, unknown>,
+): Record<string, unknown> => {
+  const display: Record<string, unknown> = {};
+
+  DISPLAY_SERVER_JSON_KEYS.forEach((key) => {
+    if (key in serverJson) {
+      display[key] = serverJson[key];
+    }
+  });
+
+  const remotesFromField = getExistingRemotes(serverJson.remotes);
+  const remotes =
+    remotesFromField.length > 0 ? remotesFromField : getRemotesFromPackages(serverJson.packages);
+
+  if (remotes.length > 0) {
+    display.remotes = remotes;
+  }
+
+  return display;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to add server.json section to the MCP details page.
<img width="1508" height="911" alt="Screenshot 2026-08-10 at 5 11 05 PM" src="https://github.com/user-attachments/assets/bfade890-2bd2-4af0-9391-6b338a75f1bf" />


## How Has This Been Tested?
Run the application in mock mode and see the MCP details page -  we will have a new section called Server.json under tools section.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
