### PR TITLE
fix: avoid dirty DB migration state in deploy_on_kind.sh

### DIFF
--- a/scripts/deploy_on_kind.sh
+++ b/scripts/deploy_on_kind.sh
@@ -37,6 +37,14 @@ else
 fi
 
 kubectl apply -k manifests/kustomize/overlays/$DEPLOY_MANIFEST_DB -n "$MR_NAMESPACE"
+
+# Scale the server deployment to 0 before swapping in $IMG. Otherwise the pod
+# created by `apply` (using the base manifest's image) can start running its
+# embedded DB migrations, then get killed by the rollout that the patch below
+# triggers, leaving the migrations table in a dirty state that blocks every
+# subsequent pod from starting (see golang-migrate "Dirty database version").
+kubectl scale deployment -n "$MR_NAMESPACE" model-registry-deployment --replicas=0
+
 kubectl patch deployment -n "$MR_NAMESPACE" model-registry-deployment \
 --patch '{"spec": {"template": {"spec": {"containers": [{"name": "rest-container", "image": "'$IMG'", "imagePullPolicy": "IfNotPresent"}]}}}}'
 
@@ -47,7 +55,7 @@ if ! kubectl wait --for=condition=available -n "$MR_NAMESPACE" deployment/model-
     exit 1
 fi
 
-kubectl delete pod -n "$MR_NAMESPACE" --selector='component=model-registry-server'
+kubectl scale deployment -n "$MR_NAMESPACE" model-registry-deployment --replicas=1
 
 repeat_cmd_until "kubectl get pod -n "$MR_NAMESPACE" --selector='component=model-registry-server' \
 -o jsonpath=\"{.items[*].spec.containers[?(@.name=='rest-container')].image}\" | tr ' ' '\n' | sort -u" "= $IMG" 500 "kubectl describe pod -n $MR_NAMESPACE --selector='component=model-registry-server'"


### PR DESCRIPTION
## Description

kubectl apply -k creates the server deployment with the base manifest's placeholder image, then a follow-up kubectl patch swaps in the real image and triggers a second rollout. If the placeholder-image pod is already running embedded DB migrations when it gets replaced, it can be killed mid-migration, leaving golang-migrate's dirty flag set and blocking every subsequent pod from starting.

Scale the deployment to 0 before patching the image, and only scale back up once the DB is confirmed available, so only one pod with the correct image is ever created.

This is to fix build errors like this https://github.com/kubeflow/hub/actions/runs/31533721347/job/93919678902?pr=3075

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
