### PR TITLE
feat(catalog): add skill catalog manifests and KEP examples

### DIFF
--- a/manifests/kustomize/options/catalog/base/deployment.yaml
+++ b/manifests/kustomize/options/catalog/base/deployment.yaml
@@ -32,6 +32,13 @@ spec:
       - name: mcp-sources
         configMap:
           name: mcp-catalog-sources
+      - name: skill-sources
+        configMap:
+          name: skill-catalog-sources
+      - name: skill-git-credentials
+        secret:
+          secretName: skill-catalog-git-credentials
+          optional: true
       containers:
         - name: catalog
           env:
@@ -60,6 +67,7 @@ spec:
             - --listen=0.0.0.0:8080
             - --catalogs-path=/catalog/sources.yaml
             - --catalogs-path=/mcp-catalog/sources.yaml
+            - --catalogs-path=/skill-catalog/sources.yaml
           image: ghcr.io/kubeflow/hub/server:latest
           ports:
             - name: http-api
@@ -86,3 +94,8 @@ spec:
             mountPath: /catalog
           - name: mcp-sources
             mountPath: /mcp-catalog
+          - name: skill-sources
+            mountPath: /skill-catalog
+          - name: skill-git-credentials
+            mountPath: /etc/skill-catalog/git-credentials
+            readOnly: true

--- a/manifests/kustomize/options/catalog/base/kustomization.yaml
+++ b/manifests/kustomize/options/catalog/base/kustomization.yaml
@@ -20,6 +20,12 @@ configMapGenerator:
   name: mcp-catalog-sources
   options:
     disableNameSuffixHash: true
+- behavior: create
+  files:
+  - sources.yaml=skill-sources.yaml
+  name: skill-catalog-sources
+  options:
+    disableNameSuffixHash: true
 
 secretGenerator:
 - name: model-catalog-postgres

--- a/manifests/kustomize/options/catalog/base/skill-sources.yaml
+++ b/manifests/kustomize/options/catalog/base/skill-sources.yaml
@@ -1,0 +1,1 @@
+skill_catalogs: []

--- a/manifests/kustomize/options/catalog/overlays/odh/default-sources.yaml
+++ b/manifests/kustomize/options/catalog/overlays/odh/default-sources.yaml
@@ -88,3 +88,4 @@ agent_catalogs:
       yamlCatalogPath: /shared-data/redhat-agents-catalog.yaml
     labels:
       - Red Hat Agents
+skill_catalogs: []

--- a/manifests/kustomize/options/ui/base/kustomization.yaml
+++ b/manifests/kustomize/options/ui/base/kustomization.yaml
@@ -7,6 +7,21 @@ resources:
 - model-registry-ui-deployment.yaml
 - model-registry-ui-service-account.yaml
 
+# Uncomment to support PRIVATE git repositories as skill catalog sources.
+#
+# Private repos need a per-repository token, and the skill catalog settings page
+# stores those tokens in the skill-catalog-git-credentials Secret. This component
+# creates that Secret and grants the model-registry-ui ServiceAccount the
+# namespaced get/update it needs to manage the Secret and the skill source
+# ConfigMaps. Leave it commented out if all your skill sources are public - the
+# catalog mounts the Secret with optional: true, so public repos work without it.
+#
+# Enabling this lets anyone who can reach the settings page write git credentials
+# and change which repositories the catalog clones, so turn it on deliberately.
+#
+# components:
+# - ../components/skill-catalog-settings
+
 images:
 - name: model-registry-ui
   newName: ghcr.io/kubeflow/hub/ui

--- a/manifests/kustomize/options/ui/components/skill-catalog-settings/kustomization.yaml
+++ b/manifests/kustomize/options/ui/components/skill-catalog-settings/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+# Opt-in only - required to support PRIVATE git repositories as skill catalog
+# sources. It grants the UI ServiceAccount write access to the skill catalog
+# source config and its git credentials, so it is not enabled by default.
+#
+# Enable it by uncommenting the components block in options/ui/base/kustomization.yaml,
+# or add it directly to an overlay:
+#
+#   components:
+#   - ../../components/skill-catalog-settings
+#
+# Public skill sources need none of this - the catalog mounts the credentials
+# Secret with optional: true.
+#
+resources:
+- skill-catalog-settings-rbac.yaml

