### PR TITLE
feat(catalog): SKC-110/111/114 skill source preview, marketplace, and…

### DIFF
--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -576,6 +576,14 @@ paths:
           and model-specific summary fields (`totalModels`, `includedModels`, `excludedModels`).
         - `mcp_servers`: Returns an `AssetSourcePreviewResponse` with `AssetPreviewResult` items
           and generic summary fields (`totalAssets`, `includedAssets`, `excludedAssets`).
+        - `skills`: Returns an `AssetSourcePreviewResponse` with `AssetPreviewResult` items.
+          Unlike model and MCP previews, a `git-skills-plugin` source is previewed by
+          shallow-cloning a repository to enumerate its skills, so `catalogData` does
+          not apply. Preview is scoped to a single repository at a time (each repo is
+          a network clone): the config must provide exactly one entry inline under
+          `properties.repositories`; more than one is rejected, and the file-based
+          `yamlCatalogPath` form is not supported for preview (skills are read from
+          git, not a catalog file).
 
         **Two modes of operation:**
 
@@ -710,6 +718,23 @@ paths:
                     - "prometheus*"
                   excludedServers:
                     - "*-internal"
+              skillSourcePreview:
+                summary: Skill source preview
+                description: |-
+                  Preview a git-skills-plugin source. Set assetType to skills and paste the
+                  source entry (type and properties.repositories). The configured repositories
+                  are shallow-cloned to enumerate their skills; includedSkills/excludedSkills on
+                  each repository decide which are included. No catalogData is used.
+                value: |
+                  assetType: skills
+                  type: git-skills-plugin
+                  properties:
+                    repositories:
+                      - url: https://github.com/example/skills.git
+                        refs: ["v1.0"]
+                        scanPaths: ["skills/"]
+                        includedSkills: ["*"]
+                        excludedSkills: ["*-draft"]
       parameters:
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/nextPageToken"
@@ -2416,7 +2441,7 @@ components:
       type: string
     PreviewCatalogSourceResponse:
       description: >-
-        Polymorphic preview response. The `assetType` discriminator determines whether the payload is a model preview or an MCP server preview.
+        Polymorphic preview response. The `assetType` discriminator determines whether the payload is a model preview (`CatalogSourcePreviewResponse`) or a generic asset preview (`AssetSourcePreviewResponse`), the latter used for both MCP server and skill sources.
       oneOf:
         - $ref: "#/components/schemas/CatalogSourcePreviewResponse"
         - $ref: "#/components/schemas/AssetSourcePreviewResponse"
@@ -2425,6 +2450,7 @@ components:
         mapping:
           models: "#/components/schemas/CatalogSourcePreviewResponse"
           mcp_servers: "#/components/schemas/AssetSourcePreviewResponse"
+          skills: "#/components/schemas/AssetSourcePreviewResponse"
     ServingConfig:
       description: >-
         Serving and deployment configuration for the model. Each property represents a distinct configuration concern with its own typed schema. All properties are optional.

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -83,6 +83,14 @@ paths:
           and model-specific summary fields (`totalModels`, `includedModels`, `excludedModels`).
         - `mcp_servers`: Returns an `AssetSourcePreviewResponse` with `AssetPreviewResult` items
           and generic summary fields (`totalAssets`, `includedAssets`, `excludedAssets`).
+        - `skills`: Returns an `AssetSourcePreviewResponse` with `AssetPreviewResult` items.
+          Unlike model and MCP previews, a `git-skills-plugin` source is previewed by
+          shallow-cloning a repository to enumerate its skills, so `catalogData` does
+          not apply. Preview is scoped to a single repository at a time (each repo is
+          a network clone): the config must provide exactly one entry inline under
+          `properties.repositories`; more than one is rejected, and the file-based
+          `yamlCatalogPath` form is not supported for preview (skills are read from
+          git, not a catalog file).
 
         **Two modes of operation:**
 
@@ -217,6 +225,23 @@ paths:
                     - "prometheus*"
                   excludedServers:
                     - "*-internal"
+              skillSourcePreview:
+                summary: Skill source preview
+                description: |-
+                  Preview a git-skills-plugin source. Set assetType to skills and paste the
+                  source entry (type and properties.repositories). The configured repositories
+                  are shallow-cloned to enumerate their skills; includedSkills/excludedSkills on
+                  each repository decide which are included. No catalogData is used.
+                value: |
+                  assetType: skills
+                  type: git-skills-plugin
+                  properties:
+                    repositories:
+                      - url: https://github.com/example/skills.git
+                        refs: ["v1.0"]
+                        scanPaths: ["skills/"]
+                        includedSkills: ["*"]
+                        excludedSkills: ["*-draft"]
       parameters:
         - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/nextPageToken"
@@ -516,7 +541,9 @@ components:
     PreviewCatalogSourceResponse:
       description: >-
         Polymorphic preview response. The `assetType` discriminator determines
-        whether the payload is a model preview or an MCP server preview.
+        whether the payload is a model preview (`CatalogSourcePreviewResponse`) or
+        a generic asset preview (`AssetSourcePreviewResponse`), the latter used for
+        both MCP server and skill sources.
       oneOf:
         - $ref: "#/components/schemas/CatalogSourcePreviewResponse"
         - $ref: "#/components/schemas/AssetSourcePreviewResponse"
@@ -525,6 +552,7 @@ components:
         mapping:
           models: "#/components/schemas/CatalogSourcePreviewResponse"
           mcp_servers: "#/components/schemas/AssetSourcePreviewResponse"
+          skills: "#/components/schemas/AssetSourcePreviewResponse"
     FilterOption:
       type: object
       required:

--- a/catalog/clients/python/tests/conftest.py
+++ b/catalog/clients/python/tests/conftest.py
@@ -219,6 +219,53 @@ def poll_for_ready(user_token: str | None, verify_ssl: bool) -> None:
         backoff = min(backoff * 2, MAX_BACKOFF)  # Exponential backoff with cap
 
 
