### PR TITLE
fix(catalog): clear named queries on re-merge and deep-copy to prevent caller mutation

### DIFF
--- a/catalog/internal/catalog/agentcatalog/sources.go
+++ b/catalog/internal/catalog/agentcatalog/sources.go
@@ -17,9 +17,9 @@ type agentOriginEntry struct {
 
 // AgentSourceCollection manages agent catalog sources from multiple origins with priority-based merging.
 type AgentSourceCollection struct {
-	mu           sync.RWMutex
-	entries      []agentOriginEntry
-	namedQueries map[string]map[string]basecatalog.FieldFilter
+	mu                sync.RWMutex
+	entries           []agentOriginEntry
+	namedQueryEntries map[string]map[string]map[string]basecatalog.FieldFilter // origin -> queryName -> fieldName -> FieldFilter
 }
 
 func NewAgentSourceCollection(originOrder ...string) *AgentSourceCollection {
@@ -28,15 +28,42 @@ func NewAgentSourceCollection(originOrder ...string) *AgentSourceCollection {
 		entries[i] = agentOriginEntry{origin: origin, sources: nil}
 	}
 	return &AgentSourceCollection{
-		entries:      entries,
-		namedQueries: make(map[string]map[string]basecatalog.FieldFilter),
+		entries:           entries,
+		namedQueryEntries: make(map[string]map[string]map[string]basecatalog.FieldFilter),
 	}
 }
 
+// Merge adds sources from one origin, completely replacing anything that was
+// previously from that origin. Any named queries previously contributed by
+// this origin are cleared.
 func (sc *AgentSourceCollection) Merge(origin string, sources map[string]basecatalog.PluginSource) error {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
+	// Clear any previously contributed named queries for this origin
+	delete(sc.namedQueryEntries, origin)
+
+	return sc.mergeSourcesInternal(origin, sources)
+}
+
+// MergeWithNamedQueries adds sources and named queries from one origin.
+// Later origins override earlier ones at the field level within a query.
+func (sc *AgentSourceCollection) MergeWithNamedQueries(origin string, sources map[string]basecatalog.PluginSource, namedQueries map[string]map[string]basecatalog.FieldFilter) error {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	if err := sc.mergeSourcesInternal(origin, sources); err != nil {
+		return err
+	}
+
+	// Deep-copy and store named queries for this origin (clears any previously contributed entries)
+	sc.namedQueryEntries[origin] = basecatalog.CloneNamedQueries(namedQueries)
+
+	return nil
+}
+
+// mergeSourcesInternal performs the source merge. Must be called with lock held.
+func (sc *AgentSourceCollection) mergeSourcesInternal(origin string, sources map[string]basecatalog.PluginSource) error {
 	for i := range sc.entries {
 		if sc.entries[i].origin == origin {
 			sc.entries[i].sources = sources
@@ -48,32 +75,23 @@ func (sc *AgentSourceCollection) Merge(origin string, sources map[string]basecat
 	return nil
 }
 
-func (sc *AgentSourceCollection) MergeWithNamedQueries(origin string, sources map[string]basecatalog.PluginSource, namedQueries map[string]map[string]basecatalog.FieldFilter) error {
-	if err := sc.Merge(origin, sources); err != nil {
-		return err
+// mergedNamedQueries computes the merged view of all named queries across origins.
+// Later origins (by entry order) override earlier ones at the field level.
+// Must be called with lock held.
+func (sc *AgentSourceCollection) mergedNamedQueries() map[string]map[string]basecatalog.FieldFilter {
+	originOrder := make([]string, len(sc.entries))
+	for i, entry := range sc.entries {
+		originOrder[i] = entry.origin
 	}
-
-	sc.mu.Lock()
-	defer sc.mu.Unlock()
-	for queryName, fieldFilters := range namedQueries {
-		if sc.namedQueries[queryName] == nil {
-			sc.namedQueries[queryName] = make(map[string]basecatalog.FieldFilter)
-		}
-		maps.Copy(sc.namedQueries[queryName], fieldFilters)
-	}
-	return nil
+	return basecatalog.MergeNamedQueriesInOrder(originOrder, sc.namedQueryEntries)
 }
 
+// GetNamedQueries returns a deep copy of all merged named queries.
 func (sc *AgentSourceCollection) GetNamedQueries() map[string]map[string]basecatalog.FieldFilter {
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
 
-	result := make(map[string]map[string]basecatalog.FieldFilter, len(sc.namedQueries))
-	for queryName, fieldFilters := range sc.namedQueries {
-		result[queryName] = make(map[string]basecatalog.FieldFilter, len(fieldFilters))
-		maps.Copy(result[queryName], fieldFilters)
-	}
-	return result
+	return basecatalog.CloneNamedQueries(sc.mergedNamedQueries())
 }
 
 func (sc *AgentSourceCollection) merged() map[string]basecatalog.PluginSource {

--- a/catalog/internal/catalog/agentcatalog/sources_test.go
+++ b/catalog/internal/catalog/agentcatalog/sources_test.go
@@ -1,0 +1,262 @@
+package agentcatalog
+
+import (
+	"testing"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentSourceCollection_NamedQueries(t *testing.T) {
+	sc := NewAgentSourceCollection()
+
+	sources := map[string]basecatalog.PluginSource{
+		"test1": {ID: "test1"},
+	}
+	namedQueries := map[string]map[string]basecatalog.FieldFilter{
+		"validation-default": {
+			"ttft_p90": {Operator: "<", Value: 70},
+		},
+	}
+
+	err := sc.MergeWithNamedQueries("origin1", sources, namedQueries)
+	if err != nil {
+		t.Fatalf("MergeWithNamedQueries failed: %v", err)
+	}
+
+	queries := sc.GetNamedQueries()
+	if len(queries) != 1 {
+		t.Errorf("GetNamedQueries() returned %d queries, want 1", len(queries))
+	}
+	if queries["validation-default"]["ttft_p90"].Operator != "<" {
+		t.Errorf("Expected operator '<', got '%s'", queries["validation-default"]["ttft_p90"].Operator)
+	}
+	if queries["validation-default"]["ttft_p90"].Value != 70 {
+		t.Errorf("Expected value 70, got %v", queries["validation-default"]["ttft_p90"].Value)
+	}
+}
+
+func TestAgentSourceCollection_NamedQueriesClearedOnMerge(t *testing.T) {
+	t.Run("Merge clears named queries from same origin", func(t *testing.T) {
+		sc := NewAgentSourceCollection()
+		sources := map[string]basecatalog.PluginSource{
+			"src1": {ID: "src1", Name: "Source 1"},
+		}
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"validation-default": {
+				"ttft_p90": {Operator: "<", Value: 70},
+			},
+		}
+
+		// First, merge with named queries
+		err := sc.MergeWithNamedQueries("origin1", sources, queries)
+		if err != nil {
+			t.Fatalf("MergeWithNamedQueries failed: %v", err)
+		}
+		if len(sc.GetNamedQueries()) != 1 {
+			t.Fatalf("Expected 1 named query, got %d", len(sc.GetNamedQueries()))
+		}
+
+		// Now re-merge the same origin without named queries (simulates config update)
+		err = sc.Merge("origin1", sources)
+		if err != nil {
+			t.Fatalf("Merge failed: %v", err)
+		}
+
+		// Named queries from origin1 should be cleared
+		result := sc.GetNamedQueries()
+		if len(result) != 0 {
+			t.Errorf("Expected 0 named queries after Merge, got %d", len(result))
+		}
+	})
+
+	t.Run("Merge only clears named queries from its own origin", func(t *testing.T) {
+		sc := NewAgentSourceCollection()
+		sources := map[string]basecatalog.PluginSource{}
+
+		// Origin A contributes a named query
+		queriesA := map[string]map[string]basecatalog.FieldFilter{
+			"queryA": {"field": {Operator: "=", Value: "a"}},
+		}
+		if err := sc.MergeWithNamedQueries("originA", sources, queriesA); err != nil {
+			t.Fatalf("MergeWithNamedQueries(originA) failed: %v", err)
+		}
+
+		// Origin B contributes a different named query
+		queriesB := map[string]map[string]basecatalog.FieldFilter{
+			"queryB": {"field": {Operator: "=", Value: "b"}},
+		}
+		if err := sc.MergeWithNamedQueries("originB", sources, queriesB); err != nil {
+			t.Fatalf("MergeWithNamedQueries(originB) failed: %v", err)
+		}
+
+		if len(sc.GetNamedQueries()) != 2 {
+			t.Fatalf("Expected 2 named queries, got %d", len(sc.GetNamedQueries()))
+		}
+
+		// Re-merge originA without named queries
+		if err := sc.Merge("originA", sources); err != nil {
+			t.Fatalf("Merge(originA) failed: %v", err)
+		}
+
+		// Only queryA should be removed; queryB should remain
+		result := sc.GetNamedQueries()
+		if len(result) != 1 {
+			t.Errorf("Expected 1 named query, got %d", len(result))
+		}
+		if _, ok := result["queryB"]; !ok {
+			t.Error("queryB should still be present")
+		}
+		if _, ok := result["queryA"]; ok {
+			t.Error("queryA should have been cleared")
+		}
+	})
+
+	t.Run("MergeWithNamedQueries replaces previous named queries from same origin", func(t *testing.T) {
+		sc := NewAgentSourceCollection()
+		sources := map[string]basecatalog.PluginSource{}
+
+		// Origin A contributes initial named queries
+		queriesV1 := map[string]map[string]basecatalog.FieldFilter{
+			"old_query": {"field": {Operator: "=", Value: "old"}},
+		}
+		if err := sc.MergeWithNamedQueries("originA", sources, queriesV1); err != nil {
+			t.Fatalf("MergeWithNamedQueries failed: %v", err)
+		}
+		if _, ok := sc.GetNamedQueries()["old_query"]; !ok {
+			t.Fatal("old_query should be present")
+		}
+
+		// Origin A re-parses with different named queries
+		queriesV2 := map[string]map[string]basecatalog.FieldFilter{
+			"new_query": {"field": {Operator: "=", Value: "new"}},
+		}
+		if err := sc.MergeWithNamedQueries("originA", sources, queriesV2); err != nil {
+			t.Fatalf("MergeWithNamedQueries failed: %v", err)
+		}
+
+		// old_query should be gone, new_query should be present
+		result := sc.GetNamedQueries()
+		if len(result) != 1 {
+			t.Errorf("Expected 1 named query, got %d", len(result))
+		}
+		if _, ok := result["old_query"]; ok {
+			t.Error("old_query should have been replaced")
+		}
+		if _, ok := result["new_query"]; !ok {
+			t.Error("new_query should be present")
+		}
+	})
+
+	t.Run("cross-origin field-level merge still works after clear", func(t *testing.T) {
+		sc := NewAgentSourceCollection()
+		sources := map[string]basecatalog.PluginSource{}
+
+		// Origin A sets field "rating" on query "quality"
+		queriesA := map[string]map[string]basecatalog.FieldFilter{
+			"quality": {"rating": {Operator: ">=", Value: 3}},
+		}
+		if err := sc.MergeWithNamedQueries("originA", sources, queriesA); err != nil {
+			t.Fatalf("MergeWithNamedQueries(originA) failed: %v", err)
+		}
+
+		// Origin B sets field "verified" on query "quality"
+		queriesB := map[string]map[string]basecatalog.FieldFilter{
+			"quality": {"verified": {Operator: "=", Value: true}},
+		}
+		if err := sc.MergeWithNamedQueries("originB", sources, queriesB); err != nil {
+			t.Fatalf("MergeWithNamedQueries(originB) failed: %v", err)
+		}
+
+		// Both fields should be present
+		result := sc.GetNamedQueries()
+		if len(result["quality"]) != 2 {
+			t.Fatalf("Expected 2 fields in quality query, got %d", len(result["quality"]))
+		}
+
+		// Clear origin A's queries
+		if err := sc.Merge("originA", sources); err != nil {
+			t.Fatalf("Merge(originA) failed: %v", err)
+		}
+
+		// Only origin B's "verified" field should remain
+		result = sc.GetNamedQueries()
+		if len(result) != 1 {
+			t.Errorf("Expected 1 named query, got %d", len(result))
+		}
+		if len(result["quality"]) != 1 {
+			t.Errorf("Expected 1 field in quality query, got %d", len(result["quality"]))
+		}
+		if _, ok := result["quality"]["verified"]; !ok {
+			t.Error("verified field should still be present")
+		}
+		if _, ok := result["quality"]["rating"]; ok {
+			t.Error("rating field should have been cleared")
+		}
+	})
+}
+
+func TestAgentSourceCollection_MergeWithNamedQueries_InputMutationIsolation(t *testing.T) {
+	t.Run("mutating input map after MergeWithNamedQueries does not affect stored state", func(t *testing.T) {
+		sc := NewAgentSourceCollection()
+		sources := map[string]basecatalog.PluginSource{}
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"my_query": {
+				"status": {Operator: "=", Value: "active"},
+			},
+		}
+
+		require.NoError(t, sc.MergeWithNamedQueries("origin", sources, queries))
+
+		// Mutate the input maps after merge
+		queries["my_query"]["status"] = basecatalog.FieldFilter{Operator: "!=", Value: "mutated"}
+		queries["injected"] = map[string]basecatalog.FieldFilter{
+			"field": {Operator: "=", Value: "injected"},
+		}
+
+		// Internal state must be unchanged
+		result := sc.GetNamedQueries()
+		require.Len(t, result, 1)
+		assert.NotContains(t, result, "injected")
+		assert.Equal(t, "=", result["my_query"]["status"].Operator)
+		assert.Equal(t, "active", result["my_query"]["status"].Value)
+	})
+
+	t.Run("mutating input slice Value after MergeWithNamedQueries does not affect stored state", func(t *testing.T) {
+		sc := NewAgentSourceCollection()
+		sources := map[string]basecatalog.PluginSource{}
+		sliceVal := []any{"active", "beta"}
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"in_query": {
+				"status": {Operator: "IN", Value: sliceVal},
+			},
+		}
+
+		require.NoError(t, sc.MergeWithNamedQueries("origin", sources, queries))
+
+		// Mutate the original slice after merge
+		sliceVal[0] = "mutated"
+
+		// Internal state must be unchanged
+		result := sc.GetNamedQueries()
+		assert.Equal(t, "active", result["in_query"]["status"].Value.([]any)[0])
+	})
+
+	t.Run("GetNamedQueries returns deep copy including slice Values", func(t *testing.T) {
+		sc := NewAgentSourceCollection()
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"in_query": {"status": {Operator: "IN", Value: []any{"active", "beta"}}},
+		}
+		require.NoError(t, sc.MergeWithNamedQueries("origin", map[string]basecatalog.PluginSource{}, queries))
+
+		// Mutate the slice returned by GetNamedQueries
+		result := sc.GetNamedQueries()
+		sliceVal := result["in_query"]["status"].Value.([]any)
+		sliceVal[0] = "mutated"
+
+		// Internal state must be unchanged
+		result2 := sc.GetNamedQueries()
+		assert.Equal(t, "active", result2["in_query"]["status"].Value.([]any)[0])
+	})
+}

--- a/catalog/internal/catalog/basecatalog/named_queries.go
+++ b/catalog/internal/catalog/basecatalog/named_queries.go
@@ -1,0 +1,65 @@
+package basecatalog
+
+import "maps"
+
+// deepCopyFieldFilter returns a copy of ff where slice values are cloned.
+func deepCopyFieldFilter(ff FieldFilter) FieldFilter {
+	if vals, ok := ff.Value.([]any); ok {
+		cp := make([]any, len(vals))
+		copy(cp, vals)
+		ff.Value = cp
+	}
+	return ff
+}
+
+// CloneFieldFilters returns a deep copy of a single query's field filters,
+// cloning mutable FieldFilter.Value slices so that later caller mutations
+// cannot affect stored state. Returns nil for a nil input.
+func CloneFieldFilters(src map[string]FieldFilter) map[string]FieldFilter {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]FieldFilter, len(src))
+	for field, ff := range src {
+		dst[field] = deepCopyFieldFilter(ff)
+	}
+	return dst
+}
+
+// CloneNamedQueries returns a deep copy of the entire named-queries map,
+// including mutable FieldFilter.Value slices, so that later caller
+// mutations cannot affect stored state.
+func CloneNamedQueries(src map[string]map[string]FieldFilter) map[string]map[string]FieldFilter {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]map[string]FieldFilter, len(src))
+	for queryName, fieldFilters := range src {
+		dst[queryName] = CloneFieldFilters(fieldFilters)
+	}
+	return dst
+}
+
+// MergeNamedQueriesInOrder computes the merged view of all named queries across
+// origins. originOrder gives priority order (later origins override earlier
+// ones at the field level); entriesByOrigin maps origin -> queryName ->
+// fieldName -> FieldFilter.
+func MergeNamedQueriesInOrder(
+	originOrder []string,
+	entriesByOrigin map[string]map[string]map[string]FieldFilter,
+) map[string]map[string]FieldFilter {
+	result := make(map[string]map[string]FieldFilter)
+	for _, origin := range originOrder {
+		originQueries, ok := entriesByOrigin[origin]
+		if !ok {
+			continue
+		}
+		for queryName, fieldFilters := range originQueries {
+			if result[queryName] == nil {
+				result[queryName] = make(map[string]FieldFilter)
+			}
+			maps.Copy(result[queryName], fieldFilters)
+		}
+	}
+	return result
+}