--- a/manifests/kustomize/options/ui/components/skill-catalog-settings/skill-catalog-settings-rbac.yaml
+++ b/manifests/kustomize/options/ui/components/skill-catalog-settings/skill-catalog-settings-rbac.yaml
@@ -1,0 +1,95 @@
+---
+# The skill catalog settings page lets an admin manage skill sources and their git
+# tokens. The BFF runs with --auth-method=internal, so these calls are made as the
+# model-registry-ui ServiceAccount rather than as the signed-in user, and the
+# catalog runs in the same namespace as the UI. A namespaced Role keeps this off
+# every other namespace's Secrets.
+#
+# Every rule below is pinned with resourceNames, and no rule grants `create`.
+# That is deliberate: Kubernetes does not evaluate resourceNames for `create`
+# (the object name is not known at authorization time), so an unnamed
+# `create` on secrets would let this ServiceAccount mint a
+# kubernetes.io/service-account-token Secret for any ServiceAccount in the
+# namespace and then read the resulting token back through the named `get` rule.
+# Instead, every object the settings page writes is pre-created:
+#   - skill-catalog-sources comes from the catalog's configMapGenerator
+#     (disableNameSuffixHash: true, so the name is stable)
+#   - skill-catalog-git-credentials is the empty Secret created below
+#
+# If the Secret name changes, update the catalog Deployment's volume to match.
+#
+# default-catalog-sources only ever needs `get`: the BFF reads it to merge
+# platform-shipped defaults with user sources but never writes to it (see
+# GetAllSkillCatalogSourceConfigs in shared_k8s_client.go). Granting `update`
+# there would let this ServiceAccount overwrite platform-managed defaults for
+# every catalog type (model/mcp/skill all share this one ConfigMap) for no
+# functional benefit, so it is deliberately excluded.
+#
+# skill-catalog-sources IS the ConfigMap the settings page writes to, and it
+# is also configMapGenerator-owned. On a GitOps deployment (kubectl apply -k /
+# ArgoCD), the next sync regenerates its data from skill-sources.yaml and
+# silently reverts any source an admin added through the UI. Models and MCP
+# have this same exposure once their own settings pages gain write RBAC;
+# skills need a genuinely user-managed (non-generated) ConfigMap before this
+# Role is safe to enable anywhere GitOps reconciles the catalog manifests.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: skill-catalog-git-credentials
+  annotations:
+    # Created empty so the settings page can populate it with `update` alone and
+    # never needs the `create` verb. The catalog Deployment mounts it with
+    # optional: true, so an empty Secret simply yields no token files.
+    kubeflow.org/description: >-
+      Per-repository git tokens for private skill catalog sources, keyed by each
+      repository's credentialRef. Managed by the skill catalog settings page.
+type: Opaque
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: model-registry-ui-skill-catalog-settings
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  resourceNames:
+  - default-catalog-sources
+  verbs:
+  - get
+# TODO: skill-catalog-sources is kustomize-generated, so a source an admin adds
+# through the settings page is reverted on the next GitOps sync. Models and MCP
+# will hit this same issue once their own settings pages gain write RBAC; skills
+# need a genuinely user-managed (non-generated) ConfigMap before this rule is
+# safe to enable by default anywhere.
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  resourceNames:
+  - skill-catalog-sources
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  resourceNames:
+  - skill-catalog-git-credentials
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: model-registry-ui-skill-catalog-settings-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: model-registry-ui-skill-catalog-settings
+subjects:
+- kind: ServiceAccount
+  name: model-registry-ui

--- a/proposals/KEP-0005-skills-catalog/README.md
+++ b/proposals/KEP-0005-skills-catalog/README.md
@@ -38,31 +38,66 @@ A standard Hub catalog plugin, following the existing plugin architecture.
 
 Registered like any other catalog source, as `type: git-skills-plugin`. A source lists git repositories and their catalog metadata. The repository list can live in the source config **inline** (used by UI-added sources - written to the user-managed ConfigMap, editable like an `hf` source) or **via a file** (`yamlCatalogPath`, used by shipped defaults that bundle many repos). The loader accepts both.
 
