### PR TITLE
fix(catalog): scope model source-id query, reject multi-repo inline s…

### DIFF
--- a/catalog/internal/catalog/modelcatalog/service/catalog_model.go
+++ b/catalog/internal/catalog/modelcatalog/service/catalog_model.go
@@ -270,38 +270,24 @@ func (r *CatalogModelRepositoryImpl) DeleteByID(id int32) error {
 }
 
 // GetDistinctSourceIDs retrieves all unique source_id values from catalog models.
-// This method queries the ContextProperty table to find distinct string_value entries
-// where the property name is 'source_id'.
+// The query is scoped to the model entity type via type_id so that source IDs
+// belonging to other catalog types (skills, MCP servers, agents) are not returned.
 func (r *CatalogModelRepositoryImpl) GetDistinctSourceIDs() ([]string, error) {
 	config := r.GetConfig()
-
 	var sourceIDs []string
 
-	// Execute the SQL query to get distinct source_id values
-	query := `SELECT DISTINCT string_value FROM "ContextProperty" WHERE name='source_id'`
+	propTableName := utils.GetTableName(config.DB, &schema.ContextProperty{})
+	tableName := utils.GetTableName(config.DB, &schema.Context{})
 
-	rows, err := config.DB.Raw(query).Rows()
+	err := config.DB.Table(propTableName+" cp").
+		Select("DISTINCT cp.string_value").
+		Joins("INNER JOIN "+tableName+" c ON cp.context_id = c.id").
+		Where("cp.name = ? AND c.type_id = ?", "source_id", config.TypeID).
+		Pluck("string_value", &sourceIDs).Error
 	if err != nil {
-		// Sanitize database errors to avoid exposing internal details to users
 		err = dbutil.SanitizeDatabaseError(err)
 		return nil, fmt.Errorf("error querying distinct source IDs: %w", err)
 	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var sourceID string
-		if err := rows.Scan(&sourceID); err != nil {
-			err = dbutil.SanitizeDatabaseError(err)
-			return nil, fmt.Errorf("error scanning source ID: %w", err)
-		}
-		sourceIDs = append(sourceIDs, sourceID)
-	}
-
-	if err := rows.Err(); err != nil {
-		err = dbutil.SanitizeDatabaseError(err)
-		return nil, fmt.Errorf("error iterating source ID rows: %w", err)
-	}
-
 	return sourceIDs, nil
 }
 

--- a/catalog/internal/catalog/skillcatalog/source_schema.go
+++ b/catalog/internal/catalog/skillcatalog/source_schema.go
@@ -181,6 +181,16 @@ func resolveRepositories(source basecatalog.PluginSource, props *skillSourceProp
 	case hasInline && hasFile:
 		return nil, fmt.Errorf("specify either %q (inline) or %q (file), not both", propRepositories, propYAMLCatalogPath)
 	case hasInline:
+		// The inline form is what the settings UI authors, and that form models a
+		// single repository: it edits repositories[0] and writes the list back as one
+		// entry. Accepting more here would let a source exist that the UI silently
+		// truncates on the next save. The file form below keeps the full list, so a
+		// platform team can still ship a multi-repo default via yamlCatalogPath.
+		if len(props.Repositories) > 1 {
+			return nil, fmt.Errorf(
+				"%q accepts a single repository (found %d); use %q to configure several",
+				propRepositories, len(props.Repositories), propYAMLCatalogPath)
+		}
 		return props.Repositories, nil
 	case hasFile:
 		return loadRepositoriesFile(source, props.YAMLCatalogPath)

--- a/catalog/internal/catalog/skillcatalog/source_schema_test.go
+++ b/catalog/internal/catalog/skillcatalog/source_schema_test.go
@@ -193,6 +193,42 @@ repositories:
 	assert.Contains(t, err.Error(), "not both")
 }
 