--- a/catalog/internal/catalog/mcpcatalog/sources.go
+++ b/catalog/internal/catalog/mcpcatalog/sources.go
@@ -19,9 +19,9 @@ type mcpOriginEntry struct {
 // MCPSourceCollection manages MCP catalog sources from multiple origins with priority-based merging.
 // Later entries in the slice take precedence over earlier ones.
 type MCPSourceCollection struct {
-	mu           sync.RWMutex
-	entries      []mcpOriginEntry
-	namedQueries map[string]map[string]basecatalog.FieldFilter
+	mu                sync.RWMutex
+	entries           []mcpOriginEntry
+	namedQueryEntries map[string]map[string]map[string]basecatalog.FieldFilter // origin -> queryName -> fieldName -> FieldFilter
 }
 
 // NewMCPSourceCollection creates a new MCPSourceCollection with the given origin order.
@@ -34,8 +34,8 @@ func NewMCPSourceCollection(originOrder ...string) *MCPSourceCollection {
 		entries[i] = mcpOriginEntry{origin: origin, sources: nil}
 	}
 	return &MCPSourceCollection{
-		entries:      entries,
-		namedQueries: make(map[string]map[string]basecatalog.FieldFilter),
+		entries:           entries,
+		namedQueryEntries: make(map[string]map[string]map[string]basecatalog.FieldFilter),
 	}
 }
 
