### PR TITLE
feat(catalog): log summary when agent catalog source finishes loading

### DIFF
--- a/catalog/internal/catalog/agentcatalog/loader.go
+++ b/catalog/internal/catalog/agentcatalog/loader.go
@@ -104,6 +104,7 @@ func (l *AgentLoader) loadFromYAML(ctx context.Context, sourceID string, source 
 	}
 
 	validNames := mapset.NewSet[string]()
+	successCount := 0
 
 	for _, ya := range catalog.Agents {
 		select {
@@ -148,10 +149,14 @@ func (l *AgentLoader) loadFromYAML(ctx context.Context, sourceID string, source 
 					}
 				}
 			}
+
+			successCount++
 		}()
 	}
 
 	if ctx.Err() == nil {
+		glog.Infof("%s: loaded %d agents", sourceID, successCount)
+
 		if _, err := l.removeOrphanedAgentsFromSource(sourceID, validNames); err != nil {
 			glog.Errorf("error removing orphaned agents from source %s: %v", sourceID, err)
 		}


### PR DESCRIPTION
## Description

The MCP and model catalog loaders log a per-source summary (e.g. "community_mcp_servers: loaded 4 MCP servers") when the initial load completes, which automated tests use to detect readiness. The agent catalog loader had no equivalent, leaving tests with no signal to wait on.

## How Has This Been Tested?
On a local kind cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
