### PR TITLE
fix(catalog): repair stale codegen patches in Python client

### DIFF
--- a/catalog/clients/python/patches/add-accuracy-orderby.patch
+++ b/catalog/clients/python/patches/add-accuracy-orderby.patch
@@ -1,12 +1,10 @@
 --- a/catalog/clients/python/src/catalog_openapi/models/order_by_field.py
 +++ b/catalog/clients/python/src/catalog_openapi/models/order_by_field.py
-@@ -29,6 +29,7 @@ class OrderByField(str, Enum):
-     CREATE_TIME = 'CREATE_TIME'
-     LAST_UPDATE_TIME = 'LAST_UPDATE_TIME'
+@@ -31,6 +31,7 @@
      ID = 'ID'
      NAME = 'NAME'
+     RECOMMENDED = 'RECOMMENDED'
 +    ACCURACY = 'ACCURACY'
  
      @classmethod
      def from_json(cls, json_str: str) -> Self:
-

--- a/catalog/clients/python/patches/include-readonly-timestamps.patch
+++ b/catalog/clients/python/patches/include-readonly-timestamps.patch
@@ -1,14 +1,11 @@
 --- a/catalog/clients/python/src/catalog_openapi/models/catalog_model.py
 +++ b/catalog/clients/python/src/catalog_openapi/models/catalog_model.py
-@@ -79,10 +79,7 @@
-         * OpenAPI `readOnly` fields are excluded.
+@@ -85,8 +85,6 @@
          * OpenAPI `readOnly` fields are excluded.
          """
--        excluded_fields: Set[str] = set([
+         excluded_fields: Set[str] = set([
 -            "create_time_since_epoch",
 -            "last_update_time_since_epoch",
--        ])
-+        excluded_fields: Set[str] = set([])
-
-         _dict = self.model_dump(
-             by_alias=True,
+             "artifact_counts",
+         ])
+ 


### PR DESCRIPTION
## Description
Two patches under catalog/clients/python/patches/ no longer apply cleanly against a fresh `make generate` — unrelated spec changes shifted their context (a new RECOMMENDED enum value, a new artifact_counts field). Re-cut both against the current baseline.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
