### PR TITLE
Enforce v1 OpenAPI parameter/field naming convention / Cleanup deprecated parameters in v1

### DIFF
--- a/.github/workflows/check-openapi-naming.yaml
+++ b/.github/workflows/check-openapi-naming.yaml
@@ -1,0 +1,22 @@
+name: Validate OpenAPI naming conventions
+on:
+  pull_request:
+    paths:
+      - "api/openapi/model-registry-v1.yaml"
+      - "api/openapi/catalog-v1.yaml"
+      - "api/openapi/naming_test.go"
+      - ".github/workflows/check-openapi-naming.yaml"
+
+permissions: # set contents: read at top-level, per OpenSSF ScoreCard rule TokenPermissionsID
+  contents: read
+
+jobs:
+  naming:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.3"
+      - name: Check OpenAPI naming conventions
+        run: make test/openapi-naming

--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,12 @@ test-cover:
 	${GO} test $$(${GO} list ./internal/... ./pkg/... | grep -v controller) -coverprofile=coverage.txt
 	${GO} tool cover -html=coverage.txt -o coverage.html
 
+# verify the v1 OpenAPI specs follow the parameter/field naming convention
+# (path params: snake_case, query params & body/response fields: camelCase)
+.PHONY: test/openapi-naming
+test/openapi-naming:
+	${GO} test ./api/openapi/...
+
 .PHONY: run/proxy
 run/proxy: gen
 	${GO} run main.go proxy --logtostderr=true

--- a/api/openapi/catalog-v1.yaml
+++ b/api/openapi/catalog-v1.yaml
@@ -743,7 +743,6 @@ paths:
         in: path
         required: true
       - $ref: "#/components/parameters/artifactType"
-      - $ref: "#/components/parameters/artifact_type"
       - $ref: "#/components/parameters/artifactFilterQuery"
       - $ref: "#/components/parameters/pageSize"
       - $ref: "#/components/parameters/artifactOrderBy"
@@ -3025,21 +3024,6 @@ components:
         artifactType:
           value: model-artifact
       name: artifactType
-      description: "Specifies the artifact type for listing artifacts."
-      schema:
-        type: array
-        items:
-          $ref: "#/components/schemas/ArtifactTypeQueryParam"
-      in: query
-      required: false
-    artifact_type:
-      deprecated: true
-      style: form
-      explode: true
-      examples:
-        artifact_type:
-          value: model-artifact
-      name: artifact_type
       description: "Specifies the artifact type for listing artifacts."
       schema:
         type: array

--- a/api/openapi/catalog-v1.yaml
+++ b/api/openapi/catalog-v1.yaml
@@ -322,15 +322,6 @@ paths:
       tags:
         - ModelCatalogService
       parameters:
-        - name: recommendations
-          in: query
-          deprecated: true
-          description: >-
-            Deprecated: use `orderBy=RECOMMENDED` instead. Sort models by lowest recommended latency using Pareto filtering.
-          required: false
-          schema:
-            type: boolean
-            default: false
         - name: targetRPS
           in: query
           description: Target requests per second for latency calculations
@@ -423,10 +414,9 @@ paths:
 
             The `RECOMMENDED` sort applies Pareto filtering and ranks models by recommended latency.
             The Pareto-related parameters (`targetRPS`, `latencyProperty`, `rpsProperty`,
-            `hardwareCountProperty`, `hardwareTypeProperty`) are applied the same way as with the
-            deprecated `recommendations` parameter. With the default `sortOrder=ASC`, the most
-            recommended models (lowest latency) appear first. Use `sortOrder=DESC` to show the least
-            recommended configurations first.
+            `hardwareCountProperty`, `hardwareTypeProperty`) tune the ranking. With the default
+            `sortOrder=ASC`, the most recommended models (lowest latency) appear first. Use
+            `sortOrder=DESC` to show the least recommended configurations first.
 
             In addition, models can be sorted by properties. For example:
             - `provider.string_value` sorts by provider name

