### PR TITLE
chore: run make gen and remove deprecated handler code

### DIFF
--- a/catalog/internal/server/openapi/v1/api_model.go
+++ b/catalog/internal/server/openapi/v1/api_model.go
@@ -38,11 +38,11 @@ type ModelCatalogServiceAPIRouter interface {
 // and updated with the logic required for the API.
 type ModelCatalogServiceAPIServicer interface {
 	FindLabels(context.Context, model.CatalogAssetType, string, string, model.SortOrder, string) (ImplResponse, error)
-	FindModels(context.Context, bool, int32, string, string, string, string, []string, string, []string, string, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)
+	FindModels(context.Context, int32, string, string, string, string, []string, string, []string, string, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)
 	FindModelsFilterOptions(context.Context) (ImplResponse, error)
 	FindSources(context.Context, string, model.CatalogAssetType, string, model.OrderByField, model.SortOrder, string) (ImplResponse, error)
 	PreviewCatalogSource(context.Context, *os.File, string, string, string, *os.File) (ImplResponse, error)
 	GetModel(context.Context, string, string) (ImplResponse, error)
-	GetAllModelArtifacts(context.Context, string, string, []model.ArtifactTypeQueryParam, []model.ArtifactTypeQueryParam, string, string, string, model.SortOrder, string) (ImplResponse, error)
+	GetAllModelArtifacts(context.Context, string, string, []model.ArtifactTypeQueryParam, string, string, string, model.SortOrder, string) (ImplResponse, error)
 	GetAllModelPerformanceArtifacts(context.Context, string, string, int32, bool, string, string, string, string, string, string, string, model.SortOrder, string) (ImplResponse, error)
 }

--- a/catalog/internal/server/openapi/v1/api_model_catalog_service.go
+++ b/catalog/internal/server/openapi/v1/api_model_catalog_service.go
@@ -217,22 +217,6 @@ func (c *ModelCatalogServiceAPIController) FindModels(w http.ResponseWriter, r *
 		c.errorHandler(w, r, &ParsingError{Err: err}, nil)
 		return
 	}
-	var recommendationsParam bool
-	if query.Has("recommendations") {
-		param, err := parseBoolParameter(
-			query.Get("recommendations"),
-			WithParse[bool](parseBool),
-		)
-		if err != nil {
-			c.errorHandler(w, r, &ParsingError{Param: "recommendations", Err: err}, nil)
-			return
-		}
-
-		recommendationsParam = param
-	} else {
-		var param bool = false
-		recommendationsParam = param
-	}
 	var targetRPSParam int32
 	if query.Has("targetRPS") {
 		param, err := parseNumericParameter[int32](
@@ -333,7 +317,7 @@ func (c *ModelCatalogServiceAPIController) FindModels(w http.ResponseWriter, r *
 		nextPageTokenParam = param
 	} else {
 	}
-	result, err := c.service.FindModels(r.Context(), recommendationsParam, targetRPSParam, latencyPropertyParam, rpsPropertyParam, hardwareCountPropertyParam, hardwareTypePropertyParam, sourceParam, qParam, sourceLabelParam, filterQueryParam, pageSizeParam, orderByParam, sortOrderParam, nextPageTokenParam)
+	result, err := c.service.FindModels(r.Context(), targetRPSParam, latencyPropertyParam, rpsPropertyParam, hardwareCountPropertyParam, hardwareTypePropertyParam, sourceParam, qParam, sourceLabelParam, filterQueryParam, pageSizeParam, orderByParam, sortOrderParam, nextPageTokenParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)
@@ -557,19 +541,6 @@ func (c *ModelCatalogServiceAPIController) GetAllModelArtifacts(w http.ResponseW
 			artifactTypeParam = append(artifactTypeParam, *paramEnum)
 		}
 	}
-	var artifactType2Param []model.ArtifactTypeQueryParam
-	if query.Has("artifact_type") {
-		paramSplits := strings.Split(query.Get("artifact_type"), ",")
-		artifactType2Param = make([]model.ArtifactTypeQueryParam, 0, len(paramSplits))
-		for _, param := range paramSplits {
-			paramEnum, err := model.NewArtifactTypeQueryParamFromValue(param)
-			if err != nil {
-				c.errorHandler(w, r, &ParsingError{Param: "artifact_type", Err: err}, nil)
-				return
-			}
-			artifactType2Param = append(artifactType2Param, *paramEnum)
-		}
-	}
 	var filterQueryParam string
 	if query.Has("filterQuery") {
 		param := query.Get("filterQuery")
@@ -605,7 +576,7 @@ func (c *ModelCatalogServiceAPIController) GetAllModelArtifacts(w http.ResponseW
 		nextPageTokenParam = param
 	} else {
 	}
-	result, err := c.service.GetAllModelArtifacts(r.Context(), sourceIdParam, modelNameParam, artifactTypeParam, artifactType2Param, filterQueryParam, pageSizeParam, orderByParam, sortOrderParam, nextPageTokenParam)
+	result, err := c.service.GetAllModelArtifacts(r.Context(), sourceIdParam, modelNameParam, artifactTypeParam, filterQueryParam, pageSizeParam, orderByParam, sortOrderParam, nextPageTokenParam)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/catalog/internal/server/openapi/v1/api_model_catalog_service_service.go
+++ b/catalog/internal/server/openapi/v1/api_model_catalog_service_service.go
@@ -62,14 +62,7 @@ func WithSkillSources(sc *catalog.SkillSourceCollection) ModelCatalogServiceOpti
 }
 
 // GetAllModelArtifacts retrieves all model artifacts for a given model from the specified source.
-func (m *ModelCatalogServiceAPIService) GetAllModelArtifacts(ctx context.Context, sourceID string, modelName string, artifactType []model.ArtifactTypeQueryParam, artifactType2 []model.ArtifactTypeQueryParam, filterQuery string, pageSize string, orderBy string, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
-	// Handle multiple artifact_type parameters (snake case - deprecated, will be removed in future)
-	for _, v := range artifactType2 {
-		if v != "" {
-			artifactType = append(artifactType, v)
-		}
-	}
-
+func (m *ModelCatalogServiceAPIService) GetAllModelArtifacts(ctx context.Context, sourceID string, modelName string, artifactType []model.ArtifactTypeQueryParam, filterQuery string, pageSize string, orderBy string, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	if newName, err := url.PathUnescape(modelName); err == nil {
 		modelName = newName
 	}
@@ -245,13 +238,13 @@ func (m *ModelCatalogServiceAPIService) FindLabels(ctx context.Context, assetTyp
 	return Response(http.StatusOK, res), nil
 }
 
-func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, recommended bool, targetRPS int32, latencyProperty string, rpsProperty string, hardwareCountProperty string, hardwareTypeProperty string, sourceIDs []string, q string, sourceLabels []string, filterQuery string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
+func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, targetRPS int32, latencyProperty string, rpsProperty string, hardwareCountProperty string, hardwareTypeProperty string, sourceIDs []string, q string, sourceLabels []string, filterQuery string, pageSize string, orderBy model.OrderByField, sortOrder model.SortOrder, nextPageToken string) (ImplResponse, error) {
 	// Validate pageSize and nextPageToken up-front. The recommended path uses numeric
 	// offset tokens; the non-recommended path uses base64-encoded DB cursors
 	// validated inside parsePaginationParams.
 	var pageSizeInt int32
 	var err error
-	if recommended || orderBy == model.ORDERBYFIELD_RECOMMENDED {
+	if orderBy == model.ORDERBYFIELD_RECOMMENDED {
 		pageSizeInt, err = parsePageSize(pageSize)
 		if err != nil {
 			return ErrorResponse(http.StatusBadRequest, err), err
@@ -293,8 +286,8 @@ func (m *ModelCatalogServiceAPIService) FindModels(ctx context.Context, recommen
 		}
 	}
 
-	// Handle recommended latency sorting (triggered by recommendations=true or orderBy=RECOMMENDED)
-	if recommended || orderBy == model.ORDERBYFIELD_RECOMMENDED {
+	// Handle recommended latency sorting (triggered by orderBy=RECOMMENDED)
+	if orderBy == model.ORDERBYFIELD_RECOMMENDED {
 		// Build Pareto filtering parameters with defaults
 		var targetRPSPtr *int32
 		if targetRPS != 0 {

--- a/catalog/internal/server/openapi/v1/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/v1/api_model_catalog_service_service_test.go
@@ -310,12 +310,11 @@ func TestFindModels(t *testing.T) {
 
 			resp, err := service.FindModels(
 				context.Background(),
-				false, // recommended
-				0,     // targetRPS
-				"",    // latencyProperty
-				"",    // rpsProperty
-				"",    // hardwareCountProperty
-				"",    // hardwareTypeProperty
+				0,  // targetRPS
+				"", // latencyProperty
+				"", // rpsProperty
+				"", // hardwareCountProperty
+				"", // hardwareTypeProperty
 				[]string{tc.sourceID},
 				tc.q,
 				[]string{""},
@@ -1623,7 +1622,6 @@ func TestGetAllModelArtifacts(t *testing.T) {
 				tc.sourceID,
 				tc.modelName,
 				[]model.ArtifactTypeQueryParam{},
-				[]model.ArtifactTypeQueryParam{},
 				"",
 				"10",
 				string(model.ORDERBYFIELD_CREATE_TIME),
@@ -1909,21 +1907,20 @@ func TestFindModelsRecommended(t *testing.T) {
 
 	service := NewModelCatalogServiceAPIService(provider, sources, nil, nil, sourceLabels, nil)
 
-	// Test recommended=true with default parameters
+	// Test orderBy=RECOMMENDED with default parameters
 	resp, err := service.FindModels(
 		context.Background(),
-		true, // recommended
-		0,    // targetRPS
-		"",   // latencyProperty
-		"",   // rpsProperty
-		"",   // hardwareCountProperty
-		"",   // hardwareTypeProperty
+		0,  // targetRPS
+		"", // latencyProperty
+		"", // rpsProperty
+		"", // hardwareCountProperty
+		"", // hardwareTypeProperty
 		[]string{"source1"},
 		"",
 		[]string{""},
 		"",
 		"10",
-		model.ORDERBYFIELD_NAME,
+		model.ORDERBYFIELD_RECOMMENDED,
 		model.SORTORDER_ASC,
 		"",
 	)
@@ -1961,7 +1958,6 @@ func TestFindModelsRecommendedWithCustomParams(t *testing.T) {
 	// Test with custom latency property and targetRPS
 	resp, err := service.FindModels(
 		context.Background(),
-		true,             // recommended
 		100,              // targetRPS
 		"custom_latency", // latencyProperty
 		"",               // rpsProperty
@@ -1972,56 +1968,7 @@ func TestFindModelsRecommendedWithCustomParams(t *testing.T) {
 		[]string{""},
 		"",
 		"10",
-		model.ORDERBYFIELD_NAME,
-		model.SORTORDER_ASC,
-		"",
-	)
-
-	assert.Equal(t, http.StatusOK, resp.Code)
-	require.NoError(t, err)
-
-	require.NotNil(t, resp.Body)
-	response, ok := resp.Body.(model.CatalogModelList)
-	require.True(t, ok)
-
-	// Verify models are sorted by recommended latency (mock returns models sorted by name)
-	require.True(t, len(response.Items) > 0)
-}
-
-func TestFindModelsRecommendedIgnoresOrderBy(t *testing.T) {
-	sources := catalog.NewSourceCollection()
-	sources.Merge("",
-		map[string]catalog.ModelSource{
-			"source1": {CatalogSource: model.CatalogSource{Id: "source1", Name: "Test Source 1"}},
-		},
-	)
-
-	sourceLabels := catalog.NewLabelCollection()
-
-	provider := &mockModelProvider{
-		models: map[string]*model.CatalogModel{
-			"modelA": {Name: "Model A"},
-			"modelB": {Name: "Model B"},
-		},
-	}
-
-	service := NewModelCatalogServiceAPIService(provider, sources, nil, nil, sourceLabels, nil)
-
-	// Test that orderBy is ignored when recommended=true
-	resp, err := service.FindModels(
-		context.Background(),
-		true, // recommended
-		0,    // targetRPS
-		"",   // latencyProperty
-		"",   // rpsProperty
-		"",   // hardwareCountProperty
-		"",   // hardwareTypeProperty
-		[]string{"source1"},
-		"",
-		[]string{""},
-		"",
-		"10",
-		model.ORDERBYFIELD_NAME, // This should be ignored
+		model.ORDERBYFIELD_RECOMMENDED,
 		model.SORTORDER_ASC,
 		"",
 	)
@@ -2065,8 +2012,7 @@ func TestFindModelsRecommendedWithNumericNextPageToken(t *testing.T) {
 
 	resp, err := service.FindModels(
 		context.Background(),
-		true, // recommended
-		1,    // targetRPS
+		1, // targetRPS
 		"ttft_p90",
 		"",
 		"",
@@ -2076,7 +2022,7 @@ func TestFindModelsRecommendedWithNumericNextPageToken(t *testing.T) {
 		[]string{""},
 		"",
 		"10",
-		model.ORDERBYFIELD_NAME,
+		model.ORDERBYFIELD_RECOMMENDED,
 		model.SORTORDER_ASC,
 		"10", // numeric nextPageToken from FindModelsWithRecommendedLatency
 	)
@@ -2093,7 +2039,6 @@ func TestFindModelsNonRecommendedRejectsInvalidToken(t *testing.T) {
 
 	resp, err := service.FindModels(
 		context.Background(),
-		false, // NOT recommended
 		0,
 		"",
 		"",
@@ -2121,7 +2066,6 @@ func TestFindModelsRecommendedRejectsNonNumericToken(t *testing.T) {
 
 	resp, err := service.FindModels(
 		context.Background(),
-		true, // recommended
 		1,
 		"ttft_p90",
 		"",
@@ -2132,7 +2076,7 @@ func TestFindModelsRecommendedRejectsNonNumericToken(t *testing.T) {
 		[]string{""},
 		"",
 		"10",
-		model.ORDERBYFIELD_NAME,
+		model.ORDERBYFIELD_RECOMMENDED,
 		model.SORTORDER_ASC,
 		"abc", // non-numeric token must be rejected
 	)
@@ -2364,7 +2308,6 @@ func TestFindModelsRecommendedRejectsOverflowToken(t *testing.T) {
 
 	resp, err := service.FindModels(
 		context.Background(),
-		true, // recommended
 		1,
 		"ttft_p90",
 		"",
@@ -2375,7 +2318,7 @@ func TestFindModelsRecommendedRejectsOverflowToken(t *testing.T) {
 		[]string{""},
 		"",
 		"10",
-		model.ORDERBYFIELD_NAME,
+		model.ORDERBYFIELD_RECOMMENDED,
 		model.SORTORDER_ASC,
 		"9999999999999", // exceeds MaxInt32, must be rejected
 	)
@@ -2502,15 +2445,14 @@ func TestFindModelsOrderByRecommended(t *testing.T) {
 
 	service := NewModelCatalogServiceAPIService(provider, sources, nil, nil, catalog.NewLabelCollection(), nil)
 
-	// orderBy=RECOMMENDED with recommendations=false should still use the recommendation path
+	// orderBy=RECOMMENDED should use the recommendation path
 	resp, err := service.FindModels(
 		context.Background(),
-		false, // recommendations=false
-		0,     // targetRPS
-		"",    // latencyProperty
-		"",    // rpsProperty
-		"",    // hardwareCountProperty
-		"",    // hardwareTypeProperty
+		0,  // targetRPS
+		"", // latencyProperty
+		"", // rpsProperty
+		"", // hardwareCountProperty
+		"", // hardwareTypeProperty
 		[]string{"source1"},
 		"",
 		[]string{""},
@@ -2553,12 +2495,11 @@ func TestFindModelsOrderByRecommendedDesc(t *testing.T) {
 	// orderBy=RECOMMENDED with sortOrder=DESC
 	resp, err := service.FindModels(
 		context.Background(),
-		false, // recommendations=false
-		0,     // targetRPS
-		"",    // latencyProperty
-		"",    // rpsProperty
-		"",    // hardwareCountProperty
-		"",    // hardwareTypeProperty
+		0,  // targetRPS
+		"", // latencyProperty
+		"", // rpsProperty
+		"", // hardwareCountProperty
+		"", // hardwareTypeProperty
 		[]string{"source1"},
 		"",
 		[]string{""},
@@ -2604,7 +2545,6 @@ func TestFindModelsOrderByRecommendedPagination(t *testing.T) {
 	// to base64-decode it as a DB cursor.
 	resp, err := service.FindModels(
 		context.Background(),
-		false, // recommendations=false — using orderBy instead
 		0, "", "", "", "",
 		[]string{"source1"},
 		"", []string{""}, "",

--- a/catalog/pkg/openapi/api_model_catalog_service.go
+++ b/catalog/pkg/openapi/api_model_catalog_service.go
@@ -224,7 +224,6 @@ func (a *ModelCatalogServiceAPIService) FindLabelsExecute(r ApiFindLabelsRequest
 type ApiFindModelsRequest struct {
 	ctx                   context.Context
 	ApiService            *ModelCatalogServiceAPIService
-	recommendations       *bool
 	targetRPS             *int32
 	latencyProperty       *string
 	rpsProperty           *string
@@ -238,13 +237,6 @@ type ApiFindModelsRequest struct {
 	orderBy               *OrderByField
 	sortOrder             *SortOrder
 	nextPageToken         *string
-}
-
-// Deprecated: use &#x60;orderBy&#x3D;RECOMMENDED&#x60; instead. Sort models by lowest recommended latency using Pareto filtering.
-// Deprecated
-func (r ApiFindModelsRequest) Recommendations(recommendations bool) ApiFindModelsRequest {
-	r.recommendations = &recommendations
-	return r
 }
 
 // Target requests per second for latency calculations
@@ -307,7 +299,7 @@ func (r ApiFindModelsRequest) PageSize(pageSize string) ApiFindModelsRequest {
 	return r
 }
 
-// Specifies the order by criteria for listing entities.  Supported values are: - CREATE_TIME - LAST_UPDATE_TIME - ID - NAME - ACCURACY - RECOMMENDED  Defaults to &#x60;NAME&#x60;.  The &#x60;ACCURACY&#x60; sort will sort by the &#x60;overall_average&#x60; property in any linked metrics artifact.  The &#x60;RECOMMENDED&#x60; sort applies Pareto filtering and ranks models by recommended latency. The Pareto-related parameters (&#x60;targetRPS&#x60;, &#x60;latencyProperty&#x60;, &#x60;rpsProperty&#x60;, &#x60;hardwareCountProperty&#x60;, &#x60;hardwareTypeProperty&#x60;) are applied the same way as with the deprecated &#x60;recommendations&#x60; parameter. With the default &#x60;sortOrder&#x3D;ASC&#x60;, the most recommended models (lowest latency) appear first. Use &#x60;sortOrder&#x3D;DESC&#x60; to show the least recommended configurations first.  In addition, models can be sorted by properties. For example: - &#x60;provider.string_value&#x60; sorts by provider name - &#x60;artifacts.ifeval.double_value&#x60; sorts by the min/max value a property called ifeval across all associated artifacts
+// Specifies the order by criteria for listing entities.  Supported values are: - CREATE_TIME - LAST_UPDATE_TIME - ID - NAME - ACCURACY - RECOMMENDED  Defaults to &#x60;NAME&#x60;.  The &#x60;ACCURACY&#x60; sort will sort by the &#x60;overall_average&#x60; property in any linked metrics artifact.  The &#x60;RECOMMENDED&#x60; sort applies Pareto filtering and ranks models by recommended latency. The Pareto-related parameters (&#x60;targetRPS&#x60;, &#x60;latencyProperty&#x60;, &#x60;rpsProperty&#x60;, &#x60;hardwareCountProperty&#x60;, &#x60;hardwareTypeProperty&#x60;) tune the ranking. With the default &#x60;sortOrder&#x3D;ASC&#x60;, the most recommended models (lowest latency) appear first. Use &#x60;sortOrder&#x3D;DESC&#x60; to show the least recommended configurations first.  In addition, models can be sorted by properties. For example: - &#x60;provider.string_value&#x60; sorts by provider name - &#x60;artifacts.ifeval.double_value&#x60; sorts by the min/max value a property called ifeval across all associated artifacts
 func (r ApiFindModelsRequest) OrderBy(orderBy OrderByField) ApiFindModelsRequest {
 	r.orderBy = &orderBy
 	return r
@@ -364,13 +356,6 @@ func (a *ModelCatalogServiceAPIService) FindModelsExecute(r ApiFindModelsRequest
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	if r.recommendations != nil {
-		parameterAddToHeaderOrQuery(localVarQueryParams, "recommendations", r.recommendations, "form", "")
-	} else {
-		var defaultValue bool = false
-		parameterAddToHeaderOrQuery(localVarQueryParams, "recommendations", defaultValue, "form", "")
-		r.recommendations = &defaultValue
-	}
 	if r.targetRPS != nil {
 		parameterAddToHeaderOrQuery(localVarQueryParams, "targetRPS", r.targetRPS, "form", "")
 	}
@@ -882,7 +867,6 @@ type ApiGetAllModelArtifactsRequest struct {
 	sourceId      string
 	modelName     string
 	artifactType  *[]ArtifactTypeQueryParam
-	artifactType2 *[]ArtifactTypeQueryParam
 	filterQuery   *string
 	pageSize      *string
 	orderBy       *string
@@ -893,13 +877,6 @@ type ApiGetAllModelArtifactsRequest struct {
 // Specifies the artifact type for listing artifacts.
 func (r ApiGetAllModelArtifactsRequest) ArtifactType(artifactType []ArtifactTypeQueryParam) ApiGetAllModelArtifactsRequest {
 	r.artifactType = &artifactType
-	return r
-}
-
-// Specifies the artifact type for listing artifacts.
-// Deprecated
-func (r ApiGetAllModelArtifactsRequest) ArtifactType2(artifactType2 []ArtifactTypeQueryParam) ApiGetAllModelArtifactsRequest {
-	r.artifactType2 = &artifactType2
 	return r
 }
 
@@ -987,17 +964,6 @@ func (a *ModelCatalogServiceAPIService) GetAllModelArtifactsExecute(r ApiGetAllM
 			}
 		} else {
 			parameterAddToHeaderOrQuery(localVarQueryParams, "artifactType", t, "form", "multi")
-		}
-	}
-	if r.artifactType2 != nil {
-		t := *r.artifactType2
-		if reflect.TypeOf(t).Kind() == reflect.Slice {
-			s := reflect.ValueOf(t)
-			for i := 0; i < s.Len(); i++ {
-				parameterAddToHeaderOrQuery(localVarQueryParams, "artifact_type", s.Index(i).Interface(), "form", "multi")
-			}
-		} else {
-			parameterAddToHeaderOrQuery(localVarQueryParams, "artifact_type", t, "form", "multi")
 		}
 	}
 	if r.filterQuery != nil {


### PR DESCRIPTION
## Description
There were build errors on main after #3086. Updating the generated code and removing the code to handle removed parameters.

## How Has This Been Tested?
`make image/build`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