+The two forms differ in how many repositories they accept. The **inline** form takes exactly one: it is what the settings UI writes, and that form edits a single repository, so a source carrying several would be silently truncated the next time an admin saved it. The loader rejects an inline list of more than one rather than allowing that state to exist. The **file** form keeps the full list, so a platform team can still ship a multi-repo default through `yamlCatalogPath`; those sources are read-only in the UI and never rewritten by it. An operator who needs several repositories under UI management registers them as separate sources.
+
 ```yaml
 # inline form (UI-added source in the user-managed ConfigMap)
 - name: Community Skills
   id: community-skills
   type: git-skills-plugin
   enabled: true
-  trustTier: communityContributed
-  repositories:
-    - url: https://github.com/example/skills.git
-      refs: [v1.0, abc1234]       # optional; tags, releases, or commit SHAs only -
-                                  #   branches are not accepted (not reproducible).
-                                  #   Each ref yields its own catalog entries.
-                                  #   Also: scanPaths, authSecretName,
-                                  #   canonicalUrl (when url is a mirror)
-      provider: Example Org
-      category: DevOps
-      labels: [community]
-      includedSkills: ["*"]
-      excludedSkills: ["*-draft"]
-      skillOverrides: [{name: deploy, category: SRE}]
+  properties:                       # the repository list and its metadata live here
+    syncIntervalMinutes: 60         # optional
+    repositories:
+      - url: https://github.com/example/skills.git
+        refs: [v1.0, abc1234]       # optional; tags, releases, or commit SHAs only -
+                                    #   branches are not accepted (not reproducible).
+                                    #   Each ref yields its own catalog entries.
+                                    #   Also: scanPaths, credentialRef,
+                                    #   canonicalUrl (when url is a mirror)
+        trustTier: communityContributed
+        provider: Example Org
+        category: DevOps
+        labels: [community]
+        includedSkills: ["*"]
+        excludedSkills: ["*-draft"]
+        skillOverrides: [{name: deploy, category: SRE}]
 ```
 
-Each time the catalog syncs, the plugin reads each listed repository at each listed ref (making a temporary, lightweight copy used only for parsing, then throwing it away), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref (a tag, release, or commit SHA), and the exact commit it resolved to is recorded as `resolvedCommit`. Branches are not accepted as refs; the source schema rejects them so that every entry is reproducible. Skills, refs, repositories, or sources that have been removed are cleaned up. Pulling from private git repositories with securely configured credentials will be supported.
+```yaml
+# file form (shipped default, read-only in the UI)
+- name: Platform Skills
+  id: platform-skills
+  type: git-skills-plugin
+  enabled: true
+  properties:
+    yamlCatalogPath: /shared-data/platform-skills-catalog.yaml
+    syncIntervalMinutes: 60         # optional
+```
 
