### PR TITLE
fix: refresh mcp catalog source validation status after mutations

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/mcpCatalogSettings.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/mcpCatalogSettings.ts
@@ -1,5 +1,53 @@
 import { appChrome } from './appChrome';
 import { TableRow } from './components/table';
+import { Modal } from './components/Modal';
+
+class McpDeleteSourceModal extends Modal {
+  constructor() {
+    super('Delete a source');
+  }
+
+  find() {
+    return cy.findByTestId('mcp-delete-source-modal');
+  }
+
+  findDeleteButton() {
+    return cy.findByTestId('delete-modal-confirm-button');
+  }
+
+  findConfirmInput() {
+    return cy.findByTestId('delete-modal-input');
+  }
+
+  typeConfirmation(text: string) {
+    this.findConfirmInput().clear().type(text);
+    return this;
+  }
+}
+
+class McpCatalogSourceConfigRow extends TableRow {
+  findName() {
+    return this.find().find('[data-label="Name"]');
+  }
+
+  findEnableToggle() {
+    return this.find().find('[data-label="Enable"]').find('input[type="checkbox"]');
+  }
+
+  findValidationStatus() {
+    return this.find().find('[data-label="Validation status"]');
+  }
+
+  toggleEnable() {
+    this.findEnableToggle().click({ force: true });
+    return this;
+  }
+
+  shouldHaveValidationStatus(status: 'Ready' | 'Failed' | 'Starting' | 'Unknown' | '-') {
+    this.findValidationStatus().contains(status);
+    return this;
+  }
+}
 
 class McpCatalogSettings {
   visit() {
@@ -61,7 +109,7 @@ class McpCatalogSettings {
   }
 
   getRow(name: string) {
-    return new TableRow(() =>
+    return new McpCatalogSourceConfigRow(() =>
       this.findTable().find('tbody').find('tr').contains(name).parents('tr'),
     );
   }
@@ -240,3 +288,4 @@ class McpManageSourcePage {
 
 export const mcpCatalogSettings = new McpCatalogSettings();
 export const mcpManageSourcePage = new McpManageSourcePage();
+export const mcpDeleteSourceModal = new McpDeleteSourceModal();

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalogSettings/mcpCatalogSettings.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/mcpCatalogSettings/mcpCatalogSettings.cy.ts
@@ -1,6 +1,7 @@
 import {
   mcpCatalogSettings,
   mcpManageSourcePage,
+  mcpDeleteSourceModal,
 } from '~/__tests__/cypress/cypress/pages/mcpCatalogSettings';
 import {
   mockMcpCatalogSourceConfigList,
@@ -857,6 +858,141 @@ describe('MCP Catalog Source Configs Table', () => {
       mcpCatalogSettings.visit();
       const row = mcpCatalogSettings.getRow('Error Source');
       row.find().should('contain', 'Failed');
+    });
+  });
+
+  describe('Sources refresh after mutations', () => {
+    it('should refresh catalog sources after toggling enable/disable', () => {
+      const mockData = mockMcpCatalogSourceConfigList({
+        catalogs: [
+          mockMcpCatalogSourceConfig({
+            id: 'custom-mcp',
+            name: 'Custom MCP',
+            isDefault: false,
+            enabled: false,
+          }),
+        ],
+      });
+      cy.intercept('GET', '**/settings/mcp_catalog/source_configs*', {
+        data: mockData,
+      });
+      cy.intercept('GET', '**/model_catalog/sources*assetType=mcp_servers*', {
+        data: {
+          items: [],
+          size: 0,
+          pageSize: 10,
+          nextPageToken: '',
+        },
+      });
+
+      cy.intercept('PATCH', '/model-registry/api/v1/settings/mcp_catalog/source_configs/*', {
+        statusCode: 200,
+        body: {
+          data: mockMcpCatalogSourceConfig({ id: 'custom-mcp', enabled: true }),
+        },
+      }).as('toggleSource');
+
+      mcpCatalogSettings.visit();
+
+      const row = mcpCatalogSettings.getRow('Custom MCP');
+      row.findName().should('be.visible');
+
+      row.shouldHaveValidationStatus('-');
+
+      // After toggle, configs refresh should return custom-mcp as enabled
+      cy.intercept('GET', '/model-registry/api/v1/settings/mcp_catalog/source_configs', {
+        data: {
+          catalogs: [
+            mockMcpCatalogSourceConfig({
+              id: 'custom-mcp',
+              name: 'Custom MCP',
+              isDefault: false,
+              enabled: true,
+            }),
+          ],
+        },
+      });
+
+      row.toggleEnable();
+
+      cy.wait('@toggleSource');
+
+      row.shouldHaveValidationStatus('Starting');
+    });
+
+    it('should refresh catalog sources after deleting a source', () => {
+      const availableSource = {
+        id: 'mcp-source-1',
+        name: 'MCP Source 1',
+        labels: [],
+        status: 'available',
+      };
+
+      const mockData = mockMcpCatalogSourceConfigList({
+        catalogs: [
+          mockMcpCatalogSourceConfig({
+            id: 'mcp-source-1',
+            name: 'MCP Source 1',
+            isDefault: false,
+            enabled: true,
+          }),
+          mockMcpCatalogSourceConfig({
+            id: 'mcp-source-2',
+            name: 'MCP Source 2',
+            isDefault: false,
+            enabled: true,
+          }),
+        ],
+      });
+
+      cy.intercept('GET', '**/settings/mcp_catalog/source_configs*', {
+        data: mockData,
+      });
+      cy.intercept('GET', '**/model_catalog/sources*assetType=mcp_servers*', {
+        data: {
+          items: [availableSource],
+          size: 1,
+          pageSize: 10,
+          nextPageToken: '',
+        },
+      });
+
+      cy.intercept('DELETE', '/model-registry/api/v1/settings/mcp_catalog/source_configs/*', {
+        statusCode: 200,
+        body: {},
+      }).as('deleteSource');
+
+      mcpCatalogSettings.visit();
+
+      const row = mcpCatalogSettings.getRow('MCP Source 1');
+
+      row.shouldHaveValidationStatus('Ready');
+
+      // After delete, configs refresh should return without mcp-source-1
+      cy.intercept('GET', '/model-registry/api/v1/settings/mcp_catalog/source_configs', {
+        data: {
+          catalogs: [
+            mockMcpCatalogSourceConfig({
+              id: 'mcp-source-2',
+              name: 'MCP Source 2',
+              isDefault: false,
+              enabled: true,
+            }),
+          ],
+        },
+      });
+
+      row.findKebab().click();
+      cy.findByRole('menuitem', { name: 'Delete source' }).click();
+
+      mcpDeleteSourceModal.shouldBeOpen();
+      mcpDeleteSourceModal.typeConfirmation('MCP Source 1');
+      mcpDeleteSourceModal.findDeleteButton().click();
+
+      cy.wait('@deleteSource');
+
+      // Assert row was removed after delete (table had 2 rows, now has 1)
+      mcpCatalogSettings.findRows().should('have.length', 1);
     });
   });
 });

--- a/clients/ui/frontend/src/app/context/mcpCatalogSettings/McpCatalogSettingsContext.tsx
+++ b/clients/ui/frontend/src/app/context/mcpCatalogSettings/McpCatalogSettingsContext.tsx
@@ -32,6 +32,8 @@ export type McpCatalogSettingsContextType = {
   mcpCatalogSourcesLoaded: boolean;
   mcpCatalogSourcesLoadError?: Error;
   refreshMcpCatalogSources: () => void;
+  pendingSourceIds: Map<string, string>;
+  markSourcePending: (id: string, previousStatus: string) => void;
 };
 
 type McpCatalogSettingsContextProviderProps = {
@@ -50,6 +52,8 @@ export const McpCatalogSettingsContext = React.createContext<McpCatalogSettingsC
   mcpCatalogSourcesLoaded: false,
   mcpCatalogSourcesLoadError: undefined,
   refreshMcpCatalogSources: () => undefined,
+  pendingSourceIds: new Map(),
+  markSourcePending: () => undefined,
 });
 
 export const McpCatalogSettingsContextProvider: React.FC<