@@ -51,6 +51,9 @@ func (msc *MCPSourceCollection) Merge(origin string, sources map[string]basecata
 	msc.mu.Lock()
 	defer msc.mu.Unlock()
 
+	// Clear any previously contributed named queries for this origin
+	delete(msc.namedQueryEntries, origin)
+
 	return msc.mergeSourcesInternal(origin, sources)
 }
 
@@ -64,15 +67,21 @@ func (msc *MCPSourceCollection) MergeWithNamedQueries(origin string, sources map
 		return err
 	}
 
-	// Merge named queries (later origins override earlier ones at field level)
-	for queryName, fieldFilters := range namedQueries {
-		if msc.namedQueries[queryName] == nil {
-			msc.namedQueries[queryName] = make(map[string]basecatalog.FieldFilter)
-		}
-		maps.Copy(msc.namedQueries[queryName], fieldFilters)
-	}
+	// Deep-copy and store named queries for this origin (clears any previously contributed entries)
+	msc.namedQueryEntries[origin] = basecatalog.CloneNamedQueries(namedQueries)
 
 	return nil
+}
+
+// mergedNamedQueries computes the merged view of all named queries across origins.
+// Later origins (by entry order) override earlier ones at the field level.
+// Must be called with lock held.
+func (msc *MCPSourceCollection) mergedNamedQueries() map[string]map[string]basecatalog.FieldFilter {
+	originOrder := make([]string, len(msc.entries))
+	for i, entry := range msc.entries {
+		originOrder[i] = entry.origin
+	}
+	return basecatalog.MergeNamedQueriesInOrder(originOrder, msc.namedQueryEntries)
 }
 
 // GetNamedQuery returns a copy of a single named query by name.