-Source management reuses the same mechanism as the model and MCP catalogs: read-only defaults (shipped in a ConfigMap) merged with a user-managed ConfigMap that the settings UI writes via the BFF, with per-source auth stored as Secrets. Adding a skills git source through the UI works like adding a HuggingFace source for models. Editing the ConfigMap directly (kubectl/GitOps) works too; the file-watcher picks up either path.
+```yaml
+# /shared-data/platform-skills-catalog.yaml - the repository list, same schema
+# as the inline `repositories` block, but with no one-repository limit
+repositories:
+  - url: https://github.com/example/platform-skills.git
+    refs: [v2.1]
+    trustTier: platformProvided
+    provider: Example Platform Team
+    category: SRE
+  - url: https://github.com/example/partner-skills.git
+    refs: [v1.4]
+    trustTier: partnerVerified
+    provider: Example Partner
+    category: DevOps
+```
+
+`trustTier`, `provider`, and `category` are per-repository, not per-source: a file-form source may list repositories with different provenance (an inline source has a single repository, so for those the distinction does not arise). The `properties` block is decoded strictly - an unrecognised key fails the whole source rather than being ignored - so these must not be lifted to the source level.
+
+Each time the catalog syncs, the plugin reads each listed repository at each listed ref (making a temporary, lightweight copy used only for parsing, then throwing it away), finds and parses `SKILL.md` files per the specification, and rebuilds the index. A skill's `version` is the ref (a tag, release, or commit SHA), and the exact commit it resolved to is recorded as `resolvedCommit`. Branches are not accepted as refs. A ref cannot be classified by name alone — `main` and `v1.0` are indistinguishable as strings, and a tag may legitimately be called `main` — so the resolver asks the remote at sync time and refuses anything that resolves to a branch or `HEAD`, failing closed if the check itself fails. The source preview runs the same resolver, so an admin sees the rejection before saving. Skills, refs, repositories, or sources that have been removed are cleaned up. Private git repositories are read with a token supplied through `credentialRef`, described below.
+
+Source management reuses the same mechanism as the model and MCP catalogs: read-only defaults (shipped in a ConfigMap) merged with a user-managed ConfigMap that the settings UI writes via the BFF. Adding a skills git source through the UI works like adding a HuggingFace source for models. Editing the ConfigMap directly (kubectl/GitOps) works too; the file-watcher picks up either path.
+
+Git credentials are held in a single `skill-catalog-git-credentials` Secret mounted read-only into the catalog pod at `/etc/skill-catalog/git-credentials`, one key per source. A repository's `credentialRef` names the key to read - it is a plain filename within that mount, not a Secret name. The catalog service has no Kubernetes API access and so cannot resolve Secrets by name; it only reads the mounted files. When an admin enters a token in the settings UI, the BFF writes it as a key in that Secret and sets `credentialRef` to match. The token file is re-read on every sync, so kubelet's in-place refresh of the mount applies a rotated credential without restarting the pod.
 
 ### 3. Custom metadata
 