+def poll_for_filter_options(user_token: str | None, verify_ssl: bool) -> None:
+    """Wait until filter options are populated (materialized views refreshed).
+
+    The catalog HTTP server becomes reachable before leader setup completes
+    (migrations → model writes → OnLeaderReady → REFRESH MATERIALIZED VIEW).
+    This guard ensures tests only start after the views are populated.
+
+    Args:
+        user_token: Optional auth token.
+        verify_ssl: Whether to verify SSL certificates.
+    """
+    url = f"{CATALOG_URL}{API_BASE_PATH}/models/filter_options"
+    params = {
+        "url": url,
+        "headers": {
+            "Authorization": f"Bearer {user_token}",
+        }
+        if user_token
+        else None,
+        "verify": verify_ssl,
+    }
+    backoff = POLL_INTERVAL
+    poll_start = time.time()
+
+    while True:
+        elapsed_time = time.time() - poll_start
+        if elapsed_time >= MAX_POLL_TIME:
+            logger.warning("Filter options still empty after %ds; proceeding anyway", int(elapsed_time))
+            return
+        logger.info("Waiting for filter options to be populated...")
+        try:
+            response = requests.get(**params, timeout=MAX_BACKOFF)
+            if response.status_code == 200:
+                try:
+                    filters = response.json().get("filters", {})
+                    if filters:
+                        logger.info("Filter options ready (%d fields)", len(filters))
+                        return
+                except Exception:
+                    pass
+        except requests.exceptions.ConnectionError:
+            pass
+
+        time.sleep(backoff)
+        backoff = min(backoff * 2, MAX_BACKOFF)
+
+
 @pytest.fixture(scope="session")
 def api_client(user_token: str | None, verify_ssl: bool) -> Generator[CatalogAPIClient, None, None]:
     """Create API client for the catalog service.
@@ -232,6 +279,7 @@ def api_client(user_token: str | None, verify_ssl: bool) -> Generator[CatalogAPI
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     poll_for_ready(user_token=user_token, verify_ssl=verify_ssl)
+    poll_for_filter_options(user_token=user_token, verify_ssl=verify_ssl)
     with CatalogAPIClient(
         CATALOG_URL, timeout=CLIENT_TIMEOUT, verify_ssl=verify_ssl, access_token=user_token
     ) as client:

--- a/catalog/internal/catalog/catalog.go
+++ b/catalog/internal/catalog/catalog.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
 	"github.com/kubeflow/hub/catalog/internal/catalog/mcpcatalog"
 	"github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog"
+	"github.com/kubeflow/hub/catalog/internal/catalog/skillcatalog"
 )
 
 type (
@@ -23,6 +24,9 @@ type (
 
 	// Agent catalog types
 	AgentSourceCollection = agentcatalog.AgentSourceCollection
+
+	// Skill catalog types
+	SkillSourceCollection = skillcatalog.SkillSourceCollection
 
 	// MCP catalog types
 	MCPSourceCollection      = mcpcatalog.MCPSourceCollection

--- a/catalog/internal/catalog/modelcatalog/loader.go
+++ b/catalog/internal/catalog/modelcatalog/loader.go
@@ -283,7 +283,12 @@ func (l *ModelLoader) updateLabels(path string, config *basecatalog.SourceConfig
 func (l *ModelLoader) updateDatabase(ctx context.Context) error {
 	records := l.readProviderRecords(ctx)
 
+	// Hold a single write slot for the goroutine's lifetime so the WG counter
+	// never hits zero between iterations, preventing WaitForInflightWrites from
+	// falsely unblocking while the loop is still processing records.
+	l.state.TrackWrite()
 	go func() {
+		defer l.state.WriteComplete()
 		for record := range records {
 			// Check if we're still the leader before each write
 			if !l.state.ShouldWriteDatabase() {
@@ -306,9 +311,6 @@ func (l *ModelLoader) updateDatabase(ctx context.Context) error {
 			}
 
 			func() {
-				// Track this write operation
-				l.state.TrackWrite()
-				defer l.state.WriteComplete()
 
 				glog.Infof("Loading model %s with %d artifact(s)", *attr.Name, len(record.Artifacts))
 

--- a/catalog/internal/catalog/modelcatalog/testdata/dev-catalog-sources.yaml
+++ b/catalog/internal/catalog/modelcatalog/testdata/dev-catalog-sources.yaml
@@ -1,4 +1,4 @@
-catalogs:
+model_catalogs:
   - name: "Organization AI Models"
     id: organization_ai_models
     type: yaml

--- a/catalog/internal/catalog/modelcatalog/testdata/test-catalog-sources.yaml
+++ b/catalog/internal/catalog/modelcatalog/testdata/test-catalog-sources.yaml
@@ -1,4 +1,4 @@
-catalogs:
+model_catalogs:
   - name: "Catalog 1"
     id: catalog1
     type: yaml

--- a/catalog/internal/catalog/modelcatalog/testdata/test-skill-sources.yaml
+++ b/catalog/internal/catalog/modelcatalog/testdata/test-skill-sources.yaml
@@ -1,0 +1,11 @@
+skill_catalogs:
+  - name: Test Skills
+    id: test-skills
+    type: git-skills-plugin
+    enabled: true
+    properties:
+      repositories:
+        - url: https://github.com/mattpocock/skills.git
+          refs: ["v1.2.3"]
+          scanPaths: ["skills/"]
+          includedSkills: ["*"]

--- a/catalog/internal/catalog/skillcatalog/credentials.go
+++ b/catalog/internal/catalog/skillcatalog/credentials.go
@@ -1,0 +1,28 @@
+package skillcatalog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// loadRepoCredentials reads the git token for repo's credentialRef from dir.
+// credentialRef is validated as a plain filename at config-parse time so it cannot
+// escape the directory; the file is re-read on each call to pick up hot-reloaded
+// Secrets. The token reaches git only via GIT_ASKPASS (see RepoResolver.gitEnv),
+// never argv, a URL, or a log line.
+func loadRepoCredentials(dir string, repo SkillRepository) (*Credentials, error) {
+	if repo.CredentialRef == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(filepath.Join(dir, repo.CredentialRef))
+	if err != nil {
+		return nil, fmt.Errorf("reading git token for credentialRef %q: %w", repo.CredentialRef, err)
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return nil, fmt.Errorf("git token for credentialRef %q is empty", repo.CredentialRef)
+	}
+	return &Credentials{Username: gitTokenUsername, Token: token}, nil
+}

--- a/catalog/internal/catalog/skillcatalog/db_skill.go
+++ b/catalog/internal/catalog/skillcatalog/db_skill.go
@@ -126,6 +126,33 @@ func (d *DBSkillCatalog) ListSkills(_ context.Context, params ListSkillsParams) 
 	return list, nil
 }
 
+// marketplacePageSize is how many skills ListAllSkills fetches per page while
+// walking the full catalog for the marketplace document.
+const marketplacePageSize = 200
+
+// ListAllSkills returns every indexed skill, paging through the datastore. It is
+// used to render the marketplace document, which lists all skills at once rather
+// than a single page.
+func (d *DBSkillCatalog) ListAllSkills(ctx context.Context) ([]openapi.Skill, error) {
+	var all []openapi.Skill
+	var token *string
+	for {
+		list, err := d.ListSkills(ctx, ListSkillsParams{PageSize: marketplacePageSize, NextPageToken: token})
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, list.Items...)
+		// Stop on the last page, or defensively if a page returns nothing (so a
+		// pager that fails to advance its token cannot loop forever).
+		if list.NextPageToken == "" || len(list.Items) == 0 {
+			break
+		}
+		next := list.NextPageToken
+		token = &next
+	}
+	return all, nil
+}
+
 // GetSkill returns a single skill by its datastore ID.
 func (d *DBSkillCatalog) GetSkill(_ context.Context, id string) (*openapi.Skill, error) {
 	skillID, err := apiutils.ValidateIDAsInt32(id, "skill")
@@ -247,6 +274,14 @@ func dbPropToMetadataValue(prop dbmodels.Properties) openapi.MetadataValue {
 		mv.MetadataBoolValue.BoolValue = *prop.BoolValue
 	}
 	return mv
+}
+
+// deref returns the pointed-to string, or "" if the pointer is nil.
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // decodeStringSlice decodes a JSON string array stored in a string property.

--- a/catalog/internal/catalog/skillcatalog/env_config.go
+++ b/catalog/internal/catalog/skillcatalog/env_config.go
@@ -31,7 +31,49 @@ const (
 	// is mounted; each file in it is a token named by a repository's credentialRef
 	// (default /etc/skill-catalog/git-credentials).
 	EnvGitCredentialsDir = "SKILL_CATALOG_GIT_CREDENTIALS_DIR"
+
+	// EnvMarketplaceName overrides the `name` of the rendered Claude Code plugin
+	// marketplace (kebab-case; users install with name@<this>). Default
+	// "kubeflow-skill-catalog".
+	EnvMarketplaceName = "SKILL_CATALOG_MARKETPLACE_NAME"
+	// EnvMarketplaceOwner overrides the marketplace owner/maintainer name shown in
+	// the rendered marketplace. Default "Kubeflow".
+	EnvMarketplaceOwner = "SKILL_CATALOG_MARKETPLACE_OWNER"
+	// EnvContentMirror sets the external base URL that marketplace plugin clone
+	// URLs are rewritten onto (canonical https://<host>/{org}/{repo}.git ->
+	// {base}/{org}/{repo}.git). Unset means canonical upstream URLs are served.
+	EnvContentMirror = "SKILL_CONTENT_MIRROR"
+	// EnvContentMirrorInternal sets the base URL used instead of EnvContentMirror
+	// when a marketplace request carries ?audience=cluster (in-cluster consumers).
+	// Unset means the external mirror (or canonical URL) is used for all audiences.
+	EnvContentMirrorInternal = "SKILL_CONTENT_MIRROR_INTERNAL"
 )
+
+// Defaults for the rendered Claude Code plugin marketplace.
+const (
+	defaultMarketplaceName  = "kubeflow-skill-catalog"
+	defaultMarketplaceOwner = "Kubeflow"
+)
+
+// MarketplaceConfigFromEnv builds the marketplace rendering config from the
+// environment, falling back to the compiled-in defaults for name and owner and to
+// canonical (un-rewritten) clone URLs when no content mirror is configured.
+func MarketplaceConfigFromEnv() MarketplaceConfig {
+	name := os.Getenv(EnvMarketplaceName)
+	if name == "" {
+		name = defaultMarketplaceName
+	}
+	owner := os.Getenv(EnvMarketplaceOwner)
+	if owner == "" {
+		owner = defaultMarketplaceOwner
+	}
+	return MarketplaceConfig{
+		Name:           name,
+		Owner:          owner,
+		ExternalMirror: os.Getenv(EnvContentMirror),
+		InternalMirror: os.Getenv(EnvContentMirrorInternal),
+	}
+}
 
 // CredentialsDirFromEnv returns the git-credentials mount directory, overridden by
 // EnvGitCredentialsDir when set to a non-empty value; otherwise the default.

--- a/catalog/internal/catalog/skillcatalog/loader.go
+++ b/catalog/internal/catalog/skillcatalog/loader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -660,25 +659,11 @@ func runPeriodicSync(ctx context.Context, interval time.Duration, wg *sync.WaitG
 	}()
 }
 
-// credentialsForRepo resolves a repository's git credentials by reading the token
-// file named by its credentialRef from the mounted credentials directory. A repo
-// with no credentialRef clones anonymously (nil, nil); one whose token file is
-// missing or empty fails clearly rather than silently cloning anonymously. The key
-// is validated as a plain filename at config-parse time, so it cannot escape the
-// directory. The file is re-read each time, so a hot-reloaded Secret is picked up.
+// credentialsForRepo resolves a repository's git credentials from the loader's
+// mounted credentials directory. See loadRepoCredentials for the shared semantics
+// used by both the loader and the source previewer.
 func (l *SkillLoader) credentialsForRepo(repo SkillRepository) (*Credentials, error) {
-	if repo.CredentialRef == "" {
-		return nil, nil
-	}
-	data, err := os.ReadFile(filepath.Join(l.credentialsDir, repo.CredentialRef))
-	if err != nil {
-		return nil, fmt.Errorf("reading git token for credentialRef %q: %w", repo.CredentialRef, err)
-	}
-	token := strings.TrimSpace(string(data))
-	if token == "" {
-		return nil, fmt.Errorf("git token for credentialRef %q is empty", repo.CredentialRef)
-	}
-	return &Credentials{Username: gitTokenUsername, Token: token}, nil
+	return loadRepoCredentials(l.credentialsDir, repo)
 }
 
 // refJob is one (repository, ref) pair to resolve.

--- a/catalog/internal/catalog/skillcatalog/marketplace.go
+++ b/catalog/internal/catalog/skillcatalog/marketplace.go
@@ -1,0 +1,263 @@
+package skillcatalog
+
+import (
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	model "github.com/kubeflow/hub/catalog/pkg/openapi"
+)
+
+// This file renders indexed skills as a Claude Code plugin marketplace document,
+// per https://code.claude.com/docs/en/plugin-marketplaces. Every indexed ref of a
+// skill becomes its own plugin entry whose source is a git-subdir pinned to the
+// exact resolved commit, so an install is reproducible.
+
+// gitSubdirSourceType is the Claude Code plugin source discriminator for a
+// subdirectory within a git repository.
+const gitSubdirSourceType = "git-subdir"
+
+// Marketplace is the top-level Claude Code marketplace document.
+type Marketplace struct {
+	Name     string               `json:"name"`
+	Owner    MarketplaceOwner     `json:"owner"`
+	Metadata *MarketplaceMetadata `json:"metadata,omitempty"`
+	Plugins  []MarketplacePlugin  `json:"plugins"`
+}
+
+// MarketplaceOwner identifies the marketplace maintainer.
+type MarketplaceOwner struct {
+	Name  string `json:"name"`
+	Email string `json:"email,omitempty"`
+	URL   string `json:"url,omitempty"`
+}
+
+// MarketplaceMetadata carries optional descriptive fields.
+type MarketplaceMetadata struct {
+	Description string `json:"description,omitempty"`
+	Version     string `json:"version,omitempty"`
+}
+
+// MarketplacePlugin is one installable entry (one skill at one ref).
+type MarketplacePlugin struct {
+	Name        string             `json:"name"`
+	Source      GitSubdirSource    `json:"source"`
+	Description string             `json:"description,omitempty"`
+	Version     string             `json:"version,omitempty"`
+	Author      *MarketplaceAuthor `json:"author,omitempty"`
+	License     string             `json:"license,omitempty"`
+	Keywords    []string           `json:"keywords,omitempty"`
+	Category    string             `json:"category,omitempty"`
+}
+
+// MarketplaceAuthor is the plugin author block (name required by the schema).
+type MarketplaceAuthor struct {
+	Name string `json:"name"`
+}
+
+// GitSubdirSource pins a skill to an exact commit within a git-repository
+// subdirectory. `sha` is the reproducible pin; `ref` records the human-readable
+// tag/commit the entry was indexed at.
+type GitSubdirSource struct {
+	Source string `json:"source"`
+	URL    string `json:"url"`
+	Path   string `json:"path"`
+	Ref    string `json:"ref,omitempty"`
+	SHA    string `json:"sha,omitempty"`
+}
+
+// MarketplaceConfig holds the deployment-level marketplace settings resolved from
+// the environment (see MarketplaceConfigFromEnv).
+type MarketplaceConfig struct {
+	Name           string
+	Owner          string
+	ExternalMirror string
+	InternalMirror string
+}
+
+// MarketplaceOptions are the per-request rendering inputs.
+type MarketplaceOptions struct {
+	Name  string
+	Owner MarketplaceOwner
+	// URLRewrite, when non-nil, maps a skill's canonical repository URL to the URL
+	// clients should clone from (e.g. an internal or external mirror base).
+	URLRewrite func(repoURL string) string
+}
+
+// Options resolves the rendering options for one request. Clone URLs default to
+// the external mirror when configured; a request with audience "cluster" uses the
+// internal mirror instead, so in-cluster consumers pull from the internal Service
+// while laptops pull from the external Route. With no mirror configured, canonical
+// upstream URLs are served unchanged.
+func (c MarketplaceConfig) Options(audience string) MarketplaceOptions {
+	base := c.ExternalMirror
+	if audience == "cluster" && c.InternalMirror != "" {
+		base = c.InternalMirror
+	}
+	var rewrite func(string) string
+	if base != "" {
+		rewrite = mirrorRewriter(base)
+	}
+	return MarketplaceOptions{
+		Name:       c.Name,
+		Owner:      MarketplaceOwner{Name: c.Owner},
+		URLRewrite: rewrite,
+	}
+}
+
+// mirrorRewriter maps a canonical repo URL onto a mirror base by taking its
+// {org}/{repo} path and joining it to the base as {base}/{org}/{repo}.git. A URL
+// that cannot be parsed is returned unchanged so a single odd entry does not break
+// the whole document.
+func mirrorRewriter(base string) func(string) string {
+	base = strings.TrimRight(base, "/")
+	return func(repoURL string) string {
+		u, err := url.Parse(repoURL)
+		if err != nil || u.Path == "" {
+			return repoURL
+		}
+		p := strings.Trim(u.Path, "/")
+		if p == "" {
+			return repoURL
+		}
+		if !strings.HasSuffix(p, ".git") {
+			p += ".git"
+		}
+		return base + "/" + p
+	}
+}
+
+// BuildMarketplace renders the given skills into a Claude Code marketplace
+// document. Skills are ordered deterministically by (repository, path, version) so
+// the document — and the disambiguated plugin names it assigns — are stable across
+// renders of identical content. A skill missing the identity needed to install it
+// (repository or name) is skipped.
+func BuildMarketplace(skills []model.Skill, opts MarketplaceOptions) Marketplace {
+	sorted := append([]model.Skill(nil), skills...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if a, b := deref(sorted[i].Repository), deref(sorted[j].Repository); a != b {
+			return a < b
+		}
+		if a, b := deref(sorted[i].Path), deref(sorted[j].Path); a != b {
+			return a < b
+		}
+		return deref(sorted[i].Version) < deref(sorted[j].Version)
+	})
+
+	used := make(map[string]int, len(sorted))
+	plugins := make([]MarketplacePlugin, 0, len(sorted))
+	for i := range sorted {
+		s := sorted[i]
+		repo := deref(s.Repository)
+		if repo == "" || s.Name == "" {
+			continue
+		}
+		cloneURL := repo
+		if opts.URLRewrite != nil {
+			cloneURL = opts.URLRewrite(repo)
+		}
+		version := deref(s.Version)
+		commit := deref(s.ResolvedCommit)
+
+		plugins = append(plugins, MarketplacePlugin{
+			Name: uniquePluginName(kebabName(s.Name), version, commit, used),
+			Source: GitSubdirSource{
+				Source: gitSubdirSourceType,
+				URL:    cloneURL,
+				Path:   marketplacePath(deref(s.Path)),
+				Ref:    version,
+				SHA:    commit,
+			},
+			Description: deref(s.Description),
+			Version:     marketplaceVersion(version, commit),
+			Author:      marketplaceAuthor(s),
+			License:     deref(s.License),
+			Keywords:    s.Labels,
+			Category:    deref(s.Category),
+		})
+	}
+
+	return Marketplace{
+		Name:    opts.Name,
+		Owner:   opts.Owner,
+		Plugins: plugins,
+	}
+}
+
+// nonKebab matches any run of characters that are not lowercase alphanumerics, used
+// to normalize a skill name into the kebab-case a plugin name requires.
+var nonKebab = regexp.MustCompile(`[^a-z0-9]+`)
+
+// kebabName normalizes a skill name to the kebab-case a Claude Code plugin name
+// requires (lowercase alphanumerics and single hyphens). Agent Skills names are
+// already kebab-case; this guards against anything that is not.
+func kebabName(name string) string {
+	n := nonKebab.ReplaceAllString(strings.ToLower(name), "-")
+	n = strings.Trim(n, "-")
+	if n == "" {
+		return "skill"
+	}
+	return n
+}
+
+// uniquePluginName returns a marketplace-unique plugin name for a skill. Plugin
+// names must be unique within a marketplace, but a skill can be indexed at several
+// refs and different repositories can define skills of the same name; base collides
+// on those. It prefers the bare name, then appends the version, then a short commit
+// prefix, and finally a numeric suffix — deterministic because callers render in a
+// stable order.
+func uniquePluginName(base, version, commit string, used map[string]int) string {
+	candidate := base
+	if _, taken := used[candidate]; taken && version != "" {
+		candidate = base + "-" + kebabName(version)
+	}
+	if _, taken := used[candidate]; taken && commit != "" {
+		short := commit
+		if len(short) > 12 {
+			short = short[:12]
+		}
+		candidate = base + "-" + kebabName(short)
+	}
+	for {
+		if n, taken := used[candidate]; taken {
+			used[candidate] = n + 1
+			candidate = base + "-" + strconv.Itoa(n+1)
+			continue
+		}
+		used[candidate] = 1
+		return candidate
+	}
+}
+
+// marketplacePath returns the git-subdir path for a skill directory. A repo-root
+// skill (path ".") maps to "." so the whole repository is checked out.
+func marketplacePath(p string) string {
+	if p == "" {
+		return "."
+	}
+	return p
+}
+
+// marketplaceVersion is the plugin's display/update version: the ref it was indexed
+// at, falling back to the resolved commit. The reproducible pin is always the
+// source's sha; this field only drives Claude Code's update tracking and display.
+func marketplaceVersion(version, commit string) string {
+	if version != "" {
+		return version
+	}
+	return commit
+}
+
+// marketplaceAuthor derives the plugin author from the skill's author, then its
+// provider; nil when neither is set (the field is optional).
+func marketplaceAuthor(s model.Skill) *MarketplaceAuthor {
+	if a := deref(s.Author); a != "" {
+		return &MarketplaceAuthor{Name: a}
+	}
+	if p := deref(s.Provider); p != "" {
+		return &MarketplaceAuthor{Name: p}
+	}
+	return nil
+}

--- a/catalog/internal/catalog/skillcatalog/marketplace_test.go
+++ b/catalog/internal/catalog/skillcatalog/marketplace_test.go
@@ -1,0 +1,137 @@
+package skillcatalog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	model "github.com/kubeflow/hub/catalog/pkg/openapi"
+)
+
+func ptr(s string) *string { return &s }
+
+func skill(name, repo, path, version, commit string) model.Skill {
+	return model.Skill{
+		Name:           name,
+		Repository:     ptr(repo),
+		Path:           ptr(path),
+		Version:        ptr(version),
+		ResolvedCommit: ptr(commit),
+	}
+}
+
+func pluginByName(m Marketplace, name string) (MarketplacePlugin, bool) {
+	for _, p := range m.Plugins {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return MarketplacePlugin{}, false
+}
+
+func TestBuildMarketplace_GitSubdirPinnedToCommit(t *testing.T) {
+	skills := []model.Skill{skill("deploy", "https://github.com/org/repo.git", "skills/deploy", "v1.0", "deadbeef")}
+
+	m := BuildMarketplace(skills, MarketplaceOptions{Name: "cat", Owner: MarketplaceOwner{Name: "Kubeflow"}})
+
+	require.Len(t, m.Plugins, 1)
+	p := m.Plugins[0]
+	assert.Equal(t, "deploy", p.Name)
+	assert.Equal(t, gitSubdirSourceType, p.Source.Source)
+	assert.Equal(t, "https://github.com/org/repo.git", p.Source.URL)
+	assert.Equal(t, "skills/deploy", p.Source.Path)
+	assert.Equal(t, "v1.0", p.Source.Ref)
+	assert.Equal(t, "deadbeef", p.Source.SHA, "install must be pinned to the resolved commit")
+}
+
+func TestBuildMarketplace_UniqueNamesAcrossRefsAndRepos(t *testing.T) {
+	skills := []model.Skill{
+		skill("deploy", "https://github.com/org/repo.git", "skills/deploy", "v2.0", "c2"),
+		skill("deploy", "https://github.com/org/repo.git", "skills/deploy", "v1.0", "c1"),
+		skill("deploy", "https://github.com/other/repo.git", "deploy", "v1.0", "c3"),
+	}
+
+	m := BuildMarketplace(skills, MarketplaceOptions{Name: "cat", Owner: MarketplaceOwner{Name: "Kubeflow"}})
+	require.Len(t, m.Plugins, 3)
+
+	names := map[string]int{}
+	for _, p := range m.Plugins {
+		names[p.Name]++
+	}
+	for name, count := range names {
+		assert.Equalf(t, 1, count, "plugin name %q must be unique within the marketplace", name)
+	}
+
+	// The first entry in deterministic (repo, path, version) order keeps the bare name.
+	_, ok := pluginByName(m, "deploy")
+	assert.True(t, ok, "one entry should keep the bare skill name")
+}
+
+func TestBuildMarketplace_DeterministicOrder(t *testing.T) {
+	skills := []model.Skill{
+		skill("b", "https://github.com/org/repo.git", "skills/b", "v1.0", "c2"),
+		skill("a", "https://github.com/org/repo.git", "skills/a", "v1.0", "c1"),
+	}
+	first := BuildMarketplace(skills, MarketplaceOptions{Name: "cat"})
+	second := BuildMarketplace(skills, MarketplaceOptions{Name: "cat"})
+	assert.Equal(t, first, second)
+	// Sorted by path: skills/a before skills/b.
+	assert.Equal(t, "a", first.Plugins[0].Name)
+}
+
+func TestBuildMarketplace_SkipsIncompleteIdentity(t *testing.T) {
+	skills := []model.Skill{
+		{Name: "no-repo"},                                              // missing repository
+		{Repository: ptr("https://github.com/org/repo.git")},          // missing name
+		skill("ok", "https://github.com/org/repo.git", "s/ok", "v1", "c"),
+	}
+	m := BuildMarketplace(skills, MarketplaceOptions{Name: "cat"})
+	require.Len(t, m.Plugins, 1)
+	assert.Equal(t, "ok", m.Plugins[0].Name)
+}
+
+func TestBuildMarketplace_AuthorFallsBackToProvider(t *testing.T) {
+	s := skill("deploy", "https://github.com/org/repo.git", "skills/deploy", "v1.0", "c")
+	s.Provider = ptr("Example Org")
+	m := BuildMarketplace([]model.Skill{s}, MarketplaceOptions{Name: "cat"})
+	require.Len(t, m.Plugins, 1)
+	require.NotNil(t, m.Plugins[0].Author)
+	assert.Equal(t, "Example Org", m.Plugins[0].Author.Name)
+}
+
+func TestBuildMarketplace_RootPathMapsToDot(t *testing.T) {
+	m := BuildMarketplace([]model.Skill{skill("whole", "https://github.com/org/repo.git", ".", "v1.0", "c")}, MarketplaceOptions{Name: "cat"})
+	require.Len(t, m.Plugins, 1)
+	assert.Equal(t, ".", m.Plugins[0].Source.Path)
+}
+
+func TestMarketplaceConfig_MirrorRewrite(t *testing.T) {
+	cfg := MarketplaceConfig{
+		Name:           "cat",
+		Owner:          "Kubeflow",
+		ExternalMirror: "https://mirror.example.com/git",
+		InternalMirror: "http://skills-git.hub.svc:8080",
+	}
+	skills := []model.Skill{skill("deploy", "https://github.com/org/repo.git", "skills/deploy", "v1.0", "c")}
+
+	// Default audience -> external mirror.
+	ext := BuildMarketplace(skills, cfg.Options(""))
+	require.Len(t, ext.Plugins, 1)
+	assert.Equal(t, "https://mirror.example.com/git/org/repo.git", ext.Plugins[0].Source.URL)
+
+	// audience=cluster -> internal mirror.
+	in := BuildMarketplace(skills, cfg.Options("cluster"))
+	require.Len(t, in.Plugins, 1)
+	assert.Equal(t, "http://skills-git.hub.svc:8080/org/repo.git", in.Plugins[0].Source.URL)
+}
+
+func TestMarketplaceConfig_NoMirrorKeepsCanonical(t *testing.T) {
+	cfg := MarketplaceConfig{Name: "cat", Owner: "Kubeflow"}
+	skills := []model.Skill{skill("deploy", "https://github.com/org/repo.git", "skills/deploy", "v1.0", "c")}
+	m := BuildMarketplace(skills, cfg.Options("cluster"))
+	require.Len(t, m.Plugins, 1)
+	assert.Equal(t, "https://github.com/org/repo.git", m.Plugins[0].Source.URL)
+	assert.Equal(t, "cat", m.Name)
+	assert.Equal(t, "Kubeflow", m.Owner.Name)
+}

--- a/catalog/internal/catalog/skillcatalog/preview.go
+++ b/catalog/internal/catalog/skillcatalog/preview.go
@@ -171,8 +171,9 @@ func filterMatchName(rs ResolvedSkill) string {
 	return skillFilterName(rs.Path, frontmatter)
 }
 
-// previewSkillName is the human-facing name shown for a previewed skill: its
-// frontmatter name, falling back to the directory name.
+// previewSkillName is the human-facing name shown for a previewed skill.
+// ParseSkillMD guarantees Name is non-empty for every resolved skill, so the
+// filterMatchName fallback is a defensive guard for unexpected nil Skill values.
 func previewSkillName(rs ResolvedSkill) string {
 	if rs.Skill != nil && rs.Skill.Name != "" {
 		return rs.Skill.Name

--- a/catalog/internal/catalog/skillcatalog/preview.go
+++ b/catalog/internal/catalog/skillcatalog/preview.go
@@ -1,0 +1,181 @@
+package skillcatalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sync/semaphore"
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
+	model "github.com/kubeflow/hub/catalog/pkg/openapi"
+)
+
+// maxPreviewJobs caps how many ref clones a single preview request may trigger.
+// Preview resolves one repository, but that repository can list several refs and
+// each ref is a synchronous clone in the request path. MaxRefsPerRepo already
+// bounds this in the normal case; maxPreviewJobs is a hard backstop should that
+// limit be raised.
+const maxPreviewJobs = 100
+
+// SkillPreviewer previews a git-skills-plugin source by resolving its repositories
+// at each ref and reporting which discovered skills the source's include/exclude
+// filters would keep. It clones repositories (parse-only, discarded) exactly like
+// the loader — reusing the same resolver, credential handling, and clone limits —
+// so a preview behaves like the sync that would follow it.
+type SkillPreviewer struct {
+	resolver       refResolver
+	credentialsDir string
+	limits         SyncLimits
+}
+
+// NewSkillPreviewer builds a previewer with the loader's limits and credentials
+// mount. Zero-valued limits fall back to the compiled-in defaults.
+func NewSkillPreviewer(resolveLimits ResolveLimits, syncLimits SyncLimits, credentialsDir string) *SkillPreviewer {
+	if syncLimits.MaxInFlightClones <= 0 {
+		syncLimits.MaxInFlightClones = defaultMaxInFlightClones
+	}
+	if syncLimits.MaxRefsPerRepo <= 0 {
+		syncLimits.MaxRefsPerRepo = defaultMaxRefsPerRepo
+	}
+	if syncLimits.MaxResolveWorkers <= 0 {
+		syncLimits.MaxResolveWorkers = defaultMaxResolveWorkers
+	}
+	if credentialsDir == "" {
+		credentialsDir = defaultGitCredentialsDir
+	}
+	return &SkillPreviewer{
+		resolver:       NewRepoResolver(resolveLimits),
+		credentialsDir: credentialsDir,
+		limits:         syncLimits,
+	}
+}
+
+// PreviewSkillSource previews a pasted git-skills-plugin source config. Scoped to
+// one repository per request because each is a network clone; configs with more
+// than one repository are rejected. Returns one result per discovered skill with
+// Included reflecting the config's include/exclude filters.
+func (p *SkillPreviewer) PreviewSkillSource(ctx context.Context, configBytes []byte) ([]model.AssetPreviewResult, error) {
+	spec, err := parsePreviewSource(configBytes)
+	if err != nil {
+		return nil, err
+	}
+	switch len(spec.Repositories) {
+	case 0:
+		return nil, fmt.Errorf("no repositories configured; add exactly one repository under properties.repositories to preview")
+	case 1:
+		// expected
+	default:
+		return nil, fmt.Errorf("preview operates on a single repository at a time, but the configuration lists %d; remove all but one repository before previewing", len(spec.Repositories))
+	}
+
+	// Compute each repository's filter up front, then resolve with the filters
+	// cleared so every skill in the repo is discovered and can be reported as
+	// included or excluded. Resolving with the filters left in place would drop
+	// excluded skills before they reach the preview, hiding exactly what the user
+	// is trying to see.
+	filtersByURL := make(map[string]*basecatalog.NameFilter, len(spec.Repositories))
+	cleared := make([]SkillRepository, len(spec.Repositories))
+	for i, r := range spec.Repositories {
+		nf, ferr := basecatalog.NewNameFilter("includedSkills", r.IncludedSkills, "excludedSkills", r.ExcludedSkills)
+		if ferr != nil {
+			return nil, fmt.Errorf("repository %q: invalid include/exclude patterns: %w", r.URL, ferr)
+		}
+		filtersByURL[r.URL] = nf
+		c := r
+		c.IncludedSkills = nil
+		c.ExcludedSkills = nil
+		cleared[i] = c
+	}
+
+	jobs, jobErrs, _ := buildRefJobs(cleared, p.limits.MaxRefsPerRepo) // rejected URLs unused: preview has no index to clean up
+	if len(jobErrs) > 0 {
+		return nil, fmt.Errorf("invalid repository configuration: %s", strings.Join(jobErrs, "; "))
+	}
+	if len(jobs) == 0 {
+		return []model.AssetPreviewResult{}, nil
+	}
+	if len(jobs) > maxPreviewJobs {
+		return nil, fmt.Errorf("preview would resolve %d repository refs, exceeding the limit of %d; reduce the number of repositories or refs and try again", len(jobs), maxPreviewJobs)
+	}
+
+	sem := semaphore.NewWeighted(p.limits.MaxInFlightClones)
+	creds := func(repo SkillRepository) (*Credentials, error) { return loadRepoCredentials(p.credentialsDir, repo) }
+	// Preview always resolves fresh: there is no previously-indexed commit to
+	// compare against, so nothing is skipped.
+	noSkip := func(SkillRepository, string) string { return "" }
+	results := resolveJobsConcurrently(ctx, jobs, p.limits.MaxResolveWorkers, sem, p.resolver, creds, noSkip)
+
+	var previews []model.AssetPreviewResult
+	var errs []string
+	resolved := 0
+	for _, res := range results {
+		if res.err != nil {
+			errs = append(errs, fmt.Sprintf("%s@%s: %v", res.repo.URL, res.ref, res.err))
+			continue
+		}
+		resolved++
+		filter := filtersByURL[res.repo.URL]
+		for i := range res.skills {
+			rs := res.skills[i]
+			previews = append(previews, model.AssetPreviewResult{
+				Name:     previewSkillName(rs),
+				Included: filter.Allows(filterMatchName(rs)),
+			})
+		}
+	}
+
+	// A preview that resolved nothing while hitting errors is a failed preview (bad
+	// URL, auth failure, or an unreachable host): surface it rather than returning
+	// an empty list that reads as "no skills found". A partial failure (some refs
+	// resolved) still returns what it found.
+	if resolved == 0 && len(errs) > 0 {
+		return nil, fmt.Errorf("failed to resolve any repository: %s", strings.Join(errs, "; "))
+	}
+	return previews, nil
+}
+
+// parsePreviewSource decodes a single pasted skill source entry into a validated
+// SkillSourceSpec. The assetType discriminator already selected this path, so an
+// omitted `type` is tolerated and defaulted to the skill source type.
+//
+// Preview always resolves skills from a git repository, never from a catalog file:
+// the file-based repository list (yamlCatalogPath) is rejected so a pasted config
+// cannot point the server at a local file, and so preview cannot be mistaken for a
+// static-catalog read like the model/MCP previews. The repository must be inline.
+func parsePreviewSource(configBytes []byte) (*SkillSourceSpec, error) {
+	var source basecatalog.PluginSource
+	if err := yaml.Unmarshal(configBytes, &source); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+	if source.Type == "" {
+		source.Type = SourceTypeGitSkillsPlugin
+	}
+	if raw, ok := source.Properties[propYAMLCatalogPath]; ok {
+		if s, _ := raw.(string); s != "" {
+			return nil, fmt.Errorf("preview reads skills from a git repository: set the repository inline under %q, not %q (a server-side catalog file)", propRepositories, propYAMLCatalogPath)
+		}
+	}
+	return ParseSkillSource(source)
+}
+
+// filterMatchName is the name a skill's include/exclude filter matches against. It
+// defers to skillFilterName — the resolver's own rule — so preview and scan cannot
+// disagree about which skills a filter would keep.
+func filterMatchName(rs ResolvedSkill) string {
+	frontmatter := ""
+	if rs.Skill != nil {
+		frontmatter = rs.Skill.Name
+	}
+	return skillFilterName(rs.Path, frontmatter)
+}
+
+// previewSkillName is the human-facing name shown for a previewed skill: its
+// frontmatter name, falling back to the directory name.
+func previewSkillName(rs ResolvedSkill) string {
+	if rs.Skill != nil && rs.Skill.Name != "" {
+		return rs.Skill.Name
+	}
+	return filterMatchName(rs)
+}

--- a/catalog/internal/catalog/skillcatalog/preview_test.go
+++ b/catalog/internal/catalog/skillcatalog/preview_test.go
@@ -1,0 +1,254 @@
+package skillcatalog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// previewFakeResolver returns canned skills (or errors) per (repository, ref),
+// letting preview tests exercise the full parse/resolve/filter path without git.
+type previewFakeResolver struct {
+	skills map[string][]ResolvedSkill
+	errs   map[string]error
+}
+
+func (f *previewFakeResolver) Resolve(_ context.Context, repo SkillRepository, ref string, _ *Credentials) ([]ResolvedSkill, error) {
+	k := repo.URL + "@" + ref
+	if err := f.errs[k]; err != nil {
+		return nil, err
+	}
+	return f.skills[k], nil
+}
+
+func (f *previewFakeResolver) RemoteCommit(_ context.Context, _ SkillRepository, _ string, _ *Credentials) (string, error) {
+	return "", nil
+}
+
+func newTestPreviewer(resolver refResolver) *SkillPreviewer {
+	return &SkillPreviewer{
+		resolver:       resolver,
+		credentialsDir: "/nonexistent",
+		limits:         SyncLimits{MaxInFlightClones: 10, MaxRefsPerRepo: 10, MaxResolveWorkers: 4},
+	}
+}
+
+func resolved(path, name string) ResolvedSkill {
+	return ResolvedSkill{Path: path, Version: "v1.0", ResolvedCommit: "abc", Skill: &ParsedSkill{Name: name}}
+}
+
+func TestPreviewSkillSource_IncludesAndExcludes(t *testing.T) {
+	fake := &previewFakeResolver{skills: map[string][]ResolvedSkill{
+		"https://example.com/a.git@v1.0": {
+			resolved("skills/deploy", "deploy"),
+			resolved("skills/rollout-draft", "rollout-draft"),
+		},
+	}}
+	p := newTestPreviewer(fake)
+
+	cfg := `
+type: git-skills-plugin
+properties:
+  repositories:
+    - url: https://example.com/a.git
+      refs: ["v1.0"]
+      includedSkills: ["*"]
+      excludedSkills: ["*-draft"]
+`
+	results, err := p.PreviewSkillSource(context.Background(), []byte(cfg))
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	byName := map[string]bool{}
+	for _, r := range results {
+		byName[r.Name] = r.Included
+	}
+	assert.True(t, byName["deploy"], "deploy should be included")
+	assert.False(t, byName["rollout-draft"], "rollout-draft should be excluded but still listed")
+}
+
+func TestPreviewSkillSource_AcceptsJSONConfig(t *testing.T) {
+	// The source-management UI collects form fields; the BFF serializes them into
+	// the config payload (typically JSON) and posts it inline — there is no config
+	// file. Confirm the parser accepts a JSON body (not just YAML), with the single
+	// repository wrapped under properties.repositories exactly as the save path writes it.
+	fake := &previewFakeResolver{skills: map[string][]ResolvedSkill{
+		"https://example.com/a.git@v1.0": {resolved("skills/deploy", "deploy")},
+	}}
+	p := newTestPreviewer(fake)
+
+	cfg := `{"assetType":"skills","type":"git-skills-plugin","properties":{"repositories":[{"url":"https://example.com/a.git","refs":["v1.0"],"includedSkills":["*"]}]}}`
+	results, err := p.PreviewSkillSource(context.Background(), []byte(cfg))
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "deploy", results[0].Name)
+	assert.True(t, results[0].Included)
+}
+
+func TestPreviewSkillSource_RootLevelSkillUsesFrontmatterName(t *testing.T) {
+	fake := &previewFakeResolver{skills: map[string][]ResolvedSkill{
+		"https://example.com/a.git@v1.0": {resolved(".", "whole-repo-skill")},
+	}}
+	p := newTestPreviewer(fake)
+
+	cfg := `
+type: git-skills-plugin
+properties:
+  repositories:
+    - url: https://example.com/a.git
+      refs: ["v1.0"]
+      excludedSkills: ["whole-repo-skill"]
+`
+	results, err := p.PreviewSkillSource(context.Background(), []byte(cfg))
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "whole-repo-skill", results[0].Name)
+	assert.False(t, results[0].Included, "root-level skill filtered by frontmatter name")
+}
+
+func TestPreviewSkillSource_InvalidConfig(t *testing.T) {
+	p := newTestPreviewer(&previewFakeResolver{})
+
+	// No repositories configured is a config error, surfaced before any clone.
+	_, err := p.PreviewSkillSource(context.Background(), []byte("type: git-skills-plugin\nproperties: {}\n"))
+	require.Error(t, err)
+}
+
+func TestPreviewSkillSource_RejectsYamlCatalogPath(t *testing.T) {
+	p := newTestPreviewer(&previewFakeResolver{})
+
+	// yamlCatalogPath is a server-side file listing repos; preview must read from
+	// git (inline repository) instead, so this is rejected before any file access.
+	cfg := `
+type: git-skills-plugin
+properties:
+  yamlCatalogPath: /etc/skill-catalog/repos.yaml
+`
+	_, err := p.PreviewSkillSource(context.Background(), []byte(cfg))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "git repository")
+}
+
+func TestPreviewSkillSource_RepoWithoutRefs(t *testing.T) {
+	p := newTestPreviewer(&previewFakeResolver{})
+
+	cfg := `
+type: git-skills-plugin
+properties:
+  repositories:
+    - url: https://example.com/a.git
+`
+	_, err := p.PreviewSkillSource(context.Background(), []byte(cfg))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no refs configured")
+}
+
+func TestPreviewSkillSource_AllReposFailIsError(t *testing.T) {
+	fake := &previewFakeResolver{errs: map[string]error{
+		"https://example.com/a.git@v1.0": errors.New("boom"),
+	}}
+	p := newTestPreviewer(fake)
+
+	cfg := `
+type: git-skills-plugin
+properties:
+  repositories:
+    - url: https://example.com/a.git
+      refs: ["v1.0"]
+`
+	_, err := p.PreviewSkillSource(context.Background(), []byte(cfg))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to resolve any repository")
+}
+
+func TestPreviewSkillSource_RejectsMultipleRepositories(t *testing.T) {
+	p := newTestPreviewer(&previewFakeResolver{})
+
+	// Preview is scoped to a single repository; a config listing more than one is
+	// a caller error, surfaced before any clone.
+	cfg := `
+type: git-skills-plugin
+properties:
+  repositories:
+    - url: https://example.com/a.git
+      refs: ["v1.0"]
+    - url: https://example.com/b.git
+      refs: ["v1.0"]
+`
+	_, err := p.PreviewSkillSource(context.Background(), []byte(cfg))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single repository")
+}
+
+func TestPreviewSkillSource_PartialRefFailureReturnsResolved(t *testing.T) {
+	// One repository, two refs: a ref that fails to resolve does not sink the refs
+	// that succeed.
+	fake := &previewFakeResolver{
+		skills: map[string][]ResolvedSkill{
+			"https://example.com/a.git@v1.0": {resolved("skills/deploy", "deploy")},
+		},
+		errs: map[string]error{
+			"https://example.com/a.git@v2.0": errors.New("ref not found"),
+		},
+	}
+	p := newTestPreviewer(fake)
+
+	cfg := `
+type: git-skills-plugin
+properties:
+  repositories:
+    - url: https://example.com/a.git
+      refs: ["v1.0", "v2.0"]
+`
+	results, err := p.PreviewSkillSource(context.Background(), []byte(cfg))
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "deploy", results[0].Name)
+}
+
+// TestPreviewSkillSource_RejectsDisallowedTransport exercises the real resolver to
+// confirm the transport allowlist (which blocks file:// and ext:: — SSRF/command
+// execution vectors) is enforced on the preview path, not just the sync path. The
+// protocol is rejected before any clone, so no network or filesystem access occurs.
+func TestPreviewSkillSource_RejectsDisallowedTransport(t *testing.T) {
+	p := NewSkillPreviewer(ResolveLimits{}, SyncLimits{}, t.TempDir())
+
+	cfg := `
+type: git-skills-plugin
+properties:
+  repositories:
+    - url: file:///tmp/whatever.git
+      refs: ["v1.0"]
+`
+	_, err := p.PreviewSkillSource(context.Background(), []byte(cfg))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disallowed transport")
+}
+
+func TestPreviewSkillSource_TooManyJobs(t *testing.T) {
+	p := newTestPreviewer(&previewFakeResolver{})
+	// Raise the per-repo ref cap so buildRefJobs accepts the repo; the total-job
+	// cap (maxPreviewJobs) is what should reject it.
+	p.limits.MaxRefsPerRepo = maxPreviewJobs + 100
+
+	refs := make([]string, 0, maxPreviewJobs+1)
+	for i := 0; i <= maxPreviewJobs; i++ {
+		refs = append(refs, fmt.Sprintf(`"v%d"`, i))
+	}
+	cfg := fmt.Sprintf(`
+type: git-skills-plugin
+properties:
+  repositories:
+    - url: https://example.com/a.git
+      refs: [%s]
+`, strings.Join(refs, ", "))
+
+	_, err := p.PreviewSkillSource(context.Background(), []byte(cfg))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeding the limit")
+}

--- a/catalog/internal/catalog/skillcatalog/repo_resolver.go
+++ b/catalog/internal/catalog/skillcatalog/repo_resolver.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -352,6 +353,19 @@ func (r *RepoResolver) enforceSizeLimit(dir string) error {
 	return err
 }
 
+// skillFilterName returns the name a skill's include/exclude filter matches
+// against: the skill's directory name, or — for a repo-root SKILL.md (relDir ".")
+// — its frontmatter name, since a root skill has no directory name to match on.
+// relDir is slash-separated. This is the single definition of the filter-match
+// rule, shared by the resolver's scan and the source previewer so the two cannot
+// drift apart.
+func skillFilterName(relDir, frontmatterName string) string {
+	if relDir == "." || relDir == "" {
+		return frontmatterName
+	}
+	return path.Base(relDir)
+}
+
 // scan walks the repo's scanPaths for SKILL.md files, parses each, and builds the
 // resolved skills. Directories named .git and node_modules are skipped.
 // All non-SKILL.md files are accumulated in a single pass and used to derive
@@ -418,32 +432,38 @@ func (r *RepoResolver) scan(root string, repo SkillRepository, version, commit s
 			}
 			seen[relDir] = true
 
-			// For a root-level SKILL.md there is no directory name to use as the
-			// skill name or apply include/exclude filters against; the skill's name
-			// must come from its frontmatter.
-			name := filepath.Base(relDir)
-			if relDir == "." {
-				name = ""
-			} else if !filter.Allows(name) {
-				return nil
+			// dirName is the skill's directory name, used as the parse fallback when
+			// the frontmatter omits a name. A repo-root SKILL.md (relDir ".") has no
+			// directory name. A nested skill can be filtered here from its directory
+			// name; a root skill has nothing to match against until its frontmatter
+			// name is parsed, so it is filtered below instead.
+			// filepath.Base (not path.Base) because the walk's `path` variable shadows
+			// the path package here; relDir is slash-separated and the resolver runs on
+			// Linux, so the two are equivalent.
+			dirName := ""
+			if relDir != "." {
+				dirName = filepath.Base(relDir)
+				if !filter.Allows(skillFilterName(relDir, "")) {
+					return nil
+				}
 			}
 
 			content, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}
-			parsed, perr := ParseSkillMD(content, name)
+			parsed, perr := ParseSkillMD(content, dirName)
 			if perr != nil {
 				// Lenient: an unparseable skill is skipped and logged, per the spec
 				// ("missing description or unparseable YAML → skip and log"); it is
 				// not fatal to the rest of the repo.
-				glog.Warningf("skipping skill %q (%s) in %s: %v", name, relDir, repo.URL, perr)
+				glog.Warningf("skipping skill %q (%s) in %s: %v", dirName, relDir, repo.URL, perr)
 				return nil
 			}
 
-			// For a root-level SKILL.md the directory name is not available before
-			// parsing; apply include/exclude filters here using the name from frontmatter.
-			if relDir == "." && !filter.Allows(parsed.Name) {
+			// A root-level skill is filtered here, once its frontmatter name — the
+			// only name it can be matched on — has been parsed.
+			if relDir == "." && !filter.Allows(skillFilterName(relDir, parsed.Name)) {
 				return nil
 			}
 

--- a/catalog/internal/catalog/skillcatalog/repo_resolver.go
+++ b/catalog/internal/catalog/skillcatalog/repo_resolver.go
@@ -432,11 +432,11 @@ func (r *RepoResolver) scan(root string, repo SkillRepository, version, commit s
 			}
 			seen[relDir] = true
 
-			// dirName is the skill's directory name, used as the parse fallback when
-			// the frontmatter omits a name. A repo-root SKILL.md (relDir ".") has no
-			// directory name. A nested skill can be filtered here from its directory
-			// name; a root skill has nothing to match against until its frontmatter
-			// name is parsed, so it is filtered below instead.
+			// dirName is the skill's directory name, used for the name-mismatch warning
+			// inside ParseSkillMD and for skip log messages. A repo-root SKILL.md
+			// (relDir ".") has no directory name. A nested skill can be pre-filtered
+			// here from its directory name; a root skill has nothing to match against
+			// until its frontmatter name is parsed, so it is filtered below instead.
 			// filepath.Base (not path.Base) because the walk's `path` variable shadows
 			// the path package here; relDir is slash-separated and the resolver runs on
 			// Linux, so the two are equivalent.

--- a/catalog/internal/catalog/skillcatalog/skillmd_parser.go
+++ b/catalog/internal/catalog/skillcatalog/skillmd_parser.go
@@ -29,6 +29,8 @@ var (
 	ErrNoFrontmatter = errors.New("SKILL.md has no YAML frontmatter")
 	// ErrInvalidFrontmatter indicates the frontmatter block is not valid YAML.
 	ErrInvalidFrontmatter = errors.New("SKILL.md frontmatter is not valid YAML")
+	// ErrMissingName indicates the required `name` field is absent or non-string.
+	ErrMissingName = errors.New("SKILL.md frontmatter is missing required 'name'")
 	// ErrMissingDescription indicates the required `description` field is absent.
 	ErrMissingDescription = errors.New("SKILL.md frontmatter is missing required 'description'")
 )
@@ -50,11 +52,11 @@ type ParsedSkill struct {
 	Warnings []string
 }
 
-// ParseSkillMD parses SKILL.md content leniently per the Agent Skills spec.
-// expectedName is the skill's directory name, used for the name-match warning.
+// ParseSkillMD parses SKILL.md content per the Agent Skills spec.
+// expectedName is the skill's directory name, used for the name-mismatch warning.
 //
-// It returns a non-nil error only for the skip cases (no/invalid frontmatter,
-// missing description); a successful parse may still carry Warnings.
+// It returns a non-nil error for skip cases (no/invalid frontmatter, missing
+// name or description); a successful parse may still carry Warnings.
 func ParseSkillMD(content []byte, expectedName string) (*ParsedSkill, error) {
 	fmText, body, err := splitFrontmatter(content)
 	if err != nil {
@@ -81,23 +83,21 @@ func ParseSkillMD(content []byte, expectedName string) (*ParsedSkill, error) {
 		return nil, ErrMissingDescription
 	}
 
+	// name is required per the Agent Skills specification; missing or non-string skips.
 	skill.Name = skill.stringField(raw, "name")
+	if skill.Name == "" {
+		return nil, ErrMissingName
+	}
+	// Frontmatter name is authoritative; warn when it diverges from the directory name.
+	if expectedName != "" && skill.Name != expectedName {
+		skill.warnf("frontmatter name %q does not match directory %q", skill.Name, expectedName)
+	}
+
 	skill.License = skill.stringField(raw, "license")
 	skill.Compatibility = skill.stringField(raw, "compatibility")
 	skill.AllowedTools = parseAllowedTools(raw["allowed-tools"])
 	skill.Metadata = skill.mapField(raw, "metadata")
 	skill.Author = skill.resolveAuthor(raw)
-
-	// Name (lenient: warn, never skip).
-	switch {
-	case skill.Name == "" && expectedName == "":
-		skill.warnf("frontmatter is missing 'name' for a root-level SKILL.md")
-	case skill.Name == "":
-		skill.Name = expectedName
-		skill.warnf("frontmatter is missing 'name'; using directory name %q", expectedName)
-	case expectedName != "" && skill.Name != expectedName:
-		skill.warnf("frontmatter name %q does not match directory %q", skill.Name, expectedName)
-	}
 
 	// Length limits from the spec (lenient: warn, never skip).
 	if n := utf8.RuneCountInString(skill.Name); n > maxSkillNameLength {

--- a/catalog/internal/catalog/skillcatalog/skillmd_parser_test.go
+++ b/catalog/internal/catalog/skillcatalog/skillmd_parser_test.go
@@ -59,17 +59,16 @@ func TestParseSkillMD_NameMismatchWarns(t *testing.T) {
 		"expected a name-mismatch warning, got %v", skill.Warnings)
 }
 
-func TestParseSkillMD_MissingNameUsesDirectory(t *testing.T) {
+func TestParseSkillMD_MissingNameSkipped(t *testing.T) {
 	content := `---
 description: A skill with no name.
 ---
 Body.
 `
 	skill, err := ParseSkillMD([]byte(content), "fallback-name")
-	require.NoError(t, err)
-	require.NotNil(t, skill)
-	assert.Equal(t, "fallback-name", skill.Name)
-	assert.True(t, hasWarning(skill.Warnings, "name"), "expected a missing-name warning, got %v", skill.Warnings)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingName)
+	assert.Nil(t, skill)
 }
 
 func TestParseSkillMD_NameTooLongWarns(t *testing.T) {
@@ -240,6 +239,7 @@ func TestParseSkillMD_IndentedDashesInsideBlockScalarNotAFence(t *testing.T) {
 	// The `---` inside the `description` block scalar is indented, so it must not
 	// be treated as the closing fence — only the column-0 `---` closes frontmatter.
 	content := `---
+name: x
 foo: bar
 description: |
    blah
@@ -312,16 +312,14 @@ Body.
 	assert.True(t, hasWarning(skill.Warnings, "metadata"), "expected a metadata type warning, got %v", skill.Warnings)
 }
 
-func TestParseSkillMD_NonStringNameWarnsAndFallsBack(t *testing.T) {
-	// name written as a number is not a string; ignore it, fall back to the
-	// directory name, and still parse rather than failing.
+func TestParseSkillMD_NonStringNameSkipped(t *testing.T) {
+	// name written as a number is not a string; stringField returns "" and the
+	// skill is skipped as if name were absent.
 	content := "---\nname: 123\ndescription: Valid description.\nlicense: apache-2.0\n---\nbody\n"
 	skill, err := ParseSkillMD([]byte(content), "expected-dir")
-	require.NoError(t, err)
-	require.NotNil(t, skill)
-	assert.Equal(t, "expected-dir", skill.Name)
-	assert.Equal(t, "apache-2.0", skill.License, "other fields still parse")
-	assert.True(t, hasWarning(skill.Warnings, "name"), "expected a name type/fallback warning, got %v", skill.Warnings)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingName)
+	assert.Nil(t, skill)
 }
 
 func hasWarning(warnings []string, substr string) bool {

--- a/catalog/internal/plugins/model/plugin.go
+++ b/catalog/internal/plugins/model/plugin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
 	"github.com/kubeflow/hub/catalog/internal/catalog/mcpcatalog"
 	"github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog"
+	"github.com/kubeflow/hub/catalog/internal/catalog/skillcatalog"
 	modelcatalogmodels "github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog/models"
 	modelcatalogservice "github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog/service"
 	"github.com/kubeflow/hub/catalog/internal/db/models"
@@ -32,6 +33,19 @@ type mcpSourceProvider interface {
 // Used to get agent sources for the unified FindSources endpoint.
 type agentSourceProvider interface {
 	AgentSources() *agentcatalog.AgentSourceCollection
+}
+
+// skillPreviewProvider is a local interface satisfied by the skill plugin. It
+// supplies the previewer that lets the shared sources/preview endpoint handle
+// assetType: skills without the model service depending on the skill catalog.
+type skillPreviewProvider interface {
+	SkillPreviewer() openapi.SkillSourcePreviewer
+}
+
+// skillSourceProvider is a local interface satisfied by the skill plugin.
+// Used to get skill sources for the unified FindSources endpoint.
+type skillSourceProvider interface {
+	SkillSources() *skillcatalog.SkillSourceCollection
 }
 
 type Plugin struct {
@@ -127,6 +141,15 @@ func (p *Plugin) Init(_ context.Context, cfg plugin.Config) error {
 				poRefresher.Trigger()
 				return nil
 			})
+			// Models are fully written before OnLeaderReady is called (WaitForInflightWrites
+			// runs first), so the event handler above will not fire for the initial load.
+			// Do a synchronous refresh here so filter options are populated immediately.
+			if err := p.services.PropertyOptionsRepository.Refresh(models.ContextPropertyOptionType); err != nil {
+				return fmt.Errorf("refreshing context property options: %w", err)
+			}
+			if err := p.services.PropertyOptionsRepository.Refresh(models.ArtifactPropertyOptionType); err != nil {
+				return fmt.Errorf("refreshing artifact property options: %w", err)
+			}
 			return nil
 		},
 	})
@@ -171,6 +194,16 @@ func (p *Plugin) RegisterRoutes(router chi.Router) error {
 		}
 	}
 
+	var svcOpts []openapi.ModelCatalogServiceOption
+	if skillPlugin, ok := plugin.Get("skill"); ok {
+		if sp, ok := skillPlugin.(skillPreviewProvider); ok {
+			svcOpts = append(svcOpts, openapi.WithSkillPreviewer(sp.SkillPreviewer()))
+		}
+		if ss, ok := skillPlugin.(skillSourceProvider); ok {
+			svcOpts = append(svcOpts, openapi.WithSkillSources(ss.SkillSources()))
+		}
+	}
+
 	svc := openapi.NewModelCatalogServiceAPIService(
 		modelcatalog.NewDBCatalog(p.services, p.loader.Sources),
 		p.loader.Sources,
@@ -178,6 +211,7 @@ func (p *Plugin) RegisterRoutes(router chi.Router) error {
 		agentSources,
 		p.loader.Labels,
 		p.services.CatalogSourceRepository,
+		svcOpts...,
 	)
 	ctrl := openapi.NewModelCatalogServiceAPIController(svc)
 

--- a/catalog/internal/plugins/skill/marketplace_handler.go
+++ b/catalog/internal/plugins/skill/marketplace_handler.go
@@ -1,0 +1,33 @@
+package skill
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/golang/glog"
+
+	"github.com/kubeflow/hub/catalog/internal/catalog/skillcatalog"
+)
+
+// MarketplaceHandler renders the indexed skills as a Claude Code plugin
+// marketplace document. The optional `audience` query parameter selects the clone
+// URL base for git-subdir sources ("cluster" for in-cluster consumers); see
+// MarketplaceConfig.Options.
+func MarketplaceHandler(provider *skillcatalog.DBSkillCatalog, cfg skillcatalog.MarketplaceConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		skills, err := provider.ListAllSkills(r.Context())
+		if err != nil {
+			glog.Errorf("skill marketplace: listing skills: %v", err)
+			http.Error(w, "failed to list skills", http.StatusInternalServerError)
+			return
+		}
+
+		doc := skillcatalog.BuildMarketplace(skills, cfg.Options(r.URL.Query().Get("audience")))
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(doc); err != nil {
+			// Headers/body may be partially written; log rather than double-write.
+			glog.Errorf("skill marketplace: encoding response: %v", err)
+		}
+	}
+}

--- a/catalog/internal/plugins/skill/plugin.go
+++ b/catalog/internal/plugins/skill/plugin.go
@@ -19,8 +19,9 @@ import (
 
 type Plugin struct {
 	*plugin.PluginBase
-	loader   *skillcatalog.SkillLoader
-	services skillcatalog.Services
+	loader    *skillcatalog.SkillLoader
+	services  skillcatalog.Services
+	previewer *skillcatalog.SkillPreviewer
 }
 
 func (p *Plugin) Name() string                   { return "skill" }
@@ -57,12 +58,21 @@ func (p *Plugin) Init(_ context.Context, cfg plugin.Config) error {
 	// are overridable via SKILL_CATALOG_* environment variables (see env_config.go).
 	// Private-repo credentials are read at clone time from token files in the mounted
 	// git-credentials directory, named by each repository's credentialRef.
+	resolveLimits := skillcatalog.ResolveLimitsFromEnv()
+	syncLimits := skillcatalog.SyncLimitsFromEnv()
+	credentialsDir := skillcatalog.CredentialsDirFromEnv()
+
 	loaderOpts := []skillcatalog.LoaderOption{
-		skillcatalog.WithSyncLimits(skillcatalog.SyncLimitsFromEnv()),
-		skillcatalog.WithResolveLimits(skillcatalog.ResolveLimitsFromEnv()),
-		skillcatalog.WithCredentialsDir(skillcatalog.CredentialsDirFromEnv()),
+		skillcatalog.WithSyncLimits(syncLimits),
+		skillcatalog.WithResolveLimits(resolveLimits),
+		skillcatalog.WithCredentialsDir(credentialsDir),
 	}
 	p.loader = skillcatalog.NewSkillLoader(p.services, base, loaderOpts...)
+
+	// The previewer resolves a pasted source config on demand (for the shared
+	// sources/preview endpoint). It uses the same clone limits and credentials
+	// mount as the loader so a preview behaves like the sync that would follow it.
+	p.previewer = skillcatalog.NewSkillPreviewer(resolveLimits, syncLimits, credentialsDir)
 
 	p.PluginBase = plugin.NewPluginBase(plugin.PluginBaseConfig{
 		Name:        "skill",
@@ -81,6 +91,18 @@ func (p *Plugin) Init(_ context.Context, cfg plugin.Config) error {
 	return nil
 }
 
+// SkillPreviewer returns the skill source previewer for cross-plugin access. The
+// model plugin injects it into the shared sources/preview endpoint so an
+// assetType: skills preview resolves through the skill catalog's own resolver.
+func (p *Plugin) SkillPreviewer() openapi.SkillSourcePreviewer { return p.previewer }
+
+// SkillSources returns the loader's source collection for cross-plugin access.
+// The model plugin injects it into FindSources so skill sources appear alongside
+// model/MCP/agent sources when queried with assetType: skills.
+func (p *Plugin) SkillSources() *skillcatalog.SkillSourceCollection {
+	return p.loader.SourceCollection()
+}
+
 func (p *Plugin) RegisterRoutes(router chi.Router) error {
 	provider := skillcatalog.NewDBSkillCatalog(p.services)
 	ctrl := openapi.NewSkillCatalogServiceAPIController(
@@ -90,6 +112,12 @@ func (p *Plugin) RegisterRoutes(router chi.Router) error {
 	for _, route := range ctrl.OrderedRoutes() {
 		router.Method(route.Method, route.Pattern, route.HandlerFunc)
 	}
+
+	// The marketplace endpoint renders indexed skills as a Claude Code plugin
+	// marketplace. It is a per-consumer-format view (Claude's schema, not the
+	// catalog's typed API), so it is mounted as an ad-hoc route rather than
+	// generated from the OpenAPI spec — mirroring the MCP plugin's logo handler.
+	router.Get(p.BasePath()+"/claude/marketplace.json", MarketplaceHandler(provider, skillcatalog.MarketplaceConfigFromEnv()))
 
 	return nil
 }

--- a/catalog/internal/server/openapi/api_model_catalog_service_service.go
+++ b/catalog/internal/server/openapi/api_model_catalog_service_service.go
@@ -31,8 +31,34 @@ type ModelCatalogServiceAPIService struct {
 	sources          *catalog.SourceCollection
 	mcpSources       *catalog.MCPSourceCollection
 	agentSources     *catalog.AgentSourceCollection
+	skillSources     *catalog.SkillSourceCollection
 	labels           *catalog.LabelCollection
 	sourceRepository models.CatalogSourceRepository
+	skillPreviewer   SkillSourcePreviewer
+}
+
+// SkillSourcePreviewer previews a git-skills-plugin source by resolving its
+// repositories. It is implemented by the skill plugin and injected via
+// WithSkillPreviewer, so the shared sources/preview endpoint can dispatch
+// assetType: skills without this package depending on the skill catalog package.
+type SkillSourcePreviewer interface {
+	PreviewSkillSource(ctx context.Context, configBytes []byte) ([]model.AssetPreviewResult, error)
+}
+
+// ModelCatalogServiceOption configures optional dependencies of the service.
+type ModelCatalogServiceOption func(*ModelCatalogServiceAPIService)
+
+// WithSkillPreviewer enables previewing git-skills-plugin sources through the
+// shared sources/preview endpoint. When unset, an assetType: skills preview
+// returns 501 Not Implemented.
+func WithSkillPreviewer(p SkillSourcePreviewer) ModelCatalogServiceOption {
+	return func(s *ModelCatalogServiceAPIService) { s.skillPreviewer = p }
+}
+
+// WithSkillSources wires the skill source collection into FindSources so that
+// sources with assetType: skills appear alongside model/MCP/agent sources.
+func WithSkillSources(sc *catalog.SkillSourceCollection) ModelCatalogServiceOption {
+	return func(s *ModelCatalogServiceAPIService) { s.skillSources = sc }
 }
 
 // GetAllModelArtifacts retrieves all model artifacts for a given model from the specified source.
@@ -390,6 +416,12 @@ func (m *ModelCatalogServiceAPIService) FindSources(ctx context.Context, name st
 		}
 	}
 
+	if m.skillSources != nil {
+		for id, skillSrc := range m.skillSources.AllSources() {
+			sources[id] = skillSourceToCatalogSource(skillSrc)
+		}
+	}
+
 	if len(sources) > math.MaxInt32 {
 		err := errors.New("too many registered sources")
 		return ErrorResponse(http.StatusInternalServerError, err), err
@@ -492,6 +524,17 @@ func agentSourceToCatalogSource(src basecatalog.PluginSource) model.CatalogSourc
 	}
 }
 
+func skillSourceToCatalogSource(src basecatalog.PluginSource) model.CatalogSource {
+	assetType := model.CATALOGASSETTYPE_SKILLS
+	return model.CatalogSource{
+		Id:        src.ID,
+		Name:      src.Name,
+		Enabled:   src.Enabled,
+		Labels:    src.Labels,
+		AssetType: &assetType,
+	}
+}
+
 func (m *ModelCatalogServiceAPIService) PreviewCatalogSource(ctx context.Context, configParam *os.File, pageSizeParam string, nextPageTokenParam string, filterStatusParam string, catalogDataParam *os.File) (ImplResponse, error) {
 	if _, err := parsePageSize(pageSizeParam); err != nil {
 		return ErrorResponse(http.StatusBadRequest, err), err
@@ -540,7 +583,46 @@ func (m *ModelCatalogServiceAPIService) PreviewCatalogSource(ctx context.Context
 		return m.previewMCPSource(ctx, configBytes, catalogDataBytes, pageSizeParam, nextPageTokenParam, filterStatus)
 	}
 
+	if assetTypeProbe.AssetType == string(model.CATALOGASSETTYPE_SKILLS) {
+		return m.previewSkillSource(ctx, configBytes, pageSizeParam, nextPageTokenParam, filterStatus)
+	}
+
 	return m.previewModelSource(ctx, configBytes, catalogDataBytes, pageSizeParam, nextPageTokenParam, filterStatus)
+}
+
+// previewSkillSource previews a git-skills-plugin source. Unlike the model and MCP
+// previews, which read a catalog file, a skill preview resolves (shallow-clones)
+// the configured repositories to enumerate their skills; catalogData does not apply
+// and is ignored. It reuses the shared filter/paginate helpers and reports results
+// as generic assets (assetType: skills, AssetSourcePreviewResponse), mirroring MCP.
+func (m *ModelCatalogServiceAPIService) previewSkillSource(ctx context.Context, configBytes []byte, pageSizeParam, nextPageTokenParam, filterStatus string) (ImplResponse, error) {
+	if m.skillPreviewer == nil {
+		err := errors.New("skill source preview is not available")
+		return ErrorResponse(http.StatusNotImplemented, err), err
+	}
+
+	previewResults, err := m.skillPreviewer.PreviewSkillSource(ctx, configBytes)
+	if err != nil {
+		return ErrorResponse(http.StatusUnprocessableEntity, fmt.Errorf("failed to load skills: %w", err)), err
+	}
+
+	page, err := filterAndPaginate(previewResults, func(r model.AssetPreviewResult) bool { return r.Included }, filterStatus, pageSizeParam, nextPageTokenParam)
+	if err != nil {
+		return ErrorResponse(http.StatusBadRequest, err), err
+	}
+
+	return Response(http.StatusOK, model.AssetSourcePreviewResponse{
+		AssetType:     model.CATALOGASSETTYPE_SKILLS,
+		PageSize:      page.pageSize,
+		Size:          int32(len(page.items)),
+		NextPageToken: page.nextPageToken,
+		Items:         page.items,
+		Summary: model.AssetSourcePreviewResponseAllOfSummary{
+			TotalAssets:    page.total,
+			IncludedAssets: page.includedCount,
+			ExcludedAssets: page.excludedCount,
+		},
+	}), nil
 }
 
 type previewPage[T model.Sortable] struct {
@@ -763,8 +845,8 @@ func genLabelCmpFunc(orderByKey string, sortOrder model.SortOrder) func(sortable
 var _ ModelCatalogServiceAPIServicer = &ModelCatalogServiceAPIService{}
 
 // NewModelCatalogServiceAPIService creates a default api service
-func NewModelCatalogServiceAPIService(provider catalog.APIProvider, sources *catalog.SourceCollection, mcpSources *catalog.MCPSourceCollection, agentSources *catalog.AgentSourceCollection, labels *catalog.LabelCollection, sourceRepository models.CatalogSourceRepository) ModelCatalogServiceAPIServicer {
-	return &ModelCatalogServiceAPIService{
+func NewModelCatalogServiceAPIService(provider catalog.APIProvider, sources *catalog.SourceCollection, mcpSources *catalog.MCPSourceCollection, agentSources *catalog.AgentSourceCollection, labels *catalog.LabelCollection, sourceRepository models.CatalogSourceRepository, opts ...ModelCatalogServiceOption) ModelCatalogServiceAPIServicer {
+	svc := &ModelCatalogServiceAPIService{
 		provider:         provider,
 		sources:          sources,
 		mcpSources:       mcpSources,
@@ -772,6 +854,10 @@ func NewModelCatalogServiceAPIService(provider catalog.APIProvider, sources *cat
 		labels:           labels,
 		sourceRepository: sourceRepository,
 	}
+	for _, opt := range opts {
+		opt(svc)
+	}
+	return svc
 }
 
 func notFound(msg string) ImplResponse {

--- a/catalog/internal/server/openapi/skill_preview_dispatch_test.go
+++ b/catalog/internal/server/openapi/skill_preview_dispatch_test.go
@@ -1,0 +1,99 @@
+package openapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	model "github.com/kubeflow/hub/catalog/pkg/openapi"
+)
+
+// fakeSkillPreviewer is a stand-in for the skill plugin's previewer, returning
+// canned results so the dispatch and response shaping can be tested without git.
+type fakeSkillPreviewer struct {
+	results []model.AssetPreviewResult
+	err     error
+}
+
+func (f fakeSkillPreviewer) PreviewSkillSource(_ context.Context, _ []byte) ([]model.AssetPreviewResult, error) {
+	return f.results, f.err
+}
+
+func skillPreviewService(p SkillSourcePreviewer) ModelCatalogServiceAPIServicer {
+	// The preview path uses only the skill previewer; the other dependencies are
+	// unused here and left nil.
+	return NewModelCatalogServiceAPIService(nil, nil, nil, nil, nil, nil, WithSkillPreviewer(p))
+}
+
+func TestPreviewCatalogSource_SkillsDispatch(t *testing.T) {
+	fake := fakeSkillPreviewer{results: []model.AssetPreviewResult{
+		{Name: "deploy", Included: true},
+		{Name: "rollout", Included: true},
+		{Name: "scratch-draft", Included: false},
+	}}
+	service := skillPreviewService(fake)
+
+	configFile := writeTempYAML(t, "config", `
+assetType: skills
+type: git-skills-plugin
+properties:
+  repositories:
+    - url: https://example.com/a.git
+      refs: ["v1.0"]
+`)
+
+	resp, err := service.PreviewCatalogSource(context.Background(), configFile, "100", "", "", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	assetResp, ok := resp.Body.(model.AssetSourcePreviewResponse)
+	require.True(t, ok, "expected AssetSourcePreviewResponse, got %T", resp.Body)
+	assert.Equal(t, model.CATALOGASSETTYPE_SKILLS, assetResp.AssetType)
+	assert.Len(t, assetResp.Items, 3)
+	assert.Equal(t, int32(3), assetResp.Summary.TotalAssets)
+	assert.Equal(t, int32(2), assetResp.Summary.IncludedAssets)
+	assert.Equal(t, int32(1), assetResp.Summary.ExcludedAssets)
+}
+
+func TestPreviewCatalogSource_SkillsFilterStatusExcluded(t *testing.T) {
+	fake := fakeSkillPreviewer{results: []model.AssetPreviewResult{
+		{Name: "deploy", Included: true},
+		{Name: "scratch-draft", Included: false},
+	}}
+	service := skillPreviewService(fake)
+
+	configFile := writeTempYAML(t, "config", "assetType: skills\ntype: git-skills-plugin\nproperties:\n  repositories:\n    - url: https://example.com/a.git\n      refs: [\"v1.0\"]\n")
+
+	resp, err := service.PreviewCatalogSource(context.Background(), configFile, "100", "", "excluded", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	assetResp := resp.Body.(model.AssetSourcePreviewResponse)
+	require.Len(t, assetResp.Items, 1)
+	assert.Equal(t, "scratch-draft", assetResp.Items[0].Name)
+}
+
+func TestPreviewCatalogSource_SkillsPreviewerUnavailable(t *testing.T) {
+	// No WithSkillPreviewer option: an assetType: skills preview should report 501.
+	service := NewModelCatalogServiceAPIService(nil, nil, nil, nil, nil, nil)
+
+	configFile := writeTempYAML(t, "config", "assetType: skills\ntype: git-skills-plugin\n")
+
+	resp, err := service.PreviewCatalogSource(context.Background(), configFile, "100", "", "", nil)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusNotImplemented, resp.Code)
+}
+
+func TestPreviewCatalogSource_SkillsPreviewError(t *testing.T) {
+	service := skillPreviewService(fakeSkillPreviewer{err: errors.New("clone failed")})
+
+	configFile := writeTempYAML(t, "config", "assetType: skills\ntype: git-skills-plugin\n")
+
+	resp, err := service.PreviewCatalogSource(context.Background(), configFile, "100", "", "", nil)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
+}

--- a/catalog/pkg/openapi/api_model_catalog_service.go
+++ b/catalog/pkg/openapi/api_model_catalog_service.go
@@ -1563,6 +1563,14 @@ The response type varies based on the `assetType` field in the uploaded config:
     and model-specific summary fields (`totalModels`, `includedModels`, `excludedModels`).
   - `mcp_servers`: Returns an `AssetSourcePreviewResponse` with `AssetPreviewResult` items
     and generic summary fields (`totalAssets`, `includedAssets`, `excludedAssets`).
+  - `skills`: Returns an `AssetSourcePreviewResponse` with `AssetPreviewResult` items.
+    Unlike model and MCP previews, a `git-skills-plugin` source is previewed by
+    shallow-cloning a repository to enumerate its skills, so `catalogData` does
+    not apply. Preview is scoped to a single repository at a time (each repo is
+    a network clone): the config must provide exactly one entry inline under
+    `properties.repositories`; more than one is rejected, and the file-based
+    `yamlCatalogPath` form is not supported for preview (skills are read from
+    git, not a catalog file).
 
 **Two modes of operation:**
 

--- a/catalog/pkg/openapi/model_preview_catalog_source_response.go
+++ b/catalog/pkg/openapi/model_preview_catalog_source_response.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 )
 
-// PreviewCatalogSourceResponse - Polymorphic preview response. The `assetType` discriminator determines whether the payload is a model preview or an MCP server preview.
+// PreviewCatalogSourceResponse - Polymorphic preview response. The `assetType` discriminator determines whether the payload is a model preview (`CatalogSourcePreviewResponse`) or a generic asset preview (`AssetSourcePreviewResponse`), the latter used for both MCP server and skill sources.
 type PreviewCatalogSourceResponse struct {
 	AssetSourcePreviewResponse   *AssetSourcePreviewResponse
 	CatalogSourcePreviewResponse *CatalogSourcePreviewResponse
@@ -66,6 +66,18 @@ func (dst *PreviewCatalogSourceResponse) UnmarshalJSON(data []byte) error {
 		} else {
 			dst.CatalogSourcePreviewResponse = nil
 			return fmt.Errorf("failed to unmarshal PreviewCatalogSourceResponse as CatalogSourcePreviewResponse: %s", err.Error())
+		}
+	}
+
+	// check if the discriminator value is 'skills'
+	if jsonDict["assetType"] == "skills" {
+		// try to unmarshal JSON data into AssetSourcePreviewResponse
+		err = json.Unmarshal(data, &dst.AssetSourcePreviewResponse)
+		if err == nil {
+			return nil // data stored in dst.AssetSourcePreviewResponse, return on the first match
+		} else {
+			dst.AssetSourcePreviewResponse = nil
+			return fmt.Errorf("failed to unmarshal PreviewCatalogSourceResponse as AssetSourcePreviewResponse: %s", err.Error())
 		}
 	}
 

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -10,6 +10,10 @@
 # - a model-catalog server built from source.
 # - a model-registry-ui built from source (standalone mode)
 version: '3.8'
+networks:
+  hub:
+    driver: bridge
+
 services:
   model-registry-ui:
     build:
@@ -29,6 +33,8 @@ services:
     container_name: model-registry-ui
     ports:
       - "9000:9000"
+    networks:
+      - hub
     depends_on:
       - model-registry
       - model-catalog
@@ -41,12 +47,15 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ["catalog", "--listen", "0.0.0.0:8081", "--catalogs-path", "/testdata/test-catalog-sources.yaml"]
+    image: hub/server:local
+    command: ["catalog", "--listen", "0.0.0.0:8081", "--catalogs-path", "/testdata/test-catalog-sources.yaml", "--catalogs-path", "/testdata/test-skill-sources.yaml"]
     container_name: model-catalog
     ports:
       - "8081:8081"
+    networks:
+      - hub
     volumes:
-      - ./catalog/internal/catalog/modelcatalog/testdata:/testdata
+      - ./catalog/internal/catalog/modelcatalog/testdata:/testdata:z
     depends_on:
       - postgres
     profiles:
@@ -61,8 +70,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: hub/server:local
     entrypoint: ["/bin/sh"]
-    command: 
+    command:
       - -c
       - |
         if [ "$$DB_TYPE" = "postgres" ]; then
@@ -73,6 +83,8 @@ services:
     container_name: model-registry
     ports:
       - "8080:8080"
+    networks:
+      - hub
     depends_on:
       - ${DB_TYPE:-mysql}
     environment:
@@ -89,6 +101,8 @@ services:
       - MYSQL_DATABASE=model_registry
     ports:
       - "3306:3306"
+    networks:
+      - hub
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:
@@ -109,9 +123,11 @@ services:
       - POSTGRES_PASSWORD=demo
     ports:
       - "5432:5432"
+    networks:
+      - hub
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./scripts/pginit.sql:/docker-entrypoint-initdb.d/pginit.sql:ro
+      - ./scripts/pginit.sql:/docker-entrypoint-initdb.d/pginit.sql:ro,z
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d model_registry"]
       interval: 10s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,10 @@
 # - a model-catalog server
 # - a model-registry-ui (standalone mode)
 version: '3.8'
+networks:
+  hub:
+    driver: bridge
+
 services:
   model-registry-ui:
     image: ghcr.io/kubeflow/hub/ui-standalone:latest
@@ -25,6 +29,8 @@ services:
     container_name: model-registry-ui
     ports:
       - "9000:9000"
+    networks:
+      - hub
     depends_on:
       - model-registry
       - model-catalog
@@ -36,12 +42,14 @@ services:
   model-catalog:
     image: ghcr.io/kubeflow/hub/server:latest
     pull_policy: always
-    command: ["catalog", "--listen", "0.0.0.0:8081", "--catalogs-path", "/testdata/test-catalog-sources.yaml"]
+    command: ["catalog", "--listen", "0.0.0.0:8081", "--catalogs-path", "/testdata/test-catalog-sources.yaml", "--catalogs-path", "/testdata/test-skill-sources.yaml"]
     container_name: model-catalog
     ports:
       - "8081:8081"
+    networks:
+      - hub
     volumes:
-      - ./catalog/internal/catalog/testdata:/testdata
+      - ./catalog/internal/catalog/modelcatalog/testdata:/testdata:z
     depends_on:
       - postgres
     profiles:
@@ -67,6 +75,8 @@ services:
     container_name: model-registry
     ports:
       - "8080:8080"
+    networks:
+      - hub
     depends_on:
       - ${DB_TYPE:-mysql}
     environment:
@@ -83,6 +93,8 @@ services:
       - MYSQL_DATABASE=model_registry
     ports:
       - "3306:3306"
+    networks:
+      - hub
     volumes:
       - mysql_data:/var/lib/mysql
     healthcheck:
@@ -103,9 +115,11 @@ services:
       - POSTGRES_PASSWORD=demo
     ports:
       - "5432:5432"
+    networks:
+      - hub
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./scripts/pginit.sql:/docker-entrypoint-initdb.d/pginit.sql:ro
+      - ./scripts/pginit.sql:/docker-entrypoint-initdb.d/pginit.sql:ro,z
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d model_registry"]
       interval: 10s

--- a/manifests/kustomize/options/catalog/overlays/e2e/kustomization.yaml
+++ b/manifests/kustomize/options/catalog/overlays/e2e/kustomization.yaml
@@ -19,6 +19,7 @@ configMapGenerator:
   - test-catalog.yaml
   - disabled-catalog.yaml
   - test-mcp-servers.yaml
+  - sample-agent-catalog.yaml
   name: model-catalog-testdata
   options:
     disableNameSuffixHash: true

--- a/proposals/KEP-0005-skills-catalog/README.md
+++ b/proposals/KEP-0005-skills-catalog/README.md
@@ -14,7 +14,7 @@ Agent skills have an open specification, growing public repositories, and instal
 
 - `skill` plugin; API base `/api/skill_catalog/v1alpha1`.
 - A `git-skills-plugin` source type - a dedicated type for git-hosted skills, alongside the existing `yaml` and `hf` types - listing repositories whose SKILL.md files are parsed per the specification at sync time.
-- Versioned entries: a repository can list multiple refs (tags, releases, branches, or commits). Each ref becomes its own set of catalog entries, with the version shown in the UI. A branch is surfaced as `latest` (not the raw branch name), and every entry pins to the commit it resolved to, so installs are reproducible.
+- Versioned entries: a repository can list multiple refs (tags, releases, or commits). Each ref becomes its own set of catalog entries, with the version shown in the UI. Branches are not supported as refs — only specific, pinnable refs (tags, releases, or commit SHAs) are accepted, so every entry resolves to a fixed commit and installs are reproducible. Every entry pins to the commit it resolved to.
 - Custom metadata (trust tier, provider, category, labels) assigned in the source file; per-skill overrides; include/exclude filtering.
 - Catalog UI: gallery, detail with rendered SKILL.md, filters, install instructions; an admin settings page that reuses the existing model/MCP catalog-settings mechanism to manage sources (add/edit/delete user-managed sources with include/exclude preview before save; shipped defaults read-only) alongside sync status and manual sync.
 - `marketplace.json` endpoint, with optional URL rewriting for deployments fronting repos with an internal git mirror.
@@ -47,8 +47,9 @@ Registered like any other catalog source, as `type: git-skills-plugin`. A source
   trustTier: communityContributed
   repositories:
     - url: https://github.com/example/skills.git
-      refs: [main, v1.0]          # optional; tags/releases/branches/commits -
-                                  #   each ref yields its own catalog entries.
+      refs: [v1.0, abc1234]       # optional; tags, releases, or commit SHAs only -
+                                  #   branches are not accepted (not reproducible).
+                                  #   Each ref yields its own catalog entries.
                                   #   Also: scanPaths, authSecretName,
                                   #   canonicalUrl (when url is a mirror)
       provider: Example Org
@@ -59,7 +60,7 @@ Registered like any other catalog source, as `type: git-skills-plugin`. A source
       skillOverrides: [{name: deploy, category: SRE}]
 ```
 
-Each time the catalog syncs, the plugin reads each listed repository at each listed ref (making a temporary, lightweight copy used only for parsing, then throwing it away), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref (a branch is surfaced as `latest`, not the branch name), and the exact commit it resolved to is recorded as `resolvedCommit`. Skills, refs, repositories, or sources that have been removed are cleaned up. Pulling from private git repositories with securely configured credentials will be supported.
+Each time the catalog syncs, the plugin reads each listed repository at each listed ref (making a temporary, lightweight copy used only for parsing, then throwing it away), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref (a tag, release, or commit SHA), and the exact commit it resolved to is recorded as `resolvedCommit`. Branches are not accepted as refs; the source schema rejects them so that every entry is reproducible. Skills, refs, repositories, or sources that have been removed are cleaned up. Pulling from private git repositories with securely configured credentials will be supported.
 
 Source management reuses the same mechanism as the model and MCP catalogs: read-only defaults (shipped in a ConfigMap) merged with a user-managed ConfigMap that the settings UI writes via the BFF, with per-source auth stored as Secrets. Adding a skills git source through the UI works like adding a HuggingFace source for models. Editing the ConfigMap directly (kubectl/GitOps) works too; the file-watcher picks up either path.
 
@@ -92,7 +93,7 @@ The `Skill` resource carries the SKILL.md fields (including the body as `readme`
 /plugin install deploy@example-skill-catalog
 ```
 
-Every listed ref of a skill is exposed as its own plugin entry carrying its version (a branch appears as `latest`), so all versions are discoverable, and each entry's git source is pinned to the commit it resolved to (`resolvedCommit`) so `/plugin install` is reproducible even for `latest`. Source URLs default to the repositories' own URLs. An optional `skill_content_mirror: {internalBaseUrl, externalBaseUrl}` setting rewrites them for deployments that put an internal mirror in front of the repositories (using the external base by default, and the internal base for `?audience=cluster`). A note for user docs: `npx skills add` reads git repositories directly, never this endpoint.
+Every listed ref of a skill is exposed as its own plugin entry carrying its version (the tag, release, or commit SHA it was indexed at), so all versions are discoverable. Each entry's git source is pinned to the commit it resolved to (`resolvedCommit`) so `/plugin install` is reproducible. Branches are not accepted as refs. Source URLs default to the repositories' own URLs. An optional `skill_content_mirror: {internalBaseUrl, externalBaseUrl}` setting rewrites them for deployments that put an internal mirror in front of the repositories (using the external base by default, and the internal base for `?audience=cluster`). A note for user docs: `npx skills add` reads git repositories directly, never this endpoint.
 
 ### 7. UI
 

--- a/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
+++ b/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
@@ -88,7 +88,7 @@ sequenceDiagram
 
 ## 5. Identity - Canonical vs Fetch URL
 
-Internal IDs are not stable, since the index is just a cache. The canonical identity is the only permanent reference, and it stays the same even when a deployment reads through a different URL. `version` (the ref) tells entries apart - a branch surfaces as `latest`, and every entry records the commit it resolved to (`resolvedCommit`), which the marketplace pins to so installs are reproducible even for `latest`.
+Internal IDs are not stable, since the index is just a cache. The canonical identity is the only permanent reference, and it stays the same even when a deployment reads through a different URL. `version` (the ref — a tag, release, or commit SHA) tells entries apart. Branches are not accepted as refs; the source schema rejects them so that every entry resolves to a fixed, reproducible commit. Every entry records the commit it resolved to (`resolvedCommit`), which the marketplace carries as the `sha` pin.
 
 ```mermaid
 flowchart TB


### PR DESCRIPTION
… hardening

## Description
- SKC-110: wire assetType: skills into the shared sources/preview endpoint; SkillPreviewer clones one repository on demand, applies include/exclude filters, and returns AssetSourcePreviewResponse
- SKC-111: GET .../claude/marketplace.json renders indexed skills as a Claude Code plugin marketplace; every ref pinned to resolvedCommit; optional URL rewrite for internal/external mirrors via SKILL_CONTENT_MIRROR env vars
- SKC-114: extract loadRepoCredentials into shared helper (loader + previewer use identical credential path); token reaches git only via GIT_ASKPASS

Update KEP-0005 to document that branches are not accepted as refs; only tags, releases, and commit SHAs are allowed (reproducible installs).

Assisted-by: Claude Sonnet 4.6

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