@@ -83,25 +92,12 @@ func (msc *MCPSourceCollection) GetNamedQuery(name string) (map[string]basecatal
 	msc.mu.RLock()
 	defer msc.mu.RUnlock()
 
-	fieldFilters, ok := msc.namedQueries[name]
+	merged := msc.mergedNamedQueries()
+	fieldFilters, ok := merged[name]
 	if !ok {
 		return nil, false
 	}
-	result := make(map[string]basecatalog.FieldFilter, len(fieldFilters))
-	for field, ff := range fieldFilters {
-		result[field] = deepCopyFieldFilter(ff)
-	}
-	return result, true
-}
-
-// deepCopyFieldFilter returns a copy of ff where slice values are cloned.
-func deepCopyFieldFilter(ff basecatalog.FieldFilter) basecatalog.FieldFilter {
-	if vals, ok := ff.Value.([]any); ok {
-		cp := make([]any, len(vals))
-		copy(cp, vals)
-		ff.Value = cp
-	}
-	return ff
+	return basecatalog.CloneFieldFilters(fieldFilters), true
 }
 
 // GetNamedQueries returns a deep copy of all merged named queries.
@@ -109,14 +105,7 @@ func (msc *MCPSourceCollection) GetNamedQueries() map[string]map[string]basecata
 	msc.mu.RLock()
 	defer msc.mu.RUnlock()
 