--- a/api/openapi/naming_test.go
+++ b/api/openapi/naming_test.go
@@ -1,0 +1,318 @@
+package openapi
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// This test enforces the parameter and field naming convention for the v1 APIs, as described in
+// proposals/KEP-0004-api-v1-graduation/README.md:
+//
+//   - path parameters:            snake_case
+//   - query parameters:           camelCase
+//   - body/response fields:       camelCase
+//
+// The alpha spec started with this same convention but drifted over time because nothing
+// enforced it. This test exists so that drift in the v1 spec is caught in CI instead.
+//
+// A small set of fields are intentionally exempt from the body/response convention — see
+// fieldNamingExceptions below.
+var (
+	camelCaseRE = regexp.MustCompile(`^[a-z][a-zA-Z0-9]*$`)
+	snakeCaseRE = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+	httpMethods = []string{"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+)
+
+// fieldNamingExceptions lists schema properties that are intentionally exempt from the
+// camelCase convention, keyed by the schema they belong to. These mirror the MLMD/protobuf
+// MetadataValue oneOf union field names and must keep their proto casing for wire
+// compatibility with the underlying metadata store.
+var fieldNamingExceptions = map[string]map[string]bool{
+	"MetadataBoolValue":   {"bool_value": true},
+	"MetadataDoubleValue": {"double_value": true},
+	"MetadataIntValue":    {"int_value": true},
+	"MetadataProtoValue":  {"proto_value": true},
+	"MetadataStringValue": {"string_value": true},
+	"MetadataStructValue": {"struct_value": true},
+}
+
+func TestV1SpecNamingConventions(t *testing.T) {
+	specs := []string{
+		"model-registry-v1.yaml",
+		"catalog-v1.yaml",
+	}
+
+	for _, spec := range specs {
+		t.Run(spec, func(t *testing.T) {
+			data, err := os.ReadFile(spec)
+			require.NoError(t, err)
+
+			var doc map[string]any
+			require.NoError(t, yaml.Unmarshal(data, &doc))
+
+			var violations []string
+			violations = append(violations, checkParameterNaming(doc)...)
+			violations = append(violations, checkPropertyNaming(doc)...)
+
+			violations = dedupe(violations)
+			sort.Strings(violations)
+			if len(violations) > 0 {
+				t.Errorf("%s has %d naming convention violation(s):\n%s", spec, len(violations), strings.Join(violations, "\n"))
+			}
+		})
+	}
+}
+
+// checkParameterNaming walks every path item and operation, resolving both inline parameters
+// and $ref'd components/parameters entries, and verifies query parameters are camelCase and
+// path parameters are snake_case.
+func checkParameterNaming(doc map[string]any) []string {
+	var violations []string
+
+	componentParams, _ := digMap(doc, "components", "parameters")
+
+	resolve := func(raw any) map[string]any {
+		p, ok := raw.(map[string]any)
+		if !ok {
+			return nil
+		}
+		if ref, ok := p["$ref"].(string); ok {
+			key := lastSegment(ref)
+			if resolved, ok := componentParams[key].(map[string]any); ok {
+				return resolved
+			}
+			return nil
+		}
+		return p
+	}
+
+	check := func(location string, rawParams any) {
+		list, ok := rawParams.([]any)
+		if !ok {
+			return
+		}
+		for _, rawParam := range list {
+			param := resolve(rawParam)
+			if param == nil {
+				continue
+			}
+			name, _ := param["name"].(string)
+			in, _ := param["in"].(string)
+			if name == "" {
+				continue
+			}
+
+			switch in {
+			case "query":
+				if !camelCaseRE.MatchString(name) {
+					violations = append(violations, fmt.Sprintf("%s: query parameter %q must be camelCase", location, name))
+				}
+			case "path":
+				// RFC 6570 reserved expansion, e.g. {model_name+}, has a trailing '+' that
+				// isn't part of the parameter name.
+				trimmed := strings.TrimSuffix(name, "+")
+				if !snakeCaseRE.MatchString(trimmed) {
+					violations = append(violations, fmt.Sprintf("%s: path parameter %q must be snake_case", location, name))
+				}
+			}
+		}
+	}
+
+	paths, _ := doc["paths"].(map[string]any)
+	for path, rawItem := range paths {
+		item, ok := rawItem.(map[string]any)
+		if !ok {
+			continue
+		}
+		check(path, item["parameters"])
+		for _, method := range httpMethods {
+			op, ok := item[method].(map[string]any)
+			if !ok {
+				continue
+			}
+			check(fmt.Sprintf("%s %s", strings.ToUpper(method), path), op["parameters"])
+		}
+	}
+
+	return violations
+}
+
+// checkPropertyNaming recursively collects every schema "properties" key reachable from
+// components/schemas and from operation requestBody and response body schemas (inline or
+// referenced), and verifies each one is camelCase.
+func checkPropertyNaming(doc map[string]any) []string {
+	var violations []string
+	visited := map[string]bool{}
+
+	schemas, _ := digMap(doc, "components", "schemas")
+
+	var walk func(location string, node any)
+	walk = func(location string, node any) {
+		m, ok := node.(map[string]any)
+		if !ok {
+			return
+		}
+
+		if ref, ok := m["$ref"].(string); ok {
+			key := lastSegment(ref)
+			if visited[key] {
+				return
+			}
+			visited[key] = true
+			if target, ok := schemas[key].(map[string]any); ok {
+				walk(key, target)
+			}
+			return
+		}
+
+		if props, ok := m["properties"].(map[string]any); ok {
+			for name, propSchema := range props {
+				if !camelCaseRE.MatchString(name) && !fieldNamingExceptions[location][name] {
+					violations = append(violations, fmt.Sprintf("%s: field %q must be camelCase", location, name))
+				}
+				walk(location+"."+name, propSchema)
+			}
+		}
+
+		for _, key := range []string{"allOf", "oneOf", "anyOf"} {
+			if members, ok := m[key].([]any); ok {
+				for _, member := range members {
+					walk(location, member)
+				}
+			}
+		}
+
+		if items, ok := m["items"]; ok {
+			walk(location, items)
+		}
+		if additional, ok := m["additionalProperties"]; ok {
+			walk(location, additional)
+		}
+	}
+
+	// Every named schema, so unreferenced schemas are still checked.
+	for name, schema := range schemas {
+		walk(name, schema)
+	}
+
+	// Inline request body schemas (e.g. multipart bodies) that aren't registered as a named
+	// component schema.
+	paths, _ := doc["paths"].(map[string]any)
+	for path, rawItem := range paths {
+		item, ok := rawItem.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, method := range httpMethods {
+			op, ok := item[method].(map[string]any)
+			if !ok {
+				continue
+			}
+			content, ok := digMap(op, "requestBody", "content")
+			if !ok {
+				continue
+			}
+			for mediaType, rawMedia := range content {
+				media, ok := rawMedia.(map[string]any)
+				if !ok {
+					continue
+				}
+				location := fmt.Sprintf("%s %s requestBody (%s)", strings.ToUpper(method), path, mediaType)
+				walk(location, media["schema"])
+			}
+		}
+	}
+
+	// Inline response body schemas. Responses are keyed by status code (or "default"), each
+	// potentially $ref'ing components/responses, so resolve that indirection before digging
+	// into content.
+	componentResponses, _ := digMap(doc, "components", "responses")
+	for path, rawItem := range paths {
+		item, ok := rawItem.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, method := range httpMethods {
+			op, ok := item[method].(map[string]any)
+			if !ok {
+				continue
+			}
+			responses, ok := op["responses"].(map[string]any)
+			if !ok {
+				continue
+			}
+			for status, rawResponse := range responses {
+				response, ok := rawResponse.(map[string]any)
+				if !ok {
+					continue
+				}
+				if ref, ok := response["$ref"].(string); ok {
+					response, ok = componentResponses[lastSegment(ref)].(map[string]any)
+					if !ok {
+						continue
+					}
+				}
+				content, ok := response["content"].(map[string]any)
+				if !ok {
+					continue
+				}
+				for mediaType, rawMedia := range content {
+					media, ok := rawMedia.(map[string]any)
+					if !ok {
+						continue
+					}
+					location := fmt.Sprintf("%s %s response %s (%s)", strings.ToUpper(method), path, status, mediaType)
+					walk(location, media["schema"])
+				}
+			}
+		}
+	}
+
+	return violations
+}
+
+// digMap descends into nested map[string]any values by key, returning (nil, false) if any
+// segment along the path is missing or not a map.
+func digMap(m map[string]any, keys ...string) (map[string]any, bool) {
+	cur := m
+	for _, k := range keys {
+		next, ok := cur[k].(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur = next
+	}
+	return cur, true
+}
+
+// dedupe removes duplicate violation strings. The same schema can be reached both directly
+// (as a top-level components/schemas entry) and indirectly (via a $ref from an allOf/oneOf/
+// anyOf member elsewhere), so the same violation can otherwise be reported more than once.
+func dedupe(items []string) []string {
+	seen := make(map[string]bool, len(items))
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if seen[item] {
+			continue
+		}
+		seen[item] = true
+		out = append(out, item)
+	}
+	return out
+}
+
+func lastSegment(ref string) string {
+	idx := strings.LastIndex(ref, "/")
+	if idx == -1 {
+		return ref
+	}
+	return ref[idx+1:]
+}

--- a/api/openapi/src/plugins/model-v1.yaml
+++ b/api/openapi/src/plugins/model-v1.yaml
@@ -7,16 +7,6 @@ paths:
       tags:
         - ModelCatalogService
       parameters:
-        - name: recommendations
-          in: query
-          deprecated: true
-          description: >-
-            Deprecated: use `orderBy=RECOMMENDED` instead.
-            Sort models by lowest recommended latency using Pareto filtering.
-          required: false
-          schema:
-            type: boolean
-            default: false
         - name: targetRPS
           in: query
           description: Target requests per second for latency calculations
@@ -109,10 +99,9 @@ paths:
 
             The `RECOMMENDED` sort applies Pareto filtering and ranks models by recommended latency.
             The Pareto-related parameters (`targetRPS`, `latencyProperty`, `rpsProperty`,
-            `hardwareCountProperty`, `hardwareTypeProperty`) are applied the same way as with the
-            deprecated `recommendations` parameter. With the default `sortOrder=ASC`, the most
-            recommended models (lowest latency) appear first. Use `sortOrder=DESC` to show the least
-            recommended configurations first.
+            `hardwareCountProperty`, `hardwareTypeProperty`) tune the ranking. With the default
+            `sortOrder=ASC`, the most recommended models (lowest latency) appear first. Use
+            `sortOrder=DESC` to show the least recommended configurations first.
 
             In addition, models can be sorted by properties. For example:
             - `provider.string_value` sorts by provider name

--- a/api/openapi/src/plugins/model-v1.yaml
+++ b/api/openapi/src/plugins/model-v1.yaml
@@ -214,7 +214,6 @@ paths:
         in: path
         required: true
       - $ref: "#/components/parameters/artifactType"
-      - $ref: "#/components/parameters/artifact_type"
       - $ref: "#/components/parameters/artifactFilterQuery"
       - $ref: "#/components/parameters/pageSize"
       - $ref: "#/components/parameters/artifactOrderBy"
@@ -572,21 +571,6 @@ components:
         artifactType:
           value: model-artifact
       name: artifactType
-      description: "Specifies the artifact type for listing artifacts."
-      schema:
-        type: array
-        items:
-          $ref: "#/components/schemas/ArtifactTypeQueryParam"
-      in: query
-      required: false
-    artifact_type:
-      deprecated: true
-      style: form
-      explode: true
-      examples:
-        artifact_type:
-          value: model-artifact
-      name: artifact_type
       description: "Specifies the artifact type for listing artifacts."
       schema:
         type: array

--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	golang.org/x/exp v0.0.0-20250808145144-a408d31f581a
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 replace github.com/kubeflow/hub/pkg/openapi => ./pkg/openapi


### PR DESCRIPTION
## Description

The v1 API graduation (KEP-0004) fixes the alpha spec's inconsistent parameter casing, but nothing stops it drifting the same way again. Add a Go test that checks api/openapi/model-registry-v1.yaml and api/openapi/catalog-v1.yaml for path params in snake_case and query params/body fields in camelCase, with a scoped exception for the MetadataValue union's protobuf-derived field names. Wire it into GHA to run on changes to those specs.

Also removing two parameters which were deprecated before v1 and shouldn't have been brought forward:

* `artifact_type` on `/api/model_catalog/v1/sources/{source_id}/models/{model_name+}/artifacts`
* `recommendations` on `/api/model_catalog/v1/models`

## How Has This Been Tested?

`make test/openapi-naming`. We missed a rename for `artifact_type`, which failed correctly.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
