### PR TITLE
docs(devenv): add yq and kustomize to devenv requirements

### DIFF
--- a/devenv/README.md
+++ b/devenv/README.md
@@ -6,6 +6,8 @@
 - Helm >= 3.16.1
 - Python >= 3.8
 - Node >= 20
+- yq
+- kustomize
 
 ## Tilt
 


### PR DESCRIPTION
## Summary
- `make tilt-up` fails out of the box on a fresh machine because the catalog service's config sync step shells out to `yq`, and the Tiltfile renders manifests via `kustomize` — neither is listed in devenv's Requirements.
- Adds both to the Requirements list in `devenv/README.md`.

## Test plan
- [x] Reproduced the failure on a clean machine (missing `yq` broke the `catalog-config-sync` Tilt resource with `yq: command not found`)
- [x] Installed `yq` + `kustomize`, confirmed `make tilt-up` deploys cleanly
- [x] Docs-only change, no code/build impact

Assisted-by: Claude Sonnet 5