-	result := make(map[string]map[string]basecatalog.FieldFilter, len(msc.namedQueries))
-	for queryName, fieldFilters := range msc.namedQueries {
-		result[queryName] = make(map[string]basecatalog.FieldFilter, len(fieldFilters))
-		for field, ff := range fieldFilters {
-			result[queryName][field] = deepCopyFieldFilter(ff)
-		}
-	}
-	return result
+	return basecatalog.CloneNamedQueries(msc.mergedNamedQueries())
 }
 
 // mergeSourcesInternal performs the source merge. Must be called with lock held.

--- a/catalog/internal/catalog/mcpcatalog/sources_test.go
+++ b/catalog/internal/catalog/mcpcatalog/sources_test.go
@@ -861,6 +861,53 @@ func TestMCPSourceCollection_GetNamedQuery_SliceDeepCopy(t *testing.T) {
 	assert.Equal(t, "active", filters2["status"].Value.([]any)[0])
 }
 
+func TestMCPSourceCollection_MergeWithNamedQueries_InputMutationIsolation(t *testing.T) {
+	t.Run("mutating input map after MergeWithNamedQueries does not affect stored state", func(t *testing.T) {
+		coll := NewMCPSourceCollection()
+		sources := map[string]basecatalog.MCPSource{}
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"my_query": {
+				"status": {Operator: "=", Value: "active"},
+			},
+		}
+
+		require.NoError(t, coll.MergeWithNamedQueries("origin", sources, queries))
+
+		// Mutate the input maps after merge
+		queries["my_query"]["status"] = basecatalog.FieldFilter{Operator: "!=", Value: "mutated"}
+		queries["injected"] = map[string]basecatalog.FieldFilter{
+			"field": {Operator: "=", Value: "injected"},
+		}
+
+		// Internal state must be unchanged
+		result := coll.GetNamedQueries()
+		require.Len(t, result, 1)
+		assert.NotContains(t, result, "injected")
+		assert.Equal(t, "=", result["my_query"]["status"].Operator)
+		assert.Equal(t, "active", result["my_query"]["status"].Value)
+	})
+
+	t.Run("mutating input slice Value after MergeWithNamedQueries does not affect stored state", func(t *testing.T) {
+		coll := NewMCPSourceCollection()
+		sources := map[string]basecatalog.MCPSource{}
+		sliceVal := []any{"active", "beta"}
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"in_query": {
+				"status": {Operator: "IN", Value: sliceVal},
+			},
+		}
+
+		require.NoError(t, coll.MergeWithNamedQueries("origin", sources, queries))
+
+		// Mutate the original slice after merge
+		sliceVal[0] = "mutated"
+
+		// Internal state must be unchanged
+		result := coll.GetNamedQueries()
+		assert.Equal(t, "active", result["in_query"]["status"].Value.([]any)[0])
+	})
+}
+
 func TestMCPSourceCollection_ByLabel(t *testing.T) {
 	makeCollection := func(sources map[string]basecatalog.MCPSource) *MCPSourceCollection {
 		coll := NewMCPSourceCollection()
@@ -952,6 +999,115 @@ func TestMCPSourceCollection_Merge_WithoutNamedQueries(t *testing.T) {
 	all := coll.AllSources()
 	assert.Contains(t, all, "src1")
 	assert.Empty(t, coll.GetNamedQueries())
+}
+
+func TestMCPSourceCollection_NamedQueriesClearedOnMerge(t *testing.T) {
+	t.Run("Merge clears named queries from same origin", func(t *testing.T) {
+		coll := NewMCPSourceCollection()
+		sources := map[string]basecatalog.MCPSource{
+			"src1": {ID: "src1", Name: "Source 1", Type: "yaml"},
+		}
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"production_ready": {
+				"verified": {Operator: "=", Value: true},
+			},
+		}
+
+		// First, merge with named queries
+		err := coll.MergeWithNamedQueries("origin1", sources, queries)
+		require.NoError(t, err)
+		require.Len(t, coll.GetNamedQueries(), 1)
+
+		// Now re-merge the same origin without named queries (simulates config update)
+		err = coll.Merge("origin1", sources)
+		require.NoError(t, err)
+
+		// Named queries from origin1 should be cleared
+		assert.Empty(t, coll.GetNamedQueries())
+	})
+
+	t.Run("Merge only clears named queries from its own origin", func(t *testing.T) {
+		coll := NewMCPSourceCollection()
+		sources := map[string]basecatalog.MCPSource{}
+
+		// Origin A contributes a named query
+		queriesA := map[string]map[string]basecatalog.FieldFilter{
+			"queryA": {"field": {Operator: "=", Value: "a"}},
+		}
+		require.NoError(t, coll.MergeWithNamedQueries("originA", sources, queriesA))
+
+		// Origin B contributes a different named query
+		queriesB := map[string]map[string]basecatalog.FieldFilter{
+			"queryB": {"field": {Operator: "=", Value: "b"}},
+		}
+		require.NoError(t, coll.MergeWithNamedQueries("originB", sources, queriesB))
+
+		require.Len(t, coll.GetNamedQueries(), 2)
+
+		// Re-merge originA without named queries
+		require.NoError(t, coll.Merge("originA", sources))
+
+		// Only queryA should be removed; queryB should remain
+		result := coll.GetNamedQueries()
+		assert.Len(t, result, 1)
+		assert.Contains(t, result, "queryB")
+		assert.NotContains(t, result, "queryA")
+	})
+
+	t.Run("MergeWithNamedQueries replaces previous named queries from same origin", func(t *testing.T) {
+		coll := NewMCPSourceCollection()
+		sources := map[string]basecatalog.MCPSource{}
+
+		// Origin A contributes initial named queries
+		queriesV1 := map[string]map[string]basecatalog.FieldFilter{
+			"old_query": {"field": {Operator: "=", Value: "old"}},
+		}
+		require.NoError(t, coll.MergeWithNamedQueries("originA", sources, queriesV1))
+		require.Contains(t, coll.GetNamedQueries(), "old_query")
+
+		// Origin A re-parses with different named queries
+		queriesV2 := map[string]map[string]basecatalog.FieldFilter{
+			"new_query": {"field": {Operator: "=", Value: "new"}},
+		}
+		require.NoError(t, coll.MergeWithNamedQueries("originA", sources, queriesV2))
+
+		// old_query should be gone, new_query should be present
+		result := coll.GetNamedQueries()
+		assert.Len(t, result, 1)
+		assert.NotContains(t, result, "old_query")
+		assert.Contains(t, result, "new_query")
+	})
+
+	t.Run("cross-origin field-level merge still works after clear", func(t *testing.T) {
+		coll := NewMCPSourceCollection()
+		sources := map[string]basecatalog.MCPSource{}
+
+		// Origin A sets field "rating" on query "quality"
+		queriesA := map[string]map[string]basecatalog.FieldFilter{
+			"quality": {"rating": {Operator: ">=", Value: 3}},
+		}
+		require.NoError(t, coll.MergeWithNamedQueries("originA", sources, queriesA))
+
+		// Origin B sets field "verified" on query "quality"
+		queriesB := map[string]map[string]basecatalog.FieldFilter{
+			"quality": {"verified": {Operator: "=", Value: true}},
+		}
+		require.NoError(t, coll.MergeWithNamedQueries("originB", sources, queriesB))
+
+		// Both fields should be present
+		result := coll.GetNamedQueries()
+		assert.Len(t, result["quality"], 2)
+
+		// Clear origin A's queries
+		require.NoError(t, coll.Merge("originA", sources))
+
+		// Only origin B's "verified" field should remain
+		result = coll.GetNamedQueries()
+		require.Len(t, result, 1)
+		assert.Len(t, result["quality"], 1)
+		assert.Contains(t, result["quality"], "verified")
+		assert.NotContains(t, result["quality"], "rating")
+	})
 }
 
 func TestMergeMCPSources_IncludedExcludedServers(t *testing.T) {

--- a/catalog/internal/catalog/modelcatalog/sources.go
+++ b/catalog/internal/catalog/modelcatalog/sources.go
@@ -19,9 +19,9 @@ type originEntry struct {
 // SourceCollection manages catalog sources from multiple origins with priority-based merging.
 // Later entries in the slice take precedence over earlier ones.
 type SourceCollection struct {
-	mu           sync.RWMutex
-	entries      []originEntry
-	namedQueries map[string]map[string]basecatalog.FieldFilter
+	mu                sync.RWMutex
+	entries           []originEntry
+	namedQueryEntries map[string]map[string]map[string]basecatalog.FieldFilter // origin -> queryName -> fieldName -> FieldFilter
 }
 
 // NewSourceCollection creates a new SourceCollection with the given origin order.
@@ -34,8 +34,8 @@ func NewSourceCollection(originOrder ...string) *SourceCollection {
 		entries[i] = originEntry{origin: origin, sources: nil}
 	}
 	return &SourceCollection{
-		entries:      entries,
-		namedQueries: make(map[string]map[string]basecatalog.FieldFilter),
+		entries:           entries,
+		namedQueryEntries: make(map[string]map[string]map[string]basecatalog.FieldFilter),
 	}
 }
 
@@ -50,6 +50,10 @@ func NewSourceCollection(originOrder ...string) *SourceCollection {
 func (sc *SourceCollection) Merge(origin string, sources map[string]basecatalog.ModelSource) error {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
+
+	// Clear any previously contributed named queries for this origin
+	delete(sc.namedQueryEntries, origin)
+
 	return sc.mergeSourcesInternal(origin, sources)
 }
 
@@ -63,13 +67,8 @@ func (sc *SourceCollection) MergeWithNamedQueries(origin string, sources map[str
 		return err
 	}
 
-	// Merge named queries (later origins override earlier ones)
-	for queryName, fieldFilters := range namedQueries {
-		if sc.namedQueries[queryName] == nil {
-			sc.namedQueries[queryName] = make(map[string]basecatalog.FieldFilter)
-		}
-		maps.Copy(sc.namedQueries[queryName], fieldFilters)
-	}
+	// Deep-copy and store named queries for this origin (clears any previously contributed entries)
+	sc.namedQueryEntries[origin] = basecatalog.CloneNamedQueries(namedQueries)
 
 	return nil
 }
@@ -89,18 +88,23 @@ func (sc *SourceCollection) mergeSourcesInternal(origin string, sources map[stri
 	return nil
 }
 
+// mergedNamedQueries computes the merged view of all named queries across origins.
+// Later origins (by entry order) override earlier ones at the field level.
+// Must be called with lock held.
+func (sc *SourceCollection) mergedNamedQueries() map[string]map[string]basecatalog.FieldFilter {
+	originOrder := make([]string, len(sc.entries))
+	for i, entry := range sc.entries {
+		originOrder[i] = entry.origin
+	}
+	return basecatalog.MergeNamedQueriesInOrder(originOrder, sc.namedQueryEntries)
+}
+
 // GetNamedQueries returns all merged named queries
 func (sc *SourceCollection) GetNamedQueries() map[string]map[string]basecatalog.FieldFilter {
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
 
-	// Return a copy to prevent external modification
-	result := make(map[string]map[string]basecatalog.FieldFilter, len(sc.namedQueries))
-	for queryName, fieldFilters := range sc.namedQueries {
-		result[queryName] = make(map[string]basecatalog.FieldFilter, len(fieldFilters))
-		maps.Copy(result[queryName], fieldFilters)
-	}
-	return result
+	return basecatalog.CloneNamedQueries(sc.mergedNamedQueries())
 }
 
 // mergeSources performs field-level merging of two Source structs.

--- a/catalog/internal/catalog/modelcatalog/sources_test.go
+++ b/catalog/internal/catalog/modelcatalog/sources_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
 	model "github.com/kubeflow/hub/catalog/pkg/openapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSourceCollection_ByLabel(t *testing.T) {
@@ -1164,4 +1166,228 @@ func TestSourceCollection_NamedQueries(t *testing.T) {
 	if queries["validation-default"]["ttft_p90"].Value != 70 {
 		t.Errorf("Expected value 70, got %v", queries["validation-default"]["ttft_p90"].Value)
 	}
+}
+
+func TestSourceCollection_NamedQueriesClearedOnMerge(t *testing.T) {
+	t.Run("Merge clears named queries from same origin", func(t *testing.T) {
+		sc := NewSourceCollection()
+		sources := map[string]basecatalog.ModelSource{
+			"src1": {CatalogSource: model.CatalogSource{Id: "src1", Name: "Source 1"}},
+		}
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"validation-default": {
+				"ttft_p90": {Operator: "<", Value: 70},
+			},
+		}
+
+		// First, merge with named queries
+		err := sc.MergeWithNamedQueries("origin1", sources, queries)
+		if err != nil {
+			t.Fatalf("MergeWithNamedQueries failed: %v", err)
+		}
+		if len(sc.GetNamedQueries()) != 1 {
+			t.Fatalf("Expected 1 named query, got %d", len(sc.GetNamedQueries()))
+		}
+
+		// Now re-merge the same origin without named queries (simulates config update)
+		err = sc.Merge("origin1", sources)
+		if err != nil {
+			t.Fatalf("Merge failed: %v", err)
+		}
+
+		// Named queries from origin1 should be cleared
+		result := sc.GetNamedQueries()
+		if len(result) != 0 {
+			t.Errorf("Expected 0 named queries after Merge, got %d", len(result))
+		}
+	})
+
+	t.Run("Merge only clears named queries from its own origin", func(t *testing.T) {
+		sc := NewSourceCollection()
+		sources := map[string]basecatalog.ModelSource{}
+
+		// Origin A contributes a named query
+		queriesA := map[string]map[string]basecatalog.FieldFilter{
+			"queryA": {"field": {Operator: "=", Value: "a"}},
+		}
+		if err := sc.MergeWithNamedQueries("originA", sources, queriesA); err != nil {
+			t.Fatalf("MergeWithNamedQueries(originA) failed: %v", err)
+		}
+
+		// Origin B contributes a different named query
+		queriesB := map[string]map[string]basecatalog.FieldFilter{
+			"queryB": {"field": {Operator: "=", Value: "b"}},
+		}
+		if err := sc.MergeWithNamedQueries("originB", sources, queriesB); err != nil {
+			t.Fatalf("MergeWithNamedQueries(originB) failed: %v", err)
+		}
+
+		if len(sc.GetNamedQueries()) != 2 {
+			t.Fatalf("Expected 2 named queries, got %d", len(sc.GetNamedQueries()))
+		}
+
+		// Re-merge originA without named queries
+		if err := sc.Merge("originA", sources); err != nil {
+			t.Fatalf("Merge(originA) failed: %v", err)
+		}
+
+		// Only queryA should be removed; queryB should remain
+		result := sc.GetNamedQueries()
+		if len(result) != 1 {
+			t.Errorf("Expected 1 named query, got %d", len(result))
+		}
+		if _, ok := result["queryB"]; !ok {
+			t.Error("queryB should still be present")
+		}
+		if _, ok := result["queryA"]; ok {
+			t.Error("queryA should have been cleared")
+		}
+	})
+
+	t.Run("MergeWithNamedQueries replaces previous named queries from same origin", func(t *testing.T) {
+		sc := NewSourceCollection()
+		sources := map[string]basecatalog.ModelSource{}
+
+		// Origin A contributes initial named queries
+		queriesV1 := map[string]map[string]basecatalog.FieldFilter{
+			"old_query": {"field": {Operator: "=", Value: "old"}},
+		}
+		if err := sc.MergeWithNamedQueries("originA", sources, queriesV1); err != nil {
+			t.Fatalf("MergeWithNamedQueries failed: %v", err)
+		}
+		if _, ok := sc.GetNamedQueries()["old_query"]; !ok {
+			t.Fatal("old_query should be present")
+		}
+
+		// Origin A re-parses with different named queries
+		queriesV2 := map[string]map[string]basecatalog.FieldFilter{
+			"new_query": {"field": {Operator: "=", Value: "new"}},
+		}
+		if err := sc.MergeWithNamedQueries("originA", sources, queriesV2); err != nil {
+			t.Fatalf("MergeWithNamedQueries failed: %v", err)
+		}
+
+		// old_query should be gone, new_query should be present
+		result := sc.GetNamedQueries()
+		if len(result) != 1 {
+			t.Errorf("Expected 1 named query, got %d", len(result))
+		}
+		if _, ok := result["old_query"]; ok {
+			t.Error("old_query should have been replaced")
+		}
+		if _, ok := result["new_query"]; !ok {
+			t.Error("new_query should be present")
+		}
+	})
+
+	t.Run("cross-origin field-level merge still works after clear", func(t *testing.T) {
+		sc := NewSourceCollection()
+		sources := map[string]basecatalog.ModelSource{}
+
+		// Origin A sets field "rating" on query "quality"
+		queriesA := map[string]map[string]basecatalog.FieldFilter{
+			"quality": {"rating": {Operator: ">=", Value: 3}},
+		}
+		if err := sc.MergeWithNamedQueries("originA", sources, queriesA); err != nil {
+			t.Fatalf("MergeWithNamedQueries(originA) failed: %v", err)
+		}
+
+		// Origin B sets field "verified" on query "quality"
+		queriesB := map[string]map[string]basecatalog.FieldFilter{
+			"quality": {"verified": {Operator: "=", Value: true}},
+		}
+		if err := sc.MergeWithNamedQueries("originB", sources, queriesB); err != nil {
+			t.Fatalf("MergeWithNamedQueries(originB) failed: %v", err)
+		}
+
+		// Both fields should be present
+		result := sc.GetNamedQueries()
+		if len(result["quality"]) != 2 {
+			t.Fatalf("Expected 2 fields in quality query, got %d", len(result["quality"]))
+		}
+
+		// Clear origin A's queries
+		if err := sc.Merge("originA", sources); err != nil {
+			t.Fatalf("Merge(originA) failed: %v", err)
+		}
+
+		// Only origin B's "verified" field should remain
+		result = sc.GetNamedQueries()
+		if len(result) != 1 {
+			t.Errorf("Expected 1 named query, got %d", len(result))
+		}
+		if len(result["quality"]) != 1 {
+			t.Errorf("Expected 1 field in quality query, got %d", len(result["quality"]))
+		}
+		if _, ok := result["quality"]["verified"]; !ok {
+			t.Error("verified field should still be present")
+		}
+		if _, ok := result["quality"]["rating"]; ok {
+			t.Error("rating field should have been cleared")
+		}
+	})
+}
+
+func TestSourceCollection_MergeWithNamedQueries_InputMutationIsolation(t *testing.T) {
+	t.Run("mutating input map after MergeWithNamedQueries does not affect stored state", func(t *testing.T) {
+		sc := NewSourceCollection()
+		sources := map[string]basecatalog.ModelSource{}
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"my_query": {
+				"status": {Operator: "=", Value: "active"},
+			},
+		}
+
+		require.NoError(t, sc.MergeWithNamedQueries("origin", sources, queries))
+
+		// Mutate the input maps after merge
+		queries["my_query"]["status"] = basecatalog.FieldFilter{Operator: "!=", Value: "mutated"}
+		queries["injected"] = map[string]basecatalog.FieldFilter{
+			"field": {Operator: "=", Value: "injected"},
+		}
+
+		// Internal state must be unchanged
+		result := sc.GetNamedQueries()
+		require.Len(t, result, 1)
+		assert.NotContains(t, result, "injected")
+		assert.Equal(t, "=", result["my_query"]["status"].Operator)
+		assert.Equal(t, "active", result["my_query"]["status"].Value)
+	})
+
+	t.Run("mutating input slice Value after MergeWithNamedQueries does not affect stored state", func(t *testing.T) {
+		sc := NewSourceCollection()
+		sources := map[string]basecatalog.ModelSource{}
+		sliceVal := []any{"active", "beta"}
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"in_query": {
+				"status": {Operator: "IN", Value: sliceVal},
+			},
+		}
+
+		require.NoError(t, sc.MergeWithNamedQueries("origin", sources, queries))
+
+		// Mutate the original slice after merge
+		sliceVal[0] = "mutated"
+
+		// Internal state must be unchanged
+		result := sc.GetNamedQueries()
+		assert.Equal(t, "active", result["in_query"]["status"].Value.([]any)[0])
+	})
+
+	t.Run("GetNamedQueries returns deep copy including slice Values", func(t *testing.T) {
+		sc := NewSourceCollection()
+		queries := map[string]map[string]basecatalog.FieldFilter{
+			"in_query": {"status": {Operator: "IN", Value: []any{"active", "beta"}}},
+		}
+		require.NoError(t, sc.MergeWithNamedQueries("origin", map[string]basecatalog.ModelSource{}, queries))
+
+		// Mutate the slice returned by GetNamedQueries
+		result := sc.GetNamedQueries()
+		sliceVal := result["in_query"]["status"].Value.([]any)
+		sliceVal[0] = "mutated"
+
+		// Internal state must be unchanged
+		result2 := sc.GetNamedQueries()
+		assert.Equal(t, "active", result2["in_query"]["status"].Value.([]any)[0])
+	})
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Named queries in MCPSourceCollection, SourceCollection, and AgentSourceCollection were accumulated in a flat map with no per-origin tracking, so entries from a source persisted even after the source's config was re-parsed without any named queries. Replace the flat map with per-origin storage (namedQueryEntries) and compute the merged view on read, mirroring the existing pattern for sources.

Also clone the namedQueries map and its nested FieldFilter.Value slices before storing them, so a caller mutating the map after Merge()/MergeWithNamedQueries() can no longer corrupt internal state or race with reads of the merged result.

## How Has This Been Tested?
On a local dev cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