+func TestParseSkillSource_InlineMultipleRepositoriesRejected(t *testing.T) {
+	// The settings UI edits repositories[0] and writes the list back as a single
+	// entry, so an inline source with several repos would be silently truncated on
+	// the next save through the UI. Reject it at load time instead.
+	src := skillSource(mustProps(t, `
+repositories:
+  - url: https://github.com/example/skills.git
+  - url: https://github.com/example/more-skills.git
+`))
+	_, err := ParseSkillSource(src)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accepts a single repository")
+	assert.Contains(t, err.Error(), propYAMLCatalogPath)
+}
+
+func TestParseSkillSource_FileFormAllowsMultipleRepositories(t *testing.T) {
+	// The file form is authored by the platform team for shipped defaults, which the
+	// UI never writes, so it keeps the full list.
+	repoYAML := `
+repositories:
+  - url: https://github.com/example/skills.git
+    trustTier: platformProvided
+  - url: https://github.com/example/more-skills.git
+    trustTier: communityContributed
+`
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "repos.yaml"), []byte(repoYAML), 0o600))
+
+	src := skillSource(mustProps(t, `yamlCatalogPath: repos.yaml`))
+	src.Origin = filepath.Join(dir, "catalog-sources.yaml")
+
+	spec, err := ParseSkillSource(src)
+	require.NoError(t, err)
+	require.Len(t, spec.Repositories, 2)
+}
+
 func TestParseSkillSource_NeitherFormRejected(t *testing.T) {
 	src := skillSource(mustProps(t, `syncIntervalMinutes: 30`))
 	_, err := ParseSkillSource(src)
@@ -236,6 +272,22 @@ repositories:
 	require.NoError(t, err)
 }
 
+// multiRepoFileSource builds a source using the file form, the only form that
+// still accepts several repositories now that the inline form is single-repo.
+func multiRepoFileSource(t *testing.T, urls ...string) basecatalog.PluginSource {
+	t.Helper()
+	repoYAML := "repositories:\n"
+	for _, u := range urls {
+		repoYAML += "  - url: " + u + "\n"
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "repos.yaml"), []byte(repoYAML), 0o600))
+
+	src := skillSource(mustProps(t, `yamlCatalogPath: repos.yaml`))
+	src.Origin = filepath.Join(dir, "catalog-sources.yaml")
+	return src
+}
+
 func TestParseSkillSource_DuplicateRepoURL(t *testing.T) {
 	// Exact, host-case, and trailing-slash variants are all trivially equivalent
 	// and must be rejected as duplicates.
@@ -249,11 +301,7 @@ func TestParseSkillSource_DuplicateRepoURL(t *testing.T) {
 	}
 	for name, urls := range dupCases {
 		t.Run(name, func(t *testing.T) {
-			src := skillSource(mustProps(t, `
-repositories:
-  - url: `+urls[0]+`
-  - url: `+urls[1]+`
-`))
+			src := multiRepoFileSource(t, urls[0], urls[1])
 			_, err := ParseSkillSource(src)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "duplicate")
@@ -264,11 +312,10 @@ repositories:
 func TestParseSkillSource_DistinctPathCaseAllowed(t *testing.T) {
 	// Path case is preserved (git paths can be case-sensitive), so these are two
 	// distinct repositories, not duplicates.
-	src := skillSource(mustProps(t, `
-repositories:
-  - url: https://github.com/Example/skills.git
-  - url: https://github.com/example/skills.git
-`))
+	src := multiRepoFileSource(t,
+		"https://github.com/Example/skills.git",
+		"https://github.com/example/skills.git",
+	)
 	spec, err := ParseSkillSource(src)
 	require.NoError(t, err)
 	assert.Len(t, spec.Repositories, 2)


### PR DESCRIPTION
…kill sources

## Description
GetDistinctSourceIDs queried the shared ContextProperty table for name='source_id' with no filter on entity type. All catalog types (model, mcp, agent, skill) store a source_id property in that same table, so CatalogModelRepositoryImpl.GetDistinctSourceIDs could return source IDs belonging to other catalog types whenever they share a source ID. Join back to Context and scope by type_id so only model source IDs are returned.

Also reject skill source configs that specify more than one repository inline: the settings UI only edits and writes back repositories[0], so a multi-repo inline source would be silently truncated on the next UI save. Use `yamlCatalogPath` for shipped multi-repo defaults instead.

NOTE: the identity change was removed, that was there in previous commit as that was not needed

Assisted-by: Claude Sonnet 5

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).