@@ -103,7 +138,7 @@ Follows the MCP catalog UI, built on the shared catalog components, with a BFF (
 
 Source URLs are treated as trusted: managing sources requires admin access (settings page) or configuration access (ConfigMap/GitOps edits), the same trust boundary as the other catalogs. The operational risk is resource exhaustion, not untrusted input.
 
-- **Hub fetches remote content at sync** → only temporary, lightweight copies are made (kept isolated and cleaned up afterward); content is only parsed, never executed; private repositories authenticate through Kubernetes Secrets. Concrete limits bound the blast radius: a per-clone timeout, a maximum repository size, a maximum number of refs per repository, and a global cap on in-flight clones so a large source set (many repositories × many refs) cannot saturate the pod.
+- **Hub fetches remote content at sync** → only temporary, lightweight copies are made (kept isolated and cleaned up afterward); content is only parsed, never executed; private repositories authenticate with tokens from a read-only Secret mount, passed to git via `GIT_ASKPASS` so they never appear in argv, a URL, or a log line. Concrete limits bound the blast radius: a per-clone timeout, a maximum repository size, a maximum number of refs per repository, and a global cap on in-flight clones so a large source set (many repositories × many refs) cannot saturate the pod.
 - **Sync storms from rapid config changes** → hot-reload is debounced, so a burst of ConfigMap edits (UI or GitOps) coalesces into a single sync rather than a fetch storm.
 - **A source in trouble** → shown as a degraded source status; a content-scanning hook is planned for the future.
 

--- a/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
+++ b/proposals/KEP-0005-skills-catalog/skill-catalog-architecture.md
@@ -75,7 +75,7 @@ sequenceDiagram
     L->>L: remove skills from deleted sources
     loop each source file, each repo and ref
         L->>R: resolve(repo, ref)
-        R->>R: make a temporary copy at ref (Secret auth, limits)
+        R->>R: make a temporary copy at ref (credentialRef token via GIT_ASKPASS, limits)
         R->>R: find SKILL.md, parse + validate (lenient)
         R->>R: version = ref, resolvedCommit = SHA
         R->>R: apply custom metadata (tier, provider, category, labels, overrides)
@@ -88,7 +88,7 @@ sequenceDiagram
 
 ## 5. Identity - Canonical vs Fetch URL
 
-Internal IDs are not stable, since the index is just a cache. The canonical identity is the only permanent reference, and it stays the same even when a deployment reads through a different URL. `version` (the ref — a tag, release, or commit SHA) tells entries apart. Branches are not accepted as refs; the source schema rejects them so that every entry resolves to a fixed, reproducible commit. Every entry records the commit it resolved to (`resolvedCommit`), which the marketplace carries as the `sha` pin.
+Internal IDs are not stable, since the index is just a cache. The canonical identity is the only permanent reference, and it stays the same even when a deployment reads through a different URL. `version` (the ref — a tag, release, or commit SHA) tells entries apart. Branches are not accepted as refs; the resolver refuses them at sync time (the check queries the remote, since a ref cannot be classified by name alone) so that every entry resolves to a fixed, reproducible commit. Every entry records the commit it resolved to (`resolvedCommit`), which the marketplace carries as the `sha` pin.
 
 ```mermaid
 flowchart TB
@@ -100,12 +100,12 @@ flowchart TB
 
 ## 6. Custom Metadata - Who Sets Tier / Provider / Category
 
-Custom metadata lives in the source files and is applied at sync time. It is never kept in the rebuildable index and never read from repository content. Source management reuses the existing model/MCP catalog-settings mechanism: read-only default sources merged with a user-managed ConfigMap that the settings UI writes via the BFF (auth as Secrets). Adding a skills git source through the UI works like adding a HuggingFace source for models; editing the ConfigMap directly (kubectl / GitOps) works too. `trustTier` is simply a label (`platformProvided`, `partnerVerified`, `organizationApproved`, or `communityContributed`), shown as a badge and available as a filter, with no ordering or special meaning.
+Custom metadata lives in the source files and is applied at sync time. It is never kept in the rebuildable index and never read from repository content. Source management reuses the existing model/MCP catalog-settings mechanism: read-only default sources merged with a user-managed ConfigMap that the settings UI writes via the BFF (git tokens go to the mounted `skill-catalog-git-credentials` Secret, referenced from a repository by `credentialRef`, never into the ConfigMap). Adding a skills git source through the UI works like adding a HuggingFace source for models; editing the ConfigMap directly (kubectl / GitOps) works too. `trustTier` is simply a label (`platformProvided`, `partnerVerified`, `organizationApproved`, or `communityContributed`), shown as a badge and available as a filter, with no ordering or special meaning. It is declared per repository entry, which matters for file-form sources: an inline (UI-written) source carries exactly one repository, so its metadata is effectively per-source, while a file-form default can list repositories of differing provenance.
 
 | Entry path | Who | Sets |
 |---|---|---|
 | Default sources (read-only; Part II) | Platform team | All fields; read-only in the UI |
-| User-managed sources (admin settings UI or kubectl / GitOps) | Catalog admins | All fields; UI writes the user-managed ConfigMap |
+| User-managed sources (admin settings UI or kubectl / GitOps) | Catalog admins | All fields; UI writes the user-managed ConfigMap. Repositories are inline, one per source |
 | `skillOverrides` on a repo entry | Either | Per-skill category/labels |
 | SKILL.md `metadata` frontmatter | Skill authors | `customProperties` only, never tier/provider |
 


### PR DESCRIPTION
## Description

Wire the skill catalog source into the catalog deployment: seed an empty skill-catalog-sources ConfigMap, mount it at /skill-catalog, pass an extra --catalogs-path, and optionally mount the
skill-catalog-git-credentials Secret. Declare an empty skill_catalogs section in the ODH default sources.

Add a skill-catalog-settings UI component with its RBAC. The ConfigMap permissions match what the model and MCP catalog settings pages need and stay within that shape: `get` on the shared default-catalog-sources (defaults are read to merge with user sources, never written) and `get`/`update` on skill-catalog-sources alone. Every rule is pinned with resourceNames and none grants `create`, since Kubernetes does not evaluate resourceNames for `create` and an unnamed `create` on secrets would let the ServiceAccount mint a service-account-token Secret and read it back; both objects the settings page writes are pre-created by the manifests. **One caveat carries over to the other catalogs:** skill-catalog-sources is kustomize-generated, so on a GitOps deployment the next sync reverts UI-added sources, this is accepted risk as other catalogs. An operator model solves this issue.

Also document the file form of a skill source (yamlCatalogPath) in KEP-0005 alongside the existing inline example.

Assisted-by: Claude Code

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).