### PR TITLE
fix(catalog): don't delete a source's status if another plugin still …

### DIFF
--- a/catalog/internal/catalog/agentcatalog/loader.go
+++ b/catalog/internal/catalog/agentcatalog/loader.go
@@ -296,8 +296,12 @@ func (l *AgentLoader) removeAgentsFromMissingSources(allKnownSourceIDs mapset.Se
 			return fmt.Errorf("unable to remove agents from source %q: %w", oldSource, err)
 		}
 
-		if !agentSourceIDs.Contains(oldSource) {
-			glog.Infof("Removing status for agent source %s (no longer in config)", oldSource)
+		// Only delete the shared CatalogSource status record if the source is absent
+		// from ALL plugin configs — not just the agent config. allKnownSourceIDs is
+		// the union of every plugin's configured source IDs, so if another plugin
+		// (model, skill, mcp) owns this source we must not delete its status row.
+		if !agentSourceIDs.Contains(oldSource) && !allKnownSourceIDs.Contains(oldSource) {
+			glog.Infof("Removing status for agent source %s (no longer in any config)", oldSource)
 			if delErr := l.services.CatalogSourceRepository.Delete(oldSource); delErr != nil {
 				glog.Errorf("failed to delete status for agent source %s: %v", oldSource, delErr)
 			}

--- a/catalog/internal/catalog/mcpcatalog/loader.go
+++ b/catalog/internal/catalog/mcpcatalog/loader.go
@@ -523,9 +523,12 @@ func (ml *MCPLoader) removeServersFromMissingSources(enabledSourceIDs, allSource
 				glog.Errorf("Error deleting servers from source %s: %v", dbSourceID, err)
 			}
 
-			// If the source is completely gone from config (not just disabled), remove its status too
-			if !allSourceIDs.Contains(dbSourceID) {
-				glog.Infof("Removing status for MCP source %s (no longer in config)", dbSourceID)
+			// Only delete the shared CatalogSource status record if the source is absent
+			// from ALL plugin configs — not just the MCP config. allKnownSourceIDs is
+			// the union of every plugin's configured source IDs, so if another plugin
+			// (model, skill, agent) owns this source we must not delete its status row.
+			if !allSourceIDs.Contains(dbSourceID) && !allKnownSourceIDs.Contains(dbSourceID) {
+				glog.Infof("Removing status for MCP source %s (no longer in any config)", dbSourceID)
 				if delErr := ml.services.CatalogSourceRepository.Delete(dbSourceID); delErr != nil {
 					glog.Errorf("failed to delete status for MCP source %s: %v", dbSourceID, delErr)
 				}

--- a/catalog/internal/catalog/modelcatalog/loader.go
+++ b/catalog/internal/catalog/modelcatalog/loader.go
@@ -599,10 +599,12 @@ func (l *ModelLoader) removeModelsFromMissingSources(allKnownSourceIDs mapset.Se
 			return fmt.Errorf("unable to remove models from source %q: %w", oldSource, err)
 		}
 
-		// If the source is completely gone from model config (not just disabled), remove its status too.
-		// We check model-only IDs here since existingSourceIDs comes from CatalogModelRepository.
-		if !modelSourceIDs.Contains(oldSource) {
-			glog.Infof("Removing status for source %s (no longer in model config)", oldSource)
+		// Only delete the shared CatalogSource status record if the source is absent
+		// from ALL plugin configs — not just the model config. allKnownSourceIDs is
+		// the union of every plugin's configured source IDs, so if another plugin
+		// (skill, mcp, agent) owns this source we must not delete its status row.
+		if !modelSourceIDs.Contains(oldSource) && !allKnownSourceIDs.Contains(oldSource) {
+			glog.Infof("Removing status for source %s (no longer in any config)", oldSource)
 			if delErr := l.services.CatalogSourceRepository.Delete(oldSource); delErr != nil {
 				glog.Errorf("failed to delete status for source %s: %v", oldSource, delErr)
 			}

--- a/catalog/internal/catalog/skillcatalog/loader.go
+++ b/catalog/internal/catalog/skillcatalog/loader.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/kubeflow/hub/catalog/internal/catalog/basecatalog"
 	"github.com/kubeflow/hub/catalog/internal/catalog/skillcatalog/models"
+	dbmodels "github.com/kubeflow/hub/catalog/internal/db/models"
 )
 
 // Defaults for SyncLimits.
@@ -138,6 +139,37 @@ type SkillLoader struct {
 	// or a reload-triggered PerformLeaderOperations) and drop or duplicate rows.
 	syncLocksMu sync.Mutex
 	syncLocks   map[string]*sync.Mutex
+
+	// poRefresher rebuilds the context_property_options materialized view, which is
+	// what serves GetFilterOptions. Nothing else refreshes it on the skill catalog's
+	// behalf, so without this a synced source's provider/category/labels never reach
+	// the filter sidebar, and values removed from a source linger there indefinitely —
+	// until an unrelated catalog (model or agent) happens to refresh the shared view.
+	//
+	// It is debounced rather than called per source: a full reload syncs every source,
+	// and each refresh rebuilds the whole view. Replaced per leader term so it stops
+	// with that term's context.
+	poRefresherMu sync.Mutex
+	poRefresher   *dbmodels.PropertyOptionsRefresher
+}
+
+// setPropertyOptionsRefresher installs the refresher for a leader term.
+func (l *SkillLoader) setPropertyOptionsRefresher(r *dbmodels.PropertyOptionsRefresher) {
+	l.poRefresherMu.Lock()
+	defer l.poRefresherMu.Unlock()
+	l.poRefresher = r
+}
+
+// triggerPropertyOptionsRefresh schedules a rebuild of the filter-options view.
+// It is a no-op before a leader term has started, and safe to call from any sync
+// goroutine — the refresher coalesces bursts into a single rebuild.
+func (l *SkillLoader) triggerPropertyOptionsRefresh() {
+	l.poRefresherMu.Lock()
+	r := l.poRefresher
+	l.poRefresherMu.Unlock()
+	if r != nil {
+		r.Trigger()
+	}
 }
 
 // currentWG returns the WaitGroup for the current leader term, creating it on
@@ -237,6 +269,16 @@ func (l *SkillLoader) PerformLeaderOperations(ctx context.Context, allKnownSourc
 	termWG := l.currentWG()
 	l.setCloser(cancel)
 
+	// Tied to this term's context, so it stops when leadership is lost. The one-second
+	// delay coalesces the burst of syncs a reload kicks off into a single view rebuild.
+	// Skipped when no repository is wired (tests, and non-Postgres backends where the
+	// view does not exist): the refresher's goroutine would call Refresh on a nil
+	// interface the first time a sync triggered it.
+	if l.services.PropertyOptionsRepository != nil {
+		l.setPropertyOptionsRefresher(
+			dbmodels.NewPropertyOptionsRefresher(ctx, l.services.PropertyOptionsRepository, time.Second))
+	}
+
 	// Drain in-flight DB writes from the previous term first, then wait for the
 	// ticker goroutines themselves (which exit promptly after context cancellation).
 	l.state.WaitForInflightWrites(30 * time.Second)
@@ -244,6 +286,9 @@ func (l *SkillLoader) PerformLeaderOperations(ctx context.Context, allKnownSourc
 
 	if err := l.removeSkillsFromMissingSources(allKnownSourceIDs); err != nil {
 		glog.Errorf("error removing skills from missing sources: %v", err)
+	} else {
+		// A deleted source's provider/category would otherwise stay in the filter list.
+		l.triggerPropertyOptionsRefresh()
 	}
 
 	for id, source := range l.sources.AllSources() {
@@ -420,6 +465,9 @@ func (l *SkillLoader) syncSourceLocked(ctx context.Context, sourceID string, spe
 
 	status, msg := skillSourceStatus(indexed+skipped, warningMsgs, errs)
 	basecatalog.SaveSourceStatus(l.services.CatalogSourceRepository, sourceID, status, msg)
+	// Indexing or orphan removal above may have added or dropped property values, so
+	// the filter-options view needs rebuilding for them to be reflected.
+	l.triggerPropertyOptionsRefresh()
 	glog.Infof("skill source %s: indexed %d skills, skipped %d unchanged refs, %d warnings, %d errors",
 		sourceID, indexed, skipped, len(warningMsgs), len(errs))
 }
@@ -834,7 +882,11 @@ func (l *SkillLoader) removeSkillsFromMissingSources(allKnownSourceIDs mapset.Se
 		if delErr != nil {
 			return fmt.Errorf("unable to remove skills from source %q: %w", oldSource, delErr)
 		}
-		if !skillSourceIDs.Contains(oldSource) {
+		// Only delete the shared CatalogSource status record if the source is absent
+		// from ALL plugin configs — not just the skill config. allKnownSourceIDs is
+		// the union of every plugin's configured source IDs, so if another plugin
+		// (model, mcp, agent) owns this source we must not delete its status row.
+		if !skillSourceIDs.Contains(oldSource) && !allKnownSourceIDs.Contains(oldSource) {
 			if err := l.services.CatalogSourceRepository.Delete(oldSource); err != nil {
 				glog.Errorf("failed to delete status for skill source %s: %v", oldSource, err)
 			}

--- a/catalog/internal/catalog/skillcatalog/loader_reconcile_test.go
+++ b/catalog/internal/catalog/skillcatalog/loader_reconcile_test.go
@@ -750,3 +750,52 @@ func TestRemoveSkillsFromMissingSources_WaitsForInFlightSync(t *testing.T) {
 	}
 	assert.Equal(t, 1, repo.deleteBySourceCount(), "cleanup proceeds once the sync finishes")
 }
+
+// countingPropertyOptionsRepo records Refresh calls so a test can assert the
+// filter-options view is rebuilt after a sync.
+type countingPropertyOptionsRepo struct {
+	refreshes int64
+}
+
+func (c *countingPropertyOptionsRepo) Refresh(sharedmodels.PropertyOptionType) error {
+	atomic.AddInt64(&c.refreshes, 1)
+	return nil
+}
+
+func (c *countingPropertyOptionsRepo) List(sharedmodels.PropertyOptionType, int32) ([]sharedmodels.PropertyOption, error) {
+	return nil, nil
+}
+
+// Filter options are served from a materialized view that only changes when something
+// refreshes it. Nothing else does so on the skill catalog's behalf, so a source that
+// syncs without this leaves its provider/category out of the filter sidebar, and values
+// dropped from a source linger there.
+func TestPerformLeaderOperations_RefreshesPropertyOptionsAfterSync(t *testing.T) {
+	po := &countingPropertyOptionsRepo{}
+	fake := newBlockingFakeResolver(2)
+	close(fake.release) // never block; this test is about the refresh, not concurrency
+	l := &SkillLoader{
+		state: &fakeLoaderState{},
+		services: Services{
+			SkillRepository:           newFakeSkillRepo(),
+			CatalogSourceRepository:   noopSourceRepo{},
+			PropertyOptionsRepository: po,
+		},
+		resolver: fake,
+		limits:   SyncLimits{MaxInFlightClones: 4, MaxRefsPerRepo: 10, MaxResolveWorkers: 4},
+		sem:      semaphore.NewWeighted(4),
+		sources:  twoGitSources(),
+		tickerWG: &sync.WaitGroup{},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, l.PerformLeaderOperations(ctx, mapset.NewSet[string]()))
+	l.state.WaitForInflightWrites(5 * time.Second)
+
+	// The refresher debounces, so a burst of source syncs collapses into at least one
+	// rebuild rather than one per source.
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt64(&po.refreshes) > 0
+	}, 5*time.Second, 50*time.Millisecond, "property options view was never refreshed after sync")
+}


### PR DESCRIPTION
…owns it

## Description
Each loader (agent, mcp, model, skill) deleted a source's shared CatalogSource status row as soon as its own entity type stopped referencing that source, without checking whether another plugin (model, mcp, agent, skill) still configured it. Since the status row is shared across all plugin types, this could delete a source's status out from under a plugin that still owns it, whenever two plugins configured the same source ID.

Gate the delete on allKnownSourceIDs — the union of every plugin's configured source IDs — in addition to each loader's own check.

Also wires the skill catalog's filter-options materialized view to refresh after sync/removal, so provider/category/label values reflect what's actually indexed instead of drifting until an unrelated catalog happens to trigger a refresh.

Assisted-by: Claude Sonnet 5

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