@@ -68,6 +72,51 @@ export const McpCatalogSettingsContextProvider: React.FC<
     refreshCatalogSources: refreshMcpCatalogSources,
   } = useCatalogSettingsValue();
 
+  const [pendingSourceIds, setPendingSourceIds] = React.useState<Map<string, string>>(new Map());
+  const pendingSkipCountRef = React.useRef(new Map<string, number>());
+  const pollGenerationRef = React.useRef(0);
+  const lastSeenGenerationRef = React.useRef(new Map<string, number>());
+
+  const markSourcePending = React.useCallback((id: string, previousStatus: string) => {
+    lastSeenGenerationRef.current.set(id, pollGenerationRef.current);
+    pendingSkipCountRef.current.set(id, 3);
+    setPendingSourceIds((prev) => {
+      const next = new Map(prev);
+      next.set(id, previousStatus);
+      return next;
+    });
+  }, []);
+
+  React.useEffect(() => {
+    pollGenerationRef.current += 1;
+    const currentGeneration = pollGenerationRef.current;
+
+    setPendingSourceIds((prev) => {
+      if (prev.size === 0) {
+        return prev;
+      }
+      const next = new Map(prev);
+      let changed = false;
+      for (const [id] of prev) {
+        const markedAt = lastSeenGenerationRef.current.get(id) ?? 0;
+        const pollsSinceMarked = currentGeneration - markedAt;
+        const skipCount = pendingSkipCountRef.current.get(id) ?? 0;
+
+        if (pollsSinceMarked <= skipCount) {
+          continue;
+        }
+        const source = mcpCatalogSources?.items?.find((s) => s.id === id);
+        if (!source || source.status) {
+          next.delete(id);
+          pendingSkipCountRef.current.delete(id);
+          lastSeenGenerationRef.current.delete(id);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [mcpCatalogSources]);
+
   const contextValue = React.useMemo(
     () => ({
       apiState,
@@ -80,6 +129,8 @@ export const McpCatalogSettingsContextProvider: React.FC<
       mcpCatalogSourcesLoaded,
       mcpCatalogSourcesLoadError,
       refreshMcpCatalogSources,
+      pendingSourceIds,
+      markSourcePending,
     }),
     [
       apiState,
@@ -92,6 +143,8 @@ export const McpCatalogSettingsContextProvider: React.FC<
       mcpCatalogSourcesLoaded,
       mcpCatalogSourcesLoadError,
       refreshMcpCatalogSources,
+      pendingSourceIds,
+      markSourcePending,
     ],
   );
 

--- a/clients/ui/frontend/src/app/context/mcpCatalogSettings/__tests__/McpCatalogSettingsContext.spec.tsx
+++ b/clients/ui/frontend/src/app/context/mcpCatalogSettings/__tests__/McpCatalogSettingsContext.spec.tsx
@@ -1,0 +1,167 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import {
+  McpCatalogSettingsContextProvider,
+  McpCatalogSettingsContext,
+} from '~/app/context/mcpCatalogSettings/McpCatalogSettingsContext';
+import type { CatalogSourceList } from '~/app/shared/types/catalogTypes';
+import { CatalogSourceStatus } from '~/app/shared/types/catalogTypes';
+
+let mockMcpCatalogSources: CatalogSourceList;
+const mockRefreshMcpCatalogSources = jest.fn();
+
+jest.mock('mod-arch-core', () => {
+  const actual = jest.requireActual('mod-arch-core');
+  return {
+    ...actual,
+    useQueryParamNamespaces: jest.fn(() => ({})),
+  };
+});
+
+jest.mock('~/app/hooks/modelCatalog/useModelCatalogAPIState', () => ({
+  __esModule: true,
+  default: jest.fn(() => [
+    {
+      apiAvailable: true,
+      api: { getListSources: jest.fn() },
+    },
+    jest.fn(),
+  ]),
+}));
+
+jest.mock('~/app/hooks/mcpCatalogSettings/useMcpCatalogSettingsAPIState', () => ({
+  __esModule: true,
+  default: jest.fn(() => [
+    {
+      apiAvailable: true,
+      api: {
+        getMcpCatalogSourceConfigs: jest.fn(),
+        createMcpCatalogSourceConfig: jest.fn(),
+        getMcpCatalogSourceConfig: jest.fn(),
+        updateMcpCatalogSourceConfig: jest.fn(),
+        deleteMcpCatalogSourceConfig: jest.fn(),
+        previewMcpCatalogSource: jest.fn(),
+      },
+    },
+    jest.fn(),
+  ]),
+}));
+
+jest.mock('~/app/hooks/mcpCatalogSettings/useMcpCatalogSourceConfigs', () => ({
+  useMcpCatalogSourceConfigs: jest.fn(() => [{ catalogs: [] }, true, undefined, jest.fn()]),
+}));
+
+jest.mock('~/app/shared/catalogSettings/hooks/useCatalogSourcesWithPolling', () => ({
+  useCatalogSourcesWithPolling: jest.fn(
+    () => [mockMcpCatalogSources, true, undefined, mockRefreshMcpCatalogSources] as const,
+  ),
+}));
+
+const emptySources: CatalogSourceList = {
+  items: [],
+  size: 0,
+  pageSize: 0,
+  nextPageToken: '',
+};
+
+describe('McpCatalogSettingsContext — pendingSourceIds clearing', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <McpCatalogSettingsContextProvider>{children}</McpCatalogSettingsContextProvider>
+  );
+
+  beforeEach(() => {
+    mockMcpCatalogSources = emptySources;
+    jest.clearAllMocks();
+  });
+
+  it('should skip three stale responses and clear on fourth', () => {
+    mockMcpCatalogSources = {
+      ...emptySources,
+      items: [{ id: 'src-1', name: 'S1', labels: [], status: CatalogSourceStatus.AVAILABLE }],
+    };
+
+    const { result, rerender } = renderHook(() => React.useContext(McpCatalogSettingsContext), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.markSourcePending('src-1', CatalogSourceStatus.AVAILABLE);
+    });
+    expect(result.current.pendingSourceIds.has('src-1')).toBe(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const polling = require('~/app/shared/catalogSettings/hooks/useCatalogSourcesWithPolling');
+    const errorSources = {
+      ...emptySources,
+      items: [{ id: 'src-1', name: 'S1', labels: [], status: CatalogSourceStatus.ERROR }],
+    };
+
+    // 1st, 2nd, 3rd responses (stale) — all skipped
+    for (let i = 0; i < 3; i++) {
+      (polling.useCatalogSourcesWithPolling as jest.Mock).mockReturnValue([
+        { ...errorSources },
+        true,
+        undefined,
+        mockRefreshMcpCatalogSources,
+      ]);
+      rerender();
+      expect(result.current.pendingSourceIds.has('src-1')).toBe(true);
+    }
+
+    // 4th response — accepted, pending clears
+    (polling.useCatalogSourcesWithPolling as jest.Mock).mockReturnValue([
+      { ...errorSources },
+      true,
+      undefined,
+      mockRefreshMcpCatalogSources,
+    ]);
+    rerender();
+    expect(result.current.pendingSourceIds.has('src-1')).toBe(false);
+  });
+
+  it('should skip three stale responses and clear on fourth (same status)', () => {
+    mockMcpCatalogSources = {
+      ...emptySources,
+      items: [{ id: 'src-1', name: 'S1', labels: [], status: CatalogSourceStatus.AVAILABLE }],
+    };
+
+    const { result, rerender } = renderHook(() => React.useContext(McpCatalogSettingsContext), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.markSourcePending('src-1', CatalogSourceStatus.AVAILABLE);
+    });
+    expect(result.current.pendingSourceIds.has('src-1')).toBe(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const polling = require('~/app/shared/catalogSettings/hooks/useCatalogSourcesWithPolling');
+    const sameSources = {
+      ...emptySources,
+      items: [{ id: 'src-1', name: 'S1', labels: [], status: CatalogSourceStatus.AVAILABLE }],
+    };
+
+    // 1st, 2nd, 3rd responses — all skipped
+    for (let i = 0; i < 3; i++) {
+      (polling.useCatalogSourcesWithPolling as jest.Mock).mockReturnValue([
+        { ...sameSources },
+        true,
+        undefined,
+        mockRefreshMcpCatalogSources,
+      ]);
+      rerender();
+      expect(result.current.pendingSourceIds.has('src-1')).toBe(true);
+    }
+
+    // 4th response — accepted, pending clears even with same status
+    (polling.useCatalogSourcesWithPolling as jest.Mock).mockReturnValue([
+      { ...sameSources },
+      true,
+      undefined,
+      mockRefreshMcpCatalogSources,
+    ]);
+    rerender();
+    expect(result.current.pendingSourceIds.has('src-1')).toBe(false);
+  });
+});

--- a/clients/ui/frontend/src/app/pages/mcpCatalogSettings/components/McpCatalogSourceStatus.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalogSettings/components/McpCatalogSourceStatus.tsx
@@ -13,8 +13,12 @@ type McpCatalogSourceStatusProps = {
 const McpCatalogSourceStatus: React.FC<McpCatalogSourceStatusProps> = ({
   mcpCatalogSourceConfig,
 }) => {
-  const { mcpCatalogSources, mcpCatalogSourcesLoaded, mcpCatalogSourcesLoadError } =
-    React.useContext(McpCatalogSettingsContext);
+  const {
+    mcpCatalogSources,
+    mcpCatalogSourcesLoaded,
+    mcpCatalogSourcesLoadError,
+    pendingSourceIds,
+  } = React.useContext(McpCatalogSettingsContext);
   const [isErrorModalOpen, setIsErrorModalOpen] = React.useState(false);
 
   if (!mcpCatalogSourceConfig.enabled || mcpCatalogSourceConfig.isDefault) {
@@ -27,10 +31,6 @@ const McpCatalogSourceStatus: React.FC<McpCatalogSourceStatusProps> = ({
     );
   }
 
-  const matchingSource = mcpCatalogSources?.items?.find(
-    (source) => source.id === mcpCatalogSourceConfig.id,
-  );
-
   const startingOrUnknownLabel = (
     <Label
       color="grey"
@@ -40,6 +40,14 @@ const McpCatalogSourceStatus: React.FC<McpCatalogSourceStatusProps> = ({
     >
       {mcpCatalogSourcesLoadError ? 'Unknown' : 'Starting'}
     </Label>
+  );
+
+  if (pendingSourceIds.has(mcpCatalogSourceConfig.id)) {
+    return startingOrUnknownLabel;
+  }
+
+  const matchingSource = mcpCatalogSources?.items?.find(
+    (source) => source.id === mcpCatalogSourceConfig.id,
   );
 
   if (!matchingSource || !matchingSource.status) {

--- a/clients/ui/frontend/src/app/pages/mcpCatalogSettings/components/McpManageSourceForm.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalogSettings/components/McpManageSourceForm.tsx
@@ -51,7 +51,13 @@ const McpManageSourceForm: React.FC<McpManageSourceFormProps> = ({
   const [formData, setData] = useManageMcpSourceData(existingData);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [submitError, setSubmitError] = React.useState<Error | undefined>(undefined);
-  const { apiState, refreshMcpCatalogSourceConfigs } = React.useContext(McpCatalogSettingsContext);
+  const {
+    apiState,
+    mcpCatalogSources,
+    refreshMcpCatalogSourceConfigs,
+    refreshMcpCatalogSources,
+    markSourcePending,
+  } = React.useContext(McpCatalogSettingsContext);
 
   const preview = useMcpSourcePreview({
     formData,
@@ -74,13 +80,25 @@ const McpManageSourceForm: React.FC<McpManageSourceFormProps> = ({
       const sourceConfig = transformMcpFormDataToConfig(formData, existingSourceConfig);
       const payload = getMcpPayloadForConfig(sourceConfig, isEditMode);
 
-      if (isEditMode) {
+      if (isEditMode && existingData) {
+        const previousStatus =
+          mcpCatalogSources?.items?.find((s) => s.id === formData.id)?.status ?? '';
         await apiState.api.updateMcpCatalogSourceConfig({}, formData.id, payload);
+        const validationFieldsChanged =
+          existingData.sourceType !== formData.sourceType ||
+          existingData.yamlContent !== formData.yamlContent ||
+          existingData.includedServers !== formData.includedServers ||
+          existingData.excludedServers !== formData.excludedServers ||
+          existingData.enabled !== formData.enabled;
+        if (validationFieldsChanged) {
+          markSourcePending(formData.id, previousStatus);
+        }
       } else {
         await apiState.api.createMcpCatalogSourceConfig({}, payload);
       }
 
       refreshMcpCatalogSourceConfigs();
+      refreshMcpCatalogSources();
       navigate(mcpCatalogSettingsUrl());
     } catch (error) {
       setSubmitError(error instanceof Error ? error : new Error(MCP_ERROR_MESSAGES.SAVE_FAILED));

--- a/clients/ui/frontend/src/app/pages/mcpCatalogSettings/components/__tests__/McpCatalogSourceStatus.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalogSettings/components/__tests__/McpCatalogSourceStatus.spec.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  McpCatalogSettingsContext,
+  McpCatalogSettingsContextType,
+} from '~/app/context/mcpCatalogSettings/McpCatalogSettingsContext';
+import { McpCatalogSourceConfig, McpCatalogSourceType } from '~/app/mcpServerCatalogTypes';
+import McpCatalogSourceStatus from '~/app/pages/mcpCatalogSettings/components/McpCatalogSourceStatus';
+import { CatalogSourceStatus as CatalogSourceStatusEnum } from '~/app/shared/types/catalogTypes';
+
+const mockConfig: McpCatalogSourceConfig = {
+  id: 'test-source',
+  name: 'Test Source',
+  type: McpCatalogSourceType.YAML,
+  enabled: true,
+};
+
+const defaultPagination = { size: 0, pageSize: 10, nextPageToken: '' };
+
+const renderWithContext = (
+  config: McpCatalogSourceConfig,
+  contextOverrides: Partial<McpCatalogSettingsContextType>,
+) => {
+  const defaultContext: McpCatalogSettingsContextType = {
+    apiState: {
+      apiAvailable: false,
+      api: null as unknown as McpCatalogSettingsContextType['apiState']['api'],
+    },
+    refreshAPIState: jest.fn(),
+    mcpCatalogSourceConfigs: null,
+    mcpCatalogSourceConfigsLoaded: false,
+    mcpCatalogSourceConfigsLoadError: undefined,
+    refreshMcpCatalogSourceConfigs: jest.fn(),
+    mcpCatalogSources: null,
+    mcpCatalogSourcesLoaded: true,
+    mcpCatalogSourcesLoadError: undefined,
+    refreshMcpCatalogSources: jest.fn(),
+    pendingSourceIds: new Map(),
+    markSourcePending: jest.fn(),
+    ...contextOverrides,
+  };
+
+  return render(
+    <McpCatalogSettingsContext.Provider value={defaultContext}>
+      <McpCatalogSourceStatus mcpCatalogSourceConfig={config} />
+    </McpCatalogSettingsContext.Provider>,
+  );
+};
+
+describe('McpCatalogSourceStatus', () => {
+  it('renders "Ready" label with outline variant', () => {
+    renderWithContext(mockConfig, {
+      mcpCatalogSources: {
+        ...defaultPagination,
+        items: [
+          {
+            id: 'test-source',
+            name: 'Test',
+            labels: [],
+            status: CatalogSourceStatusEnum.AVAILABLE,
+          },
+        ],
+      },
+      mcpCatalogSourcesLoaded: true,
+    });
+
+    const label = screen.getByTestId('mcp-source-status-connected-test-source');
+    expect(screen.getByText('Ready')).toBeVisible();
+    expect(label.className).toMatch(/outline/);
+    expect(label.className).not.toMatch(/filled/);
+  });
+
+  it('renders "Failed" label with outline variant', () => {
+    renderWithContext(mockConfig, {
+      mcpCatalogSources: {
+        ...defaultPagination,
+        items: [
+          {
+            id: 'test-source',
+            name: 'Test',
+            labels: [],
+            status: CatalogSourceStatusEnum.ERROR,
+            error: 'Connection refused',
+          },
+        ],
+      },
+      mcpCatalogSourcesLoaded: true,
+    });
+
+    const label = screen.getByTestId('mcp-source-status-failed-test-source');
+    expect(screen.getByText('Failed')).toBeVisible();
+    expect(label.className).toMatch(/outline/);
+    expect(label.className).not.toMatch(/filled/);
+  });
+
+  it('renders "Starting" label with outline variant when source has no status', () => {
+    renderWithContext(mockConfig, {
+      mcpCatalogSources: {
+        ...defaultPagination,
+        items: [{ id: 'test-source', name: 'Test', labels: [] }],
+      },
+      mcpCatalogSourcesLoaded: true,
+    });
+
+    const label = screen.getByTestId('mcp-source-status-starting-test-source');
+    expect(screen.getByText('Starting')).toBeVisible();
+    expect(label.className).toMatch(/outline/);
+  });
+
+  it('renders "Starting" label when source is pending after mutation', () => {
+    renderWithContext(mockConfig, {
+      mcpCatalogSources: {
+        ...defaultPagination,
+        items: [
+          {
+            id: 'test-source',
+            name: 'Test',
+            labels: [],
+            status: CatalogSourceStatusEnum.AVAILABLE,
+          },
+        ],
+      },
+      mcpCatalogSourcesLoaded: true,
+      pendingSourceIds: new Map([['test-source', CatalogSourceStatusEnum.AVAILABLE]]),
+    });
+
+    expect(screen.getByTestId('mcp-source-status-starting-test-source')).toBeInTheDocument();
+    expect(screen.getByText('Starting')).toBeVisible();
+  });
+
+  it('renders "Unknown" label with outline variant when there is a load error', () => {
+    renderWithContext(mockConfig, {
+      mcpCatalogSources: null,
+      mcpCatalogSourcesLoaded: true,
+      mcpCatalogSourcesLoadError: new Error('API error'),
+    });
+
+    const label = screen.getByTestId('mcp-source-status-unknown-test-source');
+    expect(screen.getByText('Unknown')).toBeVisible();
+    expect(label.className).toMatch(/outline/);
+  });
+
+  it('renders "-" for default sources', () => {
+    renderWithContext({ ...mockConfig, isDefault: true }, { mcpCatalogSourcesLoaded: true });
+    expect(screen.getByText('-')).toBeVisible();
+  });
+
+  it('renders "-" for disabled sources', () => {
+    renderWithContext({ ...mockConfig, enabled: false }, { mcpCatalogSourcesLoaded: true });
+    expect(screen.getByText('-')).toBeVisible();
+  });
+});

--- a/clients/ui/frontend/src/app/pages/mcpCatalogSettings/screens/McpCatalogSettings.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalogSettings/screens/McpCatalogSettings.tsx
@@ -20,6 +20,7 @@ const McpCatalogSettings: React.FC = () => {
     mcpCatalogSourceConfigsLoadError,
     apiState,
     refreshMcpCatalogSourceConfigs,
+    refreshMcpCatalogSources,
   } = React.useContext(McpCatalogSettingsContext);
 
   const configs = mcpCatalogSourceConfigs?.catalogs || [];
@@ -32,8 +33,9 @@ const McpCatalogSettings: React.FC = () => {
       }
       await apiState.api.deleteMcpCatalogSourceConfig({}, sourceId);
       refreshMcpCatalogSourceConfigs();
+      refreshMcpCatalogSources();
     },
-    [apiState.api, apiState.apiAvailable, refreshMcpCatalogSourceConfigs],
+    [apiState.api, apiState.apiAvailable, refreshMcpCatalogSourceConfigs, refreshMcpCatalogSources],
   );
 
   return (

--- a/clients/ui/frontend/src/app/pages/mcpCatalogSettings/screens/McpCatalogSourceConfigsTable.tsx
+++ b/clients/ui/frontend/src/app/pages/mcpCatalogSettings/screens/McpCatalogSourceConfigsTable.tsx
@@ -31,8 +31,14 @@ const McpCatalogSourceConfigsTable: React.FC<McpCatalogSourceConfigsTableProps> 
 }) => {
   const [toggleError, setToggleError] = React.useState<Error | undefined>(undefined);
   const [updatingToggleId, setUpdatingToggleId] = React.useState<string | null>(null);
-  const { apiState, refreshMcpCatalogSourceConfigs, mcpCatalogSourcesLoadError } =
-    React.useContext(McpCatalogSettingsContext);
+  const {
+    apiState,
+    refreshMcpCatalogSourceConfigs,
+    refreshMcpCatalogSources,
+    mcpCatalogSourcesLoadError,
+    mcpCatalogSources,
+    markSourcePending,
+  } = React.useContext(McpCatalogSettingsContext);
 
   const handleEnableToggle = async (
     checked: boolean,
@@ -45,11 +51,20 @@ const McpCatalogSourceConfigsTable: React.FC<McpCatalogSourceConfigsTableProps> 
     setUpdatingToggleId(catalogSourceConfig.id);
     setToggleError(undefined);
 
+    if (checked) {
+      const previousStatus =
+        mcpCatalogSources?.items?.find((s) => s.id === catalogSourceConfig.id)?.status ?? '';
+      markSourcePending(catalogSourceConfig.id, previousStatus);
+    }
+
     try {
       await apiState.api.updateMcpCatalogSourceConfig({}, catalogSourceConfig.id, {
         enabled: checked,
       });
       refreshMcpCatalogSourceConfigs();
+      if (checked) {
+        refreshMcpCatalogSources();
+      }
     } catch (e) {
       if (e instanceof Error) {
         setToggleError(new Error(`Error enabling/disabling source ${catalogSourceConfig.name}`));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
After change source from mcp catalog, the status doesn't update not showing the real status.
With this change, when the user saves any change into the source(if it affects source) it will move to starting again if enabled and wait to receive the real status when it's finished the "starting"

NO UI CHANGED

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It was manually tested in midstream

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
