### PR TITLE
UI: 0-feat(bff): add skill catalog endpoints

### DIFF
--- a/clients/ui/bff/cmd/main.go
+++ b/clients/ui/bff/cmd/main.go
@@ -42,6 +42,9 @@ func main() {
 	flag.BoolVar(&cfg.DevMode, "dev-mode", false, "Use development mode for access to local K8s cluster")
 	flag.IntVar(&cfg.DevModeModelRegistryPort, "dev-mode-model-registry-port", getEnvAsInt("DEV_MODE_MODEL_REGISTRY_PORT", 8080), "Use port when in development mode for model registry")
 	flag.IntVar(&cfg.DevModeCatalogPort, "dev-mode-catalog-port", getEnvAsInt("DEV_MODE_CATALOG_PORT", 8081), "Use port when in development mode for catalog")
+	flag.StringVar(&cfg.DevModeCatalogNamespace, "dev-mode-catalog-namespace", getEnvAsString("DEV_MODE_CATALOG_NAMESPACE", ""), "Namespace where the catalog service runs in dev mode (used for skill catalog settings ConfigMap writes)")
+	flag.StringVar(&cfg.SkillCatalogGitCredentialsSecret, "skill-catalog-git-credentials-secret", getEnvAsString("SKILL_CATALOG_GIT_CREDENTIALS_SECRET", "skill-catalog-git-credentials"), "Name of the Secret mounted into the catalog pod holding per-source git tokens, keyed by skill source id")
+	flag.StringVar(&cfg.SkillCatalogMarketplaceURL, "skill-catalog-marketplace-url", getEnvAsString("SKILL_CATALOG_MARKETPLACE_URL", ""), "External URL of the catalog's claude/marketplace.json, shown in skill install instructions. Empty (default) uses the catalog's in-cluster address, which suits agents running in the cluster; set this when the catalog is exposed through a Route or Ingress")
 
 	// New deployment mode flag
 	flag.Var(&cfg.DeploymentMode, "deployment-mode", "Deployment mode (kubeflow, federated, or standalone)")

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -108,6 +108,20 @@ const (
 	McpCatalogSettingsPathPrefix           = SettingsPath + "/mcp_catalog"
 	McpCatalogSettingsSourceConfigListPath = McpCatalogSettingsPathPrefix + "/source_configs"
 	McpCatalogSettingsSourceConfigPath     = McpCatalogSettingsSourceConfigListPath + "/:" + CatalogSourceId
+
+	// Skill catalog
+	SkillId                     = "skill_id"
+	SkillCatalogPathPrefix      = ApiPathPrefix + "/skill_catalog"
+	SkillListPath               = SkillCatalogPathPrefix + "/skills"
+	SkillFilterOptionListPath   = SkillCatalogPathPrefix + "/skills_filter_options"
+	SkillPath                   = SkillListPath + "/:" + SkillId
+	SkillCatalogMarketplacePath = SkillCatalogPathPrefix + "/claude/marketplace.json"
+
+	// Skill catalog settings
+	SkillCatalogSettingsPathPrefix           = SettingsPath + "/skill_catalog"
+	SkillCatalogSettingsSourceConfigListPath = SkillCatalogSettingsPathPrefix + "/source_configs"
+	SkillCatalogSettingsSourceConfigPath     = SkillCatalogSettingsSourceConfigListPath + "/:" + CatalogSourceId
+	SkillCatalogSettingsSourcePreviewPath    = SkillCatalogSettingsPathPrefix + "/source_preview"
 )
 
 type App struct {
@@ -362,6 +376,20 @@ func (app *App) Routes() http.Handler {
 		apiRouter.GET(McpCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.GetMcpCatalogSourceConfigHandler)))
 		apiRouter.PATCH(McpCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.UpdateMcpCatalogSourceConfigHandler)))
 		apiRouter.DELETE(McpCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.DeleteMcpCatalogSourceConfigHandler)))
+
+		// Skill catalog endpoints
+		apiRouter.GET(SkillListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetAllSkillsHandler))))
+		apiRouter.GET(SkillFilterOptionListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetSkillsFiltersHandler))))
+		apiRouter.GET(SkillPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetSkillHandler))))
+		apiRouter.GET(SkillCatalogMarketplacePath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetSkillMarketplaceHandler))))
+
+		// Skill catalog settings page
+		apiRouter.GET(SkillCatalogSettingsSourceConfigListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.GetAllSkillCatalogSourceConfigsHandler)))
+		apiRouter.POST(SkillCatalogSettingsSourceConfigListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.CreateSkillCatalogSourceConfigHandler)))
+		apiRouter.GET(SkillCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.GetSkillCatalogSourceConfigHandler)))
+		apiRouter.PATCH(SkillCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.UpdateSkillCatalogSourceConfigHandler)))
+		apiRouter.DELETE(SkillCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.DeleteSkillCatalogSourceConfigHandler)))
+		apiRouter.POST(SkillCatalogSettingsSourcePreviewPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.CreateCatalogSourcePreviewHandler))))
 	}
 
 	// App Router

--- a/clients/ui/bff/internal/api/middleware.go
+++ b/clients/ui/bff/internal/api/middleware.go
@@ -104,28 +104,38 @@ func (app *App) AttachModelCatalogRESTClient(next func(http.ResponseWriter, *htt
 			return
 		}
 
-		modelCatalog, err := app.repositories.ModelCatalog.GetModelCatalogWithMode(r.Context(), client, namespace, app.config.DeploymentMode.IsFederatedMode())
-		if err != nil {
-			app.notFoundResponse(w, r)
-			return
-		}
 		apiPath := repositories.ModelCatalogAPIPath
 		if strings.HasPrefix(r.URL.Path, McpServerCatalogPathPrefix) {
 			apiPath = repositories.McpCatalogAPIPath
 		} else if strings.HasPrefix(r.URL.Path, AgentCatalogPathPrefix) {
 			apiPath = repositories.AgentCatalogAPIPath
+		} else if strings.HasPrefix(r.URL.Path, SkillCatalogPathPrefix) {
+			apiPath = repositories.SkillCatalogAPIPath
 		}
 
-		modelCatalogBaseURL := modelCatalog.ServerAddress
-		if apiPath != repositories.ModelCatalogAPIPath {
-			modelCatalogBaseURL = strings.Replace(modelCatalogBaseURL, repositories.ModelCatalogAPIPath, apiPath, 1)
-		}
-
-		// If we are in dev mode, we need to resolve the server address to the local host
-		// to allow the client to connect to the model registry via port forwarded from the cluster to the local machine.
-		// If you are in federated mode, we do not want to override the server address.
+		var modelCatalogBaseURL string
+		// In dev mode (non-federated), the catalog is reached via a local port-forward to
+		// the pod's own container port, which always serves plain HTTP here (the catalog
+		// binary is started with no TLS cert/key; any TLS a real deployment terminates
+		// happens at a Service/Route in front of it, which port-forwarding bypasses). Skip
+		// the K8s service lookup entirely in this branch — it also isn't reliable for this
+		// purpose: it requires the Service to carry a plain `component` label matching
+		// ModelCatalogServiceName's expected value, which this repo's own kustomize
+		// manifests don't set (they use `app.kubernetes.io/component` instead), so the
+		// lookup fails even outside dev mode. That mismatch is pre-existing and unrelated
+		// to skills — out of scope here.
 		if app.config.DevMode && !app.config.DeploymentMode.IsFederatedMode() {
-			modelCatalogBaseURL = app.repositories.ModelCatalog.ResolveServerAddress("localhost", int32(app.config.DevModeCatalogPort), modelCatalog.IsHTTPS, "", app.config.DeploymentMode.IsFederatedMode(), apiPath)
+			modelCatalogBaseURL = app.repositories.ModelCatalog.ResolveServerAddress("localhost", int32(app.config.DevModeCatalogPort), false, "", false, apiPath)
+		} else {
+			modelCatalog, err := app.repositories.ModelCatalog.GetModelCatalogWithMode(r.Context(), client, namespace, app.config.DeploymentMode.IsFederatedMode())
+			if err != nil {
+				app.notFoundResponse(w, r)
+				return
+			}
+			modelCatalogBaseURL = modelCatalog.ServerAddress
+			if apiPath != repositories.ModelCatalogAPIPath {
+				modelCatalogBaseURL = strings.Replace(modelCatalogBaseURL, repositories.ModelCatalogAPIPath, apiPath, 1)
+			}
 		}
 
 		// Set up a child logger for the rest client that automatically adds the request id to all statements for

--- a/clients/ui/bff/internal/api/skill_catalog_handler.go
+++ b/clients/ui/bff/internal/api/skill_catalog_handler.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/hub/ui/bff/internal/constants"
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/httpclient"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	"github.com/kubeflow/hub/ui/bff/internal/repositories"
+)
+
+// catalogServicePort is the port the catalog Service exposes
+// (manifests/kustomize/options/catalog/base/service.yaml).
+const catalogServicePort = 8080
+
+type SkillListEnvelope Envelope[*models.SkillList, None]
+type SkillFilterOptionsListEnvelope Envelope[*models.FilterOptionsList, None]
+type SkillEnvelope Envelope[*models.Skill, None]
+
+func (app *App) GetAllSkillsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelCatalogHttpClientKey).(httpclient.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("catalog REST client not found"))
+		return
+	}
+
+	skills, err := app.repositories.ModelCatalogClient.GetAllSkills(client, r.URL.Query())
+	if err != nil {
+		var httpErr *httpclient.HTTPError
+		if errors.As(err, &httpErr) {
+			app.errorResponse(w, r, httpErr)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillListEnvelope{Data: skills}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) GetSkillsFiltersHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	catalogClient, ok := ctx.Value(constants.ModelCatalogHttpClientKey).(httpclient.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("catalog REST client not found"))
+		return
+	}
+
+	filters, err := app.repositories.ModelCatalogClient.GetSkillsFilter(catalogClient)
+	if err != nil {
+		var httpErr *httpclient.HTTPError
+		if errors.As(err, &httpErr) {
+			app.errorResponse(w, r, httpErr)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	// Filter options come solely from the catalog service, which enumerates them from
+	// indexed skills. The BFF used to merge in provider/category/trustTier from the source
+	// ConfigMaps as well; that was redundant once a source synced (buildSkillEntity stamps
+	// those onto every skill, so they are already enumerated) and actively misleading
+	// before it did, offering filter values that matched nothing.
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillFilterOptionsListEnvelope{Data: filters}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) GetSkillHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelCatalogHttpClientKey).(httpclient.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("catalog REST client not found"))
+		return
+	}
+
+	skillId := ps.ByName(SkillId)
+	if skillId == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("skill_id is required"))
+		return
+	}
+
+	skill, err := app.repositories.ModelCatalogClient.GetSkill(client, skillId, r.URL.Query())
+	if err != nil {
+		var httpErr *httpclient.HTTPError
+		if errors.As(err, &httpErr) {
+			app.errorResponse(w, r, httpErr)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillEnvelope{Data: skill}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// SkillMarketplaceMetadata carries the URL an agent should hand to
+// `/plugin marketplace add`. It is not the URL of this BFF endpoint: this route is
+// namespace-scoped and authenticated, which an agent cannot satisfy, while the catalog
+// service serves marketplace.json unauthenticated.
+type SkillMarketplaceMetadata struct {
+	MarketplaceURL string `json:"marketplaceUrl"`
+	// External is true when an operator configured an externally reachable URL. When
+	// false the URL resolves only inside the cluster, and the UI says so.
+	External bool `json:"external"`
+}
+
+type SkillMarketplaceEnvelope Envelope[*models.SkillMarketplace, SkillMarketplaceMetadata]
+
+// skillMarketplaceURL returns the marketplace.json URL to advertise.
+//
+// The default is the catalog service's in-cluster DNS address, which is what agents
+// running in the cluster need. It is built from constants rather than a Service lookup
+// on purpose: GetModelCatalogWithMode matches on a bare `component` label that this
+// repo's manifests do not set, so the lookup cannot be relied on here.
+//
+// An operator who puts the catalog behind a Route or Ingress sets
+// SkillCatalogMarketplaceURL, and that value wins.
+func (app *App) skillMarketplaceURL(userNamespace string) (string, bool) {
+	if configured := app.config.SkillCatalogMarketplaceURL; configured != "" {
+		return configured, true
+	}
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s/claude/marketplace.json",
+		repositories.ModelCatalogServiceName,
+		app.skillCatalogNamespace(userNamespace),
+		catalogServicePort,
+		repositories.SkillCatalogAPIPath,
+	), false
+}
+
+// GetSkillMarketplaceHandler proxies to the catalog service's claude/marketplace.json
+// endpoint, giving the UI the real, backend-computed plugin/marketplace names and
+// pinned commit for building install commands, instead of guessing them client-side.
+func (app *App) GetSkillMarketplaceHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelCatalogHttpClientKey).(httpclient.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("catalog REST client not found"))
+		return
+	}
+
+	marketplace, err := app.repositories.ModelCatalogClient.GetSkillMarketplace(client, r.URL.Query())
+	if err != nil {
+		var httpErr *httpclient.HTTPError
+		if errors.As(err, &httpErr) {
+			app.errorResponse(w, r, httpErr)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	namespace, _ := r.Context().Value(constants.NamespaceHeaderParameterKey).(string)
+	marketplaceURL, external := app.skillMarketplaceURL(namespace)
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillMarketplaceEnvelope{
+		Data:     marketplace,
+		Metadata: SkillMarketplaceMetadata{MarketplaceURL: marketplaceURL, External: external},
+	}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/clients/ui/bff/internal/api/skill_catalog_handler_test.go
+++ b/clients/ui/bff/internal/api/skill_catalog_handler_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/kubeflow/hub/ui/bff/internal/config"
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestSkillCatalogFilters", func() {
+	var requestIdentity kubernetes.RequestIdentity
+
+	BeforeEach(func() {
+		requestIdentity = kubernetes.RequestIdentity{UserID: "user@example.com"}
+	})
+
+	// Filter options come from the catalog service alone. The BFF used to merge
+	// provider/category/trustTier from the source ConfigMaps on top; that offered filter
+	// values matching no indexed skill, so a user could select one and get nothing back.
+	It("returns only the catalog service's filter options", func() {
+		body, rs, err := setupApiTest[SkillFilterOptionsListEnvelope](
+			http.MethodGet,
+			"/api/v1/skill_catalog/skills_filter_options?namespace=kubeflow",
+			nil,
+			kubernetesMockedStaticClientFactory,
+			requestIdentity,
+			"kubeflow",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+		// The catalog client mock returns no filters, and the seeded ConfigMap sources
+		// carry provider "Community" and trustTier "communityContributed". Neither may
+		// appear now that the ConfigMap merge is gone.
+		if body.Data != nil && body.Data.Filters != nil {
+			Expect(*body.Data.Filters).To(BeEmpty())
+		}
+	})
+})
+
+var _ = Describe("TestSkillMarketplace", func() {
+	var requestIdentity kubernetes.RequestIdentity
+
+	BeforeEach(func() {
+		requestIdentity = kubernetes.RequestIdentity{UserID: "user@example.com"}
+	})
+
+	It("advertises the catalog's in-cluster URL when no override is configured", func() {
+		body, rs, err := setupApiTest[SkillMarketplaceEnvelope](
+			http.MethodGet,
+			"/api/v1/skill_catalog/claude/marketplace.json?namespace=kubeflow",
+			nil,
+			kubernetesMockedStaticClientFactory,
+			requestIdentity,
+			"kubeflow",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+		// Never this BFF route: it is namespace-scoped and authenticated, which an agent
+		// running `/plugin marketplace add` cannot satisfy.
+		Expect(body.Metadata.MarketplaceURL).To(Equal(
+			"http://model-catalog.kubeflow.svc.cluster.local:8080/api/skill_catalog/v1/claude/marketplace.json"))
+		Expect(body.Metadata.External).To(BeFalse())
+	})
+
+	It("uses the catalog namespace in dev mode rather than the request namespace", func() {
+		body, rs, err := setupApiTestWithConfig[SkillMarketplaceEnvelope](
+			http.MethodGet,
+			"/api/v1/skill_catalog/claude/marketplace.json?namespace=bella-namespace",
+			nil,
+			kubernetesMockedStaticClientFactory,
+			requestIdentity,
+			"bella-namespace",
+			func(cfg *config.EnvConfig) {
+				cfg.DevMode = true
+				cfg.DevModeCatalogNamespace = "kubeflow"
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		Expect(body.Metadata.MarketplaceURL).To(ContainSubstring("model-catalog.kubeflow.svc"))
+	})
+
+	It("prefers an operator-configured external URL", func() {
+		body, rs, err := setupApiTestWithConfig[SkillMarketplaceEnvelope](
+			http.MethodGet,
+			"/api/v1/skill_catalog/claude/marketplace.json?namespace=kubeflow",
+			nil,
+			kubernetesMockedStaticClientFactory,
+			requestIdentity,
+			"kubeflow",
+			func(cfg *config.EnvConfig) {
+				cfg.SkillCatalogMarketplaceURL = "https://hub.example.com/api/skill_catalog/v1/claude/marketplace.json"
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		Expect(body.Metadata.MarketplaceURL).To(Equal(
+			"https://hub.example.com/api/skill_catalog/v1/claude/marketplace.json"))
+		Expect(body.Metadata.External).To(BeTrue())
+	})
+})

--- a/clients/ui/bff/internal/api/skill_catalog_settings_handler.go
+++ b/clients/ui/bff/internal/api/skill_catalog_settings_handler.go
@@ -1,0 +1,391 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/hub/ui/bff/internal/constants"
+	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	"github.com/kubeflow/hub/ui/bff/internal/repositories"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type SkillCatalogSettingsSourceConfigEnvelope Envelope[*models.SkillCatalogSourceConfig, None]
+type SkillCatalogSettingsSourceConfigListEnvelope Envelope[*models.SkillCatalogSourceConfigList, None]
+type SkillCatalogSourcePayloadEnvelope Envelope[*models.SkillCatalogSourceConfigPayload, None]
+
+// skillCatalogNamespace returns the namespace to use for skill catalog ConfigMap reads/writes.
+// In dev mode with a catalog namespace configured, that namespace is used so the catalog service
+// (which may be in a different namespace than the user) can see the changes.
+// In production, user namespace equals catalog namespace, so the user namespace is always correct.
+func (app *App) skillCatalogNamespace(userNamespace string) string {
+	if app.config.DevMode && app.config.DevModeCatalogNamespace != "" {
+		return app.config.DevModeCatalogNamespace
+	}
+	return userNamespace
+}
+
+// pendingSkillCredential is a git token that belongs in the shared git-credentials
+// Secret once the source it belongs to has actually been persisted.
+type pendingSkillCredential struct {
+	key   string
+	token string
+}
+
+// prepareSkillRepoCredentials moves any admin-supplied git token out of the payload
+// and points the repository at where that token will live, via credentialRef. It does
+// not write the Secret: the token is returned for commitSkillRepoCredential to store
+// once the source has been persisted.
+//
+// The catalog service has no Kubernetes API access: it resolves credentialRef as a
+// filename inside the Secret mounted at /etc/skill-catalog/git-credentials (see
+// catalog/internal/catalog/skillcatalog/credentials.go), reading it through
+// GIT_ASKPASS for every clone. So the value written to the ConfigMap must be the
+// *key* within that one Secret, not a Secret name, and credentialRef has to be set
+// before the ConfigMap is written. kubelet refreshes the mount in place, so a newly
+// added key becomes readable without restarting the catalog pod.
+//
+// The token itself is cleared from the payload here so it can never reach the
+// ConfigMap or a response body.
+func (app *App) prepareSkillRepoCredentials(
+	sourceID string,
+	payload *models.SkillCatalogSourceConfigPayload,
+) (*pendingSkillCredential, error) {
+	// A source carries a single repository (validateSkillRepositories enforces it), so
+	// there is at most one token. This runs before that validation, though — the token
+	// must leave the payload before anything can persist it — so the extra repositories
+	// are still rejected here rather than assuming index 0.
+	tokenIdx := -1
+	for i := range payload.Repositories {
+		tok := payload.Repositories[i].AuthToken
+		if tok != nil && *tok != "" {
+			if tokenIdx >= 0 {
+				return nil, fmt.Errorf("%w: a source accepts a single repository, so only one auth token",
+					repositories.ErrSkillCatalogValidationFailed)
+			}
+			tokenIdx = i
+		}
+	}
+
+	if tokenIdx < 0 {
+		// No new token: clear the write-only field and keep any existing
+		// credentialRef the client round-tripped from a previous read.
+		for i := range payload.Repositories {
+			payload.Repositories[i].AuthToken = nil
+		}
+		return nil, nil
+	}
+
+	token := *payload.Repositories[tokenIdx].AuthToken
+	for i := range payload.Repositories {
+		payload.Repositories[i].AuthToken = nil
+	}
+	ref := sourceID
+	payload.Repositories[tokenIdx].CredentialRef = &ref
+
+	return &pendingSkillCredential{key: sourceID, token: token}, nil
+}
+
+// commitSkillRepoCredential stores a prepared token in the shared git-credentials
+// Secret. It runs only after the source has been persisted, so a request that is
+// rejected — a duplicate id, a failed validation, an edit to a read-only default —
+// leaves the Secret untouched. Writing before that check would let a rejected create
+// overwrite the token of the existing source whose id it collided with, breaking a
+// working source through a request the admin saw fail.
+func (app *App) commitSkillRepoCredential(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace string,
+	pending *pendingSkillCredential,
+) error {
+	if pending == nil {
+		return nil
+	}
+
+	secretName := app.config.SkillCatalogGitCredentialsSecret
+	if err := client.PatchSecret(ctx, namespace, secretName, map[string]string{pending.key: pending.token}); err != nil {
+		// Only a missing Secret is recoverable by creating it. Falling back on any error
+		// turns an RBAC or conflict failure into a confusing "already exists" from the
+		// create below, hiding the real cause from the operator.
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to store git token in secret %q: %w", secretName, err)
+		}
+		// The shared Secret may not exist yet on a fresh install; create it with this key.
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			StringData: map[string]string{pending.key: pending.token},
+		}
+		if _, createErr := client.CreateSecret(ctx, namespace, secret); createErr != nil {
+			return fmt.Errorf("failed to store git token in secret %q: %w", secretName, createErr)
+		}
+	}
+
+	return nil
+}
+
+func (app *App) GetAllSkillCatalogSourceConfigsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	configs, err := app.repositories.SkillCatalogSettingsRepository.GetAllSkillCatalogSourceConfigs(ctx, client, app.skillCatalogNamespace(namespace))
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillCatalogSettingsSourceConfigListEnvelope{Data: configs}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) GetSkillCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	sourceID := ps.ByName(CatalogSourceId)
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	config, err := app.repositories.SkillCatalogSettingsRepository.GetSkillCatalogSourceConfig(ctx, client, app.skillCatalogNamespace(namespace), sourceID)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogSourceNotFound) {
+			app.notFoundResponse(w, r)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillCatalogSettingsSourceConfigEnvelope{Data: config}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) CreateSkillCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	var envelope SkillCatalogSourcePayloadEnvelope
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("error decoding JSON: %w", err))
+		return
+	}
+
+	if envelope.Data == nil {
+		app.badRequestResponse(w, r, fmt.Errorf("missing required field: data"))
+		return
+	}
+
+	payload := *envelope.Data
+	catalogNS := app.skillCatalogNamespace(namespace)
+	pendingCredential, err := app.prepareSkillRepoCredentials(payload.Id, &payload)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogValidationFailed) {
+			app.badRequestResponse(w, r, err)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	created, err := app.repositories.SkillCatalogSettingsRepository.CreateSkillCatalogSourceConfig(ctx, client, catalogNS, payload)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogSourceAlreadyExist) ||
+			errors.Is(err, repositories.ErrSkillCatalogSourceIdRequired) ||
+			errors.Is(err, repositories.ErrSkillCatalogValidationFailed) {
+			app.badRequestResponse(w, r, err)
+		} else if errors.Is(err, repositories.ErrSkillCatalogSourceConflict) {
+			app.conflictResponse(w, r, err.Error())
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	// Only now that the source exists is its token safe to store: a rejected create
+	// above must not touch the Secret, or a duplicate id would overwrite the token of
+	// the source it collided with.
+	if err := app.commitSkillRepoCredential(ctx, client, catalogNS, pendingCredential); err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf(
+			"source %q was created, but storing its git token failed; re-save the source to retry: %w",
+			payload.Id, err))
+		return
+	}
+
+	result := SkillCatalogSettingsSourceConfigEnvelope{Data: created}
+	w.Header().Set("Location", r.URL.JoinPath(result.Data.Id).String())
+	if err = app.WriteJSON(w, http.StatusCreated, result, nil); err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("error writing JSON"))
+	}
+}
+
+func (app *App) UpdateSkillCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	var envelope SkillCatalogSourcePayloadEnvelope
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("error decoding JSON: %w", err))
+		return
+	}
+
+	if envelope.Data == nil {
+		app.badRequestResponse(w, r, fmt.Errorf("missing required field: data"))
+		return
+	}
+
+	sourceID := ps.ByName(CatalogSourceId)
+	if sourceID == "" {
+		sourceID = envelope.Data.Id
+	}
+
+	updatePayload := *envelope.Data
+	catalogNS := app.skillCatalogNamespace(namespace)
+	pendingCredential, err := app.prepareSkillRepoCredentials(sourceID, &updatePayload)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogValidationFailed) {
+			app.badRequestResponse(w, r, err)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	updated, err := app.repositories.SkillCatalogSettingsRepository.UpdateSkillCatalogSourceConfig(ctx, client, catalogNS, sourceID, updatePayload)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogSourceNotFound) {
+			app.notFoundResponse(w, r)
+		} else if errors.Is(err, repositories.ErrSkillCatalogValidationFailed) {
+			app.badRequestResponse(w, r, err)
+		} else if errors.Is(err, repositories.ErrSkillCatalogCannotChangeDefault) ||
+			errors.Is(err, repositories.ErrSkillCatalogCannotChangeType) {
+			app.forbiddenResponse(w, r, err.Error())
+		} else if errors.Is(err, repositories.ErrSkillCatalogSourceConflict) {
+			app.conflictResponse(w, r, err.Error())
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	// As on create: the token is stored only once the update has been accepted, so a
+	// 403 on a read-only default or a 404 on a missing source leaves the Secret alone.
+	if err := app.commitSkillRepoCredential(ctx, client, catalogNS, pendingCredential); err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf(
+			"source %q was updated, but storing its git token failed; re-save the source to retry: %w",
+			sourceID, err))
+		return
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillCatalogSettingsSourceConfigEnvelope{Data: updated}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) DeleteSkillCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	sourceID := ps.ByName(CatalogSourceId)
+
+	catalogNS := app.skillCatalogNamespace(namespace)
+	deletedConfig, err := app.repositories.SkillCatalogSettingsRepository.DeleteSkillCatalogSourceConfig(ctx, client, catalogNS, sourceID)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogCannotDeleteDefault) {
+			app.forbiddenResponse(w, r, err.Error())
+		} else if errors.Is(err, repositories.ErrSkillCatalogSourceNotFound) {
+			app.notFoundResponse(w, r)
+		} else if errors.Is(err, repositories.ErrSkillCatalogSourceConflict) {
+			app.conflictResponse(w, r, err.Error())
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	// Best-effort cleanup: drop only this source's key from the shared
+	// git-credentials Secret. Deleting the Secret itself would revoke every other
+	// source's token and break the catalog pod's volume mount.
+	//
+	// A failure here must not fail the delete — the source is already gone from the
+	// ConfigMap — but it leaves a revoked source's git token in the Secret, so it is
+	// logged against the source id an operator can act on.
+	if err := client.RemoveSecretKey(ctx, catalogNS, app.config.SkillCatalogGitCredentialsSecret, sourceID); err != nil {
+		if sessionLogger, ok := ctx.Value(constants.TraceLoggerKey).(*slog.Logger); ok {
+			sessionLogger.Warn("failed to remove git credentials for deleted skill catalog source",
+				"sourceId", sourceID,
+				"namespace", catalogNS,
+				"secret", app.config.SkillCatalogGitCredentialsSecret,
+				"error", err,
+			)
+		}
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillCatalogSettingsSourceConfigEnvelope{Data: deletedConfig}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/clients/ui/bff/internal/api/skill_catalog_settings_handler_test.go
+++ b/clients/ui/bff/internal/api/skill_catalog_settings_handler_test.go
@@ -1,0 +1,526 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/hub/ui/bff/internal/mocks"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestSkillCatalogSettings", func() {
+	var requestIdentity kubernetes.RequestIdentity
+
+	BeforeEach(func() {
+		requestIdentity = kubernetes.RequestIdentity{
+			UserID: "user@example.com",
+		}
+	})
+
+	newGitSource := func(id, name string) *models.SkillCatalogSourceConfigPayload {
+		return &models.SkillCatalogSourceConfigPayload{
+			Id:      id,
+			Name:    name,
+			Type:    "git-skills-plugin",
+			Enabled: skillHandlerBoolPtr(true),
+			Repositories: []models.SkillRepository{
+				{URL: "https://github.com/example/" + id, Refs: []string{"v1.0.0"}},
+			},
+		}
+	}
+
+	Context("fetching skill catalog source configs", func() {
+		It("GET ALL returns 200 and includes both default and user managed sources", func() {
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigListEnvelope](
+				http.MethodGet,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+			ids := make([]string, 0, len(body.Data.Catalogs))
+			for _, c := range body.Data.Catalogs {
+				ids = append(ids, c.Id)
+			}
+			Expect(ids).To(ContainElements("community_skills", "custom_skills"))
+		})
+
+		It("GET SINGLE returns 200 and never leaks the auth token", func() {
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodGet,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(body.Data.Type).To(Equal("git-skills-plugin"))
+			Expect(*body.Data.IsDefault).To(BeTrue())
+			Expect(body.Data.Repositories).To(HaveLen(1))
+			Expect(body.Data.Repositories[0].AuthToken).To(BeNil())
+			Expect(*body.Data.TrustTier).To(Equal("communityContributed"))
+		})
+
+		It("GET returns 404 for non-existent source", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodGet,
+				"/api/v1/settings/skill_catalog/source_configs/does_not_exist?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("GET returns 400 when namespace is missing", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodGet,
+				"/api/v1/settings/skill_catalog/source_configs",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Context("creating a skill source config", func() {
+		It("POST returns 201 on success", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{Data: newGitSource("skill_handler_test_create", "Skill Handler Test")}
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(body.Data.Id).To(Equal("skill_handler_test_create"))
+			Expect(rs.Header.Get("Location")).To(ContainSubstring("skill_handler_test_create"))
+		})
+
+		It("POST returns 400 when id is missing", func() {
+			source := newGitSource("", "No Id")
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 for a duplicate source", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{Data: newGitSource("custom_skills", "Duplicate")}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 for an unsupported catalog type", func() {
+			source := newGitSource("skill_bad_type", "Bad Type")
+			source.Type = "yaml"
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 when no repository is supplied", func() {
+			source := newGitSource("skill_no_repos", "No Repos")
+			source.Repositories = nil
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 for an invalid trustTier", func() {
+			source := newGitSource("skill_bad_tier", "Bad Tier")
+			source.TrustTier = skillHandlerStringPtr("goldPlated")
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 when data is missing from the envelope", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				SkillCatalogSourcePayloadEnvelope{},
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Context("credential syncing on create", func() {
+		It("POST moves the auth token into a credentialRef and never echoes it back", func() {
+			source := newGitSource("skill_with_token", "Skill With Token")
+			source.Repositories[0].AuthToken = skillHandlerStringPtr("ghp_secret_value")
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(body.Data.Repositories).To(HaveLen(1))
+			Expect(body.Data.Repositories[0].AuthToken).To(BeNil())
+			// The catalog service resolves credentialRef as a key inside the shared
+			// git-credentials Secret, so it must be the source id.
+			Expect(body.Data.Repositories[0].CredentialRef).NotTo(BeNil())
+			Expect(*body.Data.Repositories[0].CredentialRef).To(Equal("skill_with_token"))
+		})
+
+		It("POST returns 400 when the payload lists more than one repository", func() {
+			source := newGitSource("skill_two_tokens", "Two Tokens")
+			source.Repositories = []models.SkillRepository{
+				{URL: "https://github.com/example/one", AuthToken: skillHandlerStringPtr("token-one")},
+				{URL: "https://github.com/example/two", AuthToken: skillHandlerStringPtr("token-two")},
+			}
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Context("credential writes are gated on the source being persisted", func() {
+		readCredential := func(key string) string {
+			c, err := kubernetesMockedStaticClientFactory.GetClient(mocks.NewMockSessionContextNoParent())
+			Expect(err).NotTo(HaveOccurred())
+			secret, err := c.GetSecret(mocks.NewMockSessionContextNoParent(), "kubeflow", "skill-catalog-git-credentials")
+			if err != nil {
+				return ""
+			}
+			if v, ok := secret.Data[key]; ok {
+				return string(v)
+			}
+			return secret.StringData[key]
+		}
+
+		withToken := func(id, name, token string) SkillCatalogSourcePayloadEnvelope {
+			source := newGitSource(id, name)
+			source.Repositories[0].AuthToken = skillHandlerStringPtr(token)
+			return SkillCatalogSourcePayloadEnvelope{Data: source}
+		}
+
+		// The settings form derives a source id from the source name, so re-using a name
+		// produces a colliding id. The Secret key is that same id, so a create that the
+		// BFF rejects as a duplicate must not overwrite the existing source's token —
+		// the admin saw the request fail and reasonably assumes nothing changed.
+		It("a rejected duplicate create leaves the existing source's token intact", func() {
+			_, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				withToken("acme_skills", "Acme Skills", "REAL-TOKEN"),
+				kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(readCredential("acme_skills")).To(Equal("REAL-TOKEN"))
+
+			_, rs, err = setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				withToken("acme_skills", "Acme Skills", "WRONG-TOKEN"),
+				kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(readCredential("acme_skills")).To(Equal("REAL-TOKEN"),
+				"a rejected create must not overwrite the colliding source's credential")
+		})
+
+		It("a rejected edit of a read-only default stores no credential", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{
+						{URL: "https://github.com/example/community-skills", AuthToken: skillHandlerStringPtr("SNEAKY")},
+					},
+				},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				payload, kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+			Expect(readCredential("community_skills")).To(BeEmpty())
+		})
+
+		It("stores the credential when the source is actually created", func() {
+			_, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				withToken("beta_skills", "Beta Skills", "BETA-TOKEN"),
+				kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(readCredential("beta_skills")).To(Equal("BETA-TOKEN"))
+		})
+	})
+
+	Context("patching a skill source config", func() {
+		It("PATCH returns 200 on success", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{Enabled: skillHandlerBoolPtr(false)},
+			}
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/custom_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(*body.Data.Enabled).To(BeFalse())
+		})
+
+		It("PATCH returns 404 for a non-existent source", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{Enabled: skillHandlerBoolPtr(false)},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/does_not_exist?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("PATCH returns 403 when changing type", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{Type: "yaml"},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/custom_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+		})
+
+		It("PATCH returns 400 for an invalid credentialRef", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{
+						{URL: "https://github.com/example/custom-skills", CredentialRef: skillHandlerStringPtr("../escape")},
+					},
+				},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/custom_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("PATCH returns 403 when changing a forbidden field on a default", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{Name: "Renamed Default"},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+		})
+
+		It("PATCH returns 403 when repointing a default's repositories", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{
+						{URL: "https://github.com/attacker/evil-skills"},
+					},
+				},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+		})
+
+		It("PATCH toggles enabled on a default source via an override entry", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{Enabled: skillHandlerBoolPtr(false)},
+			}
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(*body.Data.Enabled).To(BeFalse())
+			// The default's own fields survive the override.
+			Expect(body.Data.Name).To(Equal("Community Skills"))
+		})
+	})
+
+	Context("deleting a skill source config", func() {
+		It("DELETE returns 200 on success", func() {
+			createPayload := SkillCatalogSourcePayloadEnvelope{Data: newGitSource("skill_delete_handler_test", "Skill Delete Test")}
+			_, _, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				createPayload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodDelete,
+				"/api/v1/settings/skill_catalog/source_configs/skill_delete_handler_test?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+			_, rs, err = setupApiTest[Envelope[any, any]](
+				http.MethodGet,
+				"/api/v1/settings/skill_catalog/source_configs/skill_delete_handler_test?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("DELETE returns 404 for a non-existent source", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodDelete,
+				"/api/v1/settings/skill_catalog/source_configs/does_not_exist?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("DELETE returns 403 for a default source", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodDelete,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+		})
+	})
+})
+
+func skillHandlerBoolPtr(b bool) *bool {
+	return &b
+}
+
+func skillHandlerStringPtr(s string) *string {
+	return &s
+}

--- a/clients/ui/bff/internal/api/test_utils.go
+++ b/clients/ui/bff/internal/api/test_utils.go
@@ -24,6 +24,13 @@ import (
 // the raw response together with its (already read) body. Use it directly for non-JSON
 // responses (e.g. binary payloads); setupApiTest wraps it for JSON envelope responses.
 func serveApiTest(method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string) (*http.Response, []byte, error) {
+	return serveApiTestWithConfig(method, url, body, k8Factory, requestIdentity, namespace, nil)
+}
+
+// serveApiTestWithConfig is serveApiTest with a hook to adjust the App config before
+// the request is served. Use it for behaviour that only differs by configuration —
+// dev mode namespace resolution, for instance. Pass nil for the default config.
+func serveApiTestWithConfig(method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string, configure func(*config.EnvConfig)) (*http.Response, []byte, error) {
 	mockMRClient, err := mocks.NewModelRegistryClient(nil)
 	if err != nil {
 		return nil, nil, err
@@ -37,10 +44,16 @@ func serveApiTest(method string, url string, body interface{}, k8Factory kuberne
 
 	cfg := config.EnvConfig{
 		AuthMethod: config.AuthMethodInternal,
+		// The skill catalog settings handlers write admin-supplied git tokens into
+		// this Secret; without a name they would fail before reaching the repository.
+		SkillCatalogGitCredentialsSecret: "skill-catalog-git-credentials",
 	}
 	//if token is set, use token auth
 	if requestIdentity.Token != "" {
 		cfg.AuthMethod = config.AuthMethodUser
+	}
+	if configure != nil {
+		configure(&cfg)
 	}
 	testApp := App{
 		repositories:            repositories.NewRepositories(mockMRClient, mockModelCatalogClient),
@@ -98,7 +111,12 @@ func serveApiTest(method string, url string, body interface{}, k8Factory kuberne
 }
 
 func setupApiTest[T any](method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string) (T, *http.Response, error) {
-	rs, respBody, err := serveApiTest(method, url, body, k8Factory, requestIdentity, namespace)
+	return setupApiTestWithConfig[T](method, url, body, k8Factory, requestIdentity, namespace, nil)
+}
+
+// setupApiTestWithConfig is setupApiTest over serveApiTestWithConfig.
+func setupApiTestWithConfig[T any](method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string, configure func(*config.EnvConfig)) (T, *http.Response, error) {
+	rs, respBody, err := serveApiTestWithConfig(method, url, body, k8Factory, requestIdentity, namespace, configure)
 	if err != nil {
 		return *new(T), nil, err
 	}

--- a/clients/ui/bff/internal/config/environment.go
+++ b/clients/ui/bff/internal/config/environment.go
@@ -81,9 +81,22 @@ type EnvConfig struct {
 	DeploymentMode           DeploymentMode
 	DevModeModelRegistryPort int
 	DevModeCatalogPort       int
-	StaticAssetsDir          string
-	LogLevel                 slog.Level
-	AllowedOrigins           []string
+	DevModeCatalogNamespace  string
+	// SkillCatalogGitCredentialsSecret is the single Secret mounted into the catalog
+	// pod at /etc/skill-catalog/git-credentials. Each skill source's git token is
+	// stored under a key named after the source id, and that key name is what the
+	// source's credentialRef points at — the catalog service resolves credentialRef
+	// as a filename in that mount, not as a Secret name.
+	SkillCatalogGitCredentialsSecret string
+	// SkillCatalogMarketplaceURL overrides the marketplace.json URL shown in the skill
+	// install instructions. Leave empty for the default, which is the catalog service's
+	// in-cluster address — reachable by agents running in the cluster, which is the
+	// primary consumer. Set it to an externally reachable URL when the catalog has been
+	// put behind a Route or Ingress, so the command also works from outside the cluster.
+	SkillCatalogMarketplaceURL string
+	StaticAssetsDir            string
+	LogLevel                   slog.Level
+	AllowedOrigins             []string
 	// BundlePaths is a list of filesystem paths to PEM-encoded CA bundle files.
 	// If provided, the application will attempt to load these files and add the
 	// certificates to the HTTP client's Root CAs for outbound TLS connections.

--- a/clients/ui/bff/internal/integrations/kubernetes/client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/client.go
@@ -19,6 +19,10 @@ const McpCatalogSourceKey = "sources.yaml"
 const McpCatalogSourceDefaultConfigMapName = CatalogSourceDefaultConfigMapName
 const McpCatalogSourceUserConfigMapName = "mcp-catalog-sources"
 
+const SkillCatalogSourceKey = "sources.yaml"
+const SkillCatalogSourceDefaultConfigMapName = CatalogSourceDefaultConfigMapName
+const SkillCatalogSourceUserConfigMapName = "skill-catalog-sources"
+
 type KubernetesClientInterface interface {
 	// Service discovery
 	GetServiceNames(ctx context.Context, namespace string) ([]string, error)
@@ -51,10 +55,15 @@ type KubernetesClientInterface interface {
 	CreateSecret(ctx context.Context, namespace string, secret *corev1.Secret) (*corev1.Secret, error)
 	PatchSecret(ctx context.Context, namespace string, secretName string, data map[string]string) error
 	DeleteSecret(ctx context.Context, namespace string, secretName string) error
+	RemoveSecretKey(ctx context.Context, namespace string, secretName string, key string) error
 
 	// MCP Catalog Settings
 	GetAllMcpCatalogSourceConfigs(ctx context.Context, namespace string) (corev1.ConfigMap, corev1.ConfigMap, error)
 	UpdateMcpCatalogSourceConfig(ctx context.Context, namespace string, configMap *corev1.ConfigMap) error
+
+	// Skill Catalog Settings
+	GetAllSkillCatalogSourceConfigs(ctx context.Context, namespace string) (corev1.ConfigMap, corev1.ConfigMap, error)
+	UpdateSkillCatalogSourceConfig(ctx context.Context, namespace string, configMap *corev1.ConfigMap) error
 
 	// Model transfer jobs
 	CanListJobsClusterWide(ctx context.Context, identity *RequestIdentity) (bool, error)

--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -286,6 +286,26 @@ func setupMock(mockK8sClient kubernetes.Interface, ctx context.Context) error {
 		return err
 	}
 
+	err = addSkillDataToDefaultCatalogSourcesConfigMap(mockK8sClient, ctx, "kubeflow")
+	if err != nil {
+		return err
+	}
+
+	err = createSkillCatalogSourcesConfigMap(mockK8sClient, ctx, "kubeflow")
+	if err != nil {
+		return err
+	}
+
+	err = addSkillDataToDefaultCatalogSourcesConfigMap(mockK8sClient, ctx, "bella-namespace")
+	if err != nil {
+		return err
+	}
+
+	err = createSkillCatalogSourcesConfigMap(mockK8sClient, ctx, "bella-namespace")
+	if err != nil {
+		return err
+	}
+
 	err = createHuggingFaceSecret(mockK8sClient, ctx, "kubeflow")
 	if err != nil {
 		return err
@@ -1523,6 +1543,82 @@ mcp_catalogs:
 
 	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create mcp-catalog-sources configmap: %w", err)
+	}
+
+	return nil
+}
+
+func addSkillDataToDefaultCatalogSourcesConfigMap(
+	k8sClient kubernetes.Interface,
+	ctx context.Context,
+	namespace string,
+) error {
+	cm, err := k8sClient.CoreV1().ConfigMaps(namespace).Get(ctx, k8s.CatalogSourceDefaultConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get default-catalog-sources configmap for skill data: %w", err)
+	}
+
+	skillRaw := strings.TrimSpace(`
+skill_catalogs:
+  - name: Community Skills
+    id: community_skills
+    type: git-skills-plugin
+    enabled: true
+    labels:
+      - Community
+    properties:
+      repositories:
+        - url: https://github.com/example/community-skills
+          refs:
+            - v1.0.0
+          provider: Community
+          category: development
+          trustTier: communityContributed
+`)
+
+	existingSources := cm.Data[k8s.SkillCatalogSourceKey]
+	cm.Data[k8s.SkillCatalogSourceKey] = existingSources + "\n" + skillRaw
+
+	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update default-catalog-sources configmap with skill data: %w", err)
+	}
+
+	return nil
+}
+
+func createSkillCatalogSourcesConfigMap(
+	k8sClient kubernetes.Interface,
+	ctx context.Context,
+	namespace string,
+) error {
+	raw := strings.TrimSpace(`
+skill_catalogs:
+  - name: Custom Skills
+    id: custom_skills
+    type: git-skills-plugin
+    enabled: true
+    labels:
+      - Custom
+    properties:
+      repositories:
+        - url: https://github.com/example/custom-skills
+          refs:
+            - v2.0.0
+          credentialRef: custom_skills
+`)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8s.SkillCatalogSourceUserConfigMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			k8s.SkillCatalogSourceKey: raw,
+		},
+	}
+
+	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create skill-catalog-sources configmap: %w", err)
 	}
 
 	return nil

--- a/clients/ui/bff/internal/integrations/kubernetes/shared_k8s_client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/shared_k8s_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kubeflow/hub/ui/bff/internal/constants"
@@ -306,6 +307,57 @@ func (kc *SharedClientLogic) PatchSecret(ctx context.Context, namespace string, 
 	return nil
 }
 
+// RemoveSecretKey drops a single key from a Secret, leaving the Secret and its
+// other keys in place. Used to retire one skill source's git token from the
+// shared git-credentials Secret without disturbing the other sources sharing it.
+// A missing Secret or a missing key is treated as success, so cleanup is idempotent.
+func (kc *SharedClientLogic) RemoveSecretKey(
+	ctx context.Context,
+	namespace string,
+	secretName string,
+	key string,
+) error {
+	sessionLogger := ctx.Value(constants.TraceLoggerKey).(*slog.Logger)
+
+	secret, err := kc.Client.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		sessionLogger.Error("failed to get secret for key removal",
+			"namespace", namespace,
+			"name", secretName,
+			"error", err,
+		)
+		return fmt.Errorf("failed to get secret %s: %w", secretName, err)
+	}
+
+	if _, ok := secret.Data[key]; !ok {
+		return nil
+	}
+	delete(secret.Data, key)
+	// Data already carries the surviving keys; StringData would be merged back in
+	// on update and resurrect the key we just removed.
+	secret.StringData = nil
+
+	if _, err := kc.Client.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
+		sessionLogger.Error("failed to remove key from secret",
+			"namespace", namespace,
+			"name", secretName,
+			"key", key,
+			"error", err,
+		)
+		return fmt.Errorf("failed to remove key %s from secret %s: %w", key, secretName, err)
+	}
+
+	sessionLogger.Info("successfully removed key from secret",
+		"namespace", namespace,
+		"name", secretName,
+		"key", key,
+	)
+	return nil
+}
+
 func (kc *SharedClientLogic) DeleteSecret(
 	ctx context.Context,
 	namespace string,
@@ -422,6 +474,116 @@ func (kc *SharedClientLogic) UpdateMcpCatalogSourceConfig(
 	}
 
 	sessionLogger.Info("successfully updated MCP catalog sources configmap",
+		"namespace", namespace,
+		"name", configMap.Name,
+	)
+
+	return nil
+}
+
+func (kc *SharedClientLogic) GetAllSkillCatalogSourceConfigs(
+	sessionCtx context.Context,
+	namespace string,
+) (corev1.ConfigMap, corev1.ConfigMap, error) {
+	if namespace == "" {
+		return corev1.ConfigMap{}, corev1.ConfigMap{}, fmt.Errorf("namespace cannot be empty")
+	}
+
+	sessionLogger := sessionCtx.Value(constants.TraceLoggerKey).(*slog.Logger)
+
+	// The default and user ConfigMaps have no data dependency on each other, and this is
+	// called on essentially every skill-catalog-settings request — fetch them concurrently
+	// rather than paying two sequential K8s round trips.
+	var defaultCMVal, userCMVal corev1.ConfigMap
+	var defaultErr, userErr error
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defaultCM, err := kc.Client.CoreV1().
+			ConfigMaps(namespace).
+			Get(sessionCtx, SkillCatalogSourceDefaultConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				sessionLogger.Info("default skill catalog source configmap not found, using empty",
+					"namespace", namespace,
+					"name", SkillCatalogSourceDefaultConfigMapName,
+				)
+				return
+			}
+			sessionLogger.Error("failed to fetch default skill catalog source configmap",
+				"namespace", namespace,
+				"name", SkillCatalogSourceDefaultConfigMapName,
+				"error", err,
+			)
+			defaultErr = fmt.Errorf("failed to get %s: %w", SkillCatalogSourceDefaultConfigMapName, err)
+			return
+		}
+		defaultCMVal = *defaultCM
+	}()
+	go func() {
+		defer wg.Done()
+		userCM, err := kc.Client.CoreV1().
+			ConfigMaps(namespace).
+			Get(sessionCtx, SkillCatalogSourceUserConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			sessionLogger.Error("failed to fetch skill catalog source configmap",
+				"namespace", namespace,
+				"name", SkillCatalogSourceUserConfigMapName,
+				"error", err,
+			)
+			userErr = fmt.Errorf("failed to get %s: %w", SkillCatalogSourceUserConfigMapName, err)
+			return
+		}
+		userCMVal = *userCM
+	}()
+	wg.Wait()
+
+	if defaultErr != nil {
+		return corev1.ConfigMap{}, corev1.ConfigMap{}, defaultErr
+	}
+	if userErr != nil {
+		return corev1.ConfigMap{}, corev1.ConfigMap{}, userErr
+	}
+
+	return defaultCMVal, userCMVal, nil
+}
+
+func (kc *SharedClientLogic) UpdateSkillCatalogSourceConfig(
+	ctx context.Context,
+	namespace string,
+	configMap *corev1.ConfigMap,
+) error {
+	sessionLogger := ctx.Value(constants.TraceLoggerKey).(*slog.Logger)
+
+	if configMap.Name == "" {
+		configMap.Name = SkillCatalogSourceUserConfigMapName
+		configMap.Namespace = namespace
+	}
+
+	_, err := kc.Client.CoreV1().
+		ConfigMaps(namespace).
+		Update(ctx, configMap, metav1.UpdateOptions{})
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err = kc.Client.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+		}
+		if err != nil {
+			sessionLogger.Error("failed to update skill catalog sources configmap",
+				"namespace", namespace,
+				"name", configMap.Name,
+				"error", err,
+			)
+			return fmt.Errorf("failed to update configmap %s: %w", configMap.Name, err)
+		}
+	}
+
+	sessionLogger.Info("successfully updated skill catalog sources configmap",
 		"namespace", namespace,
 		"name", configMap.Name,
 	)

--- a/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
+++ b/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
@@ -727,3 +727,29 @@ func (m *ModelCatalogClientMock) GetAgentArtifacts(client httpclient.HTTPClientI
 
 	return GetAgentArtifactListMock(agentId), nil
 }
+
+func (m *ModelCatalogClientMock) GetAllSkills(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillList, error) {
+	return &models.SkillList{
+		Items:    []models.Skill{},
+		PageSize: 10,
+		Size:     0,
+	}, nil
+}
+
+func (m *ModelCatalogClientMock) GetSkillsFilter(client httpclient.HTTPClientInterface) (*models.FilterOptionsList, error) {
+	return &models.FilterOptionsList{}, nil
+}
+
+func (m *ModelCatalogClientMock) GetSkill(client httpclient.HTTPClientInterface, skillId string, pageValues url.Values) (*models.Skill, error) {
+	return nil, &httpclient.HTTPError{
+		StatusCode: 404,
+		ErrorResponse: httpclient.ErrorResponse{
+			Code:    "404",
+			Message: fmt.Sprintf("skill not found: %s", skillId),
+		},
+	}
+}
+
+func (m *ModelCatalogClientMock) GetSkillMarketplace(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillMarketplace, error) {
+	return &models.SkillMarketplace{Plugins: []models.SkillMarketplacePlugin{}}, nil
+}

--- a/clients/ui/bff/internal/models/skill_catalog.go
+++ b/clients/ui/bff/internal/models/skill_catalog.go
@@ -1,0 +1,58 @@
+package models
+
+import "github.com/kubeflow/hub/pkg/openapi"
+
+type Skill struct {
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	SourceID        *string  `json:"sourceId,omitempty"`
+	Description     *string  `json:"description,omitempty"`
+	Readme          *string  `json:"readme,omitempty"`
+	License         *string  `json:"license,omitempty"`
+	Author          *string  `json:"author,omitempty"`
+	Compatibility   *string  `json:"compatibility,omitempty"`
+	AllowedTools    []string `json:"allowedTools,omitempty"`
+	Labels          []string `json:"labels,omitempty"`
+	Provider        *string  `json:"provider,omitempty"`
+	Category        *string  `json:"category,omitempty"`
+	TrustTier       *string  `json:"trustTier,omitempty"`
+	Repository      *string  `json:"repository,omitempty"`
+	Path            *string  `json:"path,omitempty"`
+	Version         *string  `json:"version,omitempty"`
+	ResolvedCommit  *string  `json:"resolvedCommit,omitempty"`
+	SupportingFiles []string `json:"supportingFiles,omitempty"`
+	// BodyLineCount is the SKILL.md body length. The catalog service warns above its
+	// maxSkillBodyLines (500) because an agent loads the whole body into its context,
+	// so the UI surfaces it as a quality signal. Display only — the catalog service
+	// deliberately excludes it from filter_options.
+	BodyLineCount    *int32                            `json:"bodyLineCount,omitempty"`
+	CustomProperties *map[string]openapi.MetadataValue `json:"customProperties,omitempty"`
+}
+
+type SkillList struct {
+	NextPageToken string  `json:"nextPageToken"`
+	PageSize      int32   `json:"pageSize"`
+	Size          int32   `json:"size"`
+	Items         []Skill `json:"items"`
+}
+
+// SkillMarketplace and its nested types are a subset pass-through of the Claude
+// Code plugin marketplace document served by the catalog service's
+// claude/marketplace.json endpoint (see catalog/internal/catalog/skillcatalog/marketplace.go).
+// Only the fields the UI needs to build install commands are kept.
+type SkillMarketplace struct {
+	Name    string                   `json:"name"`
+	Plugins []SkillMarketplacePlugin `json:"plugins"`
+}
+
+type SkillMarketplacePlugin struct {
+	Name   string                       `json:"name"`
+	Source SkillMarketplacePluginSource `json:"source"`
+}
+
+type SkillMarketplacePluginSource struct {
+	URL  string `json:"url"`
+	Path string `json:"path"`
+	Ref  string `json:"ref,omitempty"`
+	SHA  string `json:"sha,omitempty"`
+}

--- a/clients/ui/bff/internal/models/skill_catalog_source_configs.go
+++ b/clients/ui/bff/internal/models/skill_catalog_source_configs.go
@@ -1,0 +1,77 @@
+package models
+
+// SkillRepository represents an inline git repository entry in a git-skills-plugin source.
+//
+// Field names mirror the catalog service's SkillRepository
+// (catalog/internal/catalog/skillcatalog/source_schema.go). That struct is decoded
+// with DisallowUnknownFields, so any key written here that it does not declare
+// fails the entire source at load time.
+type SkillRepository struct {
+	URL          string   `json:"url"`
+	CanonicalURL *string  `json:"canonicalUrl,omitempty"`
+	Refs         []string `json:"refs,omitempty"`
+	ScanPaths    []string `json:"scanPaths,omitempty"`
+	// CredentialRef names a key in the git-credentials Secret mounted into the
+	// catalog pod — not a Secret name. It must be a plain filename. The BFF sets
+	// this to the source id when a token is supplied; it is never entered by hand.
+	CredentialRef *string `json:"credentialRef,omitempty"`
+	// AuthToken is a write-only git token from the admin form. The BFF stores it in
+	// the shared git-credentials Secret and clears it before serialisation, so it is
+	// never written to the ConfigMap and never returned on reads.
+	AuthToken *string `json:"authToken,omitempty"`
+	// Labels are stamped onto every skill this repository yields, so they show on
+	// skill cards and in filter_options (catalog service buildSkillEntity).
+	//
+	// Not to be confused with SkillCatalogSourceConfig.Labels: those sit on the
+	// source itself and only drive the sourceLabel grouping of sources.
+	Labels         []string `json:"labels,omitempty"`
+	IncludedSkills []string `json:"includedSkills,omitempty"`
+	ExcludedSkills []string `json:"excludedSkills,omitempty"`
+	// SkillOverrides are not editable in the settings UI; they are preserved verbatim so
+	// a UI save does not delete per-skill metadata a GitOps author set.
+	SkillOverrides []SkillOverride `json:"skillOverrides,omitempty"`
+}
+
+// SkillOverride is a per-skill exception to a repository's custom metadata, matching
+// the catalog service's SkillOverride (skillcatalog/source_schema.go). The repository's
+// own category/labels apply to every skill it yields; an override replaces them for the
+// one skill it names (buildSkillEntity precedence: repo entry -> skillOverride).
+//
+// The settings UI has no control for these — it edits repository-level metadata only —
+// but they are carried through reads and writes so that a source authored by GitOps
+// keeps them. The write path rebuilds properties.repositories from this model, so a
+// field missing here is not merely uneditable, it is erased on the next save.
+type SkillOverride struct {
+	Name     string   `json:"name"`
+	Category *string  `json:"category,omitempty"`
+	Labels   []string `json:"labels,omitempty"`
+}
+
+// SkillCatalogSourceConfig is a catalog source entry for a git-skills-plugin source.
+type SkillCatalogSourceConfig struct {
+	Id      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Enabled *bool  `json:"enabled,omitempty"`
+	// Labels group the source itself for the sourceLabel selector. A nil slice on an
+	// update means "leave as-is"; an empty (non-nil) slice means "clear them", which
+	// is how the settings UI removes the last label. For per-skill labels see
+	// SkillRepository.Labels.
+	Labels    []string `json:"labels,omitempty"`
+	Provider  *string  `json:"provider,omitempty"`
+	Category  *string  `json:"category,omitempty"`
+	TrustTier *string  `json:"trustTier,omitempty"`
+	// Repositories holds exactly one entry for any source this API writes, matching the
+	// catalog service's inline form. Provider/Category/TrustTier above are stamped onto
+	// that entry on write and read back from it, so a second entry could carry neither.
+	// It stays a slice because that is the shape the ConfigMap and the catalog service
+	// use, and a read of a yamlCatalogPath-backed source can return several.
+	Repositories []SkillRepository `json:"repositories,omitempty"`
+	IsDefault    *bool             `json:"isDefault,omitempty"`
+}
+
+type SkillCatalogSourceConfigPayload = SkillCatalogSourceConfig
+
+type SkillCatalogSourceConfigList struct {
+	Catalogs []SkillCatalogSourceConfig `json:"catalogs,omitempty"`
+}

--- a/clients/ui/bff/internal/repositories/catalog_source_preview.go
+++ b/clients/ui/bff/internal/repositories/catalog_source_preview.go
@@ -82,6 +82,12 @@ func (a CatalogSourcePreview) CreateCatalogSourcePreview(client httpclient.HTTPC
 		}
 	}
 
+	if sourcePreviewPayload.Type == CatalogTypeGitSkills {
+		if repos, ok := sourcePreviewPayload.Properties["repositories"]; ok {
+			properties["repositories"] = repos
+		}
+	}
+
 	if len(properties) > 0 {
 		configData["properties"] = properties
 	}

--- a/clients/ui/bff/internal/repositories/model_catalog.go
+++ b/clients/ui/bff/internal/repositories/model_catalog.go
@@ -13,6 +13,11 @@ const (
 	ModelCatalogAPIPath     = "/api/model_catalog/v1alpha1"
 	McpCatalogAPIPath       = "/api/mcp_catalog/v1alpha1"
 	AgentCatalogAPIPath     = "/api/agent_catalog/v1alpha1"
+	// Skills are served only at v1: the catalog service dropped the skill v1alpha1
+	// routes. v1 also renames fields to camelCase (source_id -> sourceId), which
+	// models.Skill's tags must match.
+	SkillCatalogAPIPath  = "/api/skill_catalog/v1"
+	CatalogTypeGitSkills = "git-skills-plugin"
 )
 
 type ModelCatalogRepository struct {

--- a/clients/ui/bff/internal/repositories/model_catalog_client.go
+++ b/clients/ui/bff/internal/repositories/model_catalog_client.go
@@ -10,6 +10,7 @@ type ModelCatalogClientInterface interface {
 	CatalogSourcePreviewInterface
 	McpServerCatalogInterface
 	AgentCatalogInterface
+	SkillCatalogInterface
 }
 
 type ModelCatalogClient struct {
@@ -19,6 +20,7 @@ type ModelCatalogClient struct {
 	CatalogSourcePreview
 	McpServerCatalog
 	AgentCatalog
+	SkillCatalog
 }
 
 func NewModelCatalogClient(logger *slog.Logger) (ModelCatalogClientInterface, error) {

--- a/clients/ui/bff/internal/repositories/model_catalog_settings_test.go
+++ b/clients/ui/bff/internal/repositories/model_catalog_settings_test.go
@@ -574,6 +574,18 @@ var _ = Describe("ModelCatalogSettingRepository", func() {
 	})
 })
 
+var _ = Describe("validateCatalogId", func() {
+	It("accepts an id with only lowercase letters, numbers, and underscores", func() {
+		Expect(validateCatalogId("my_source_1")).NotTo(HaveOccurred())
+	})
+
+	It("rejects a hyphenated id (model/mcp catalogs never accepted hyphens)", func() {
+		err := validateCatalogId("my-source")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("lowercase letters, numbers, and underscores"))
+	})
+})
+
 func boolPtr(b bool) *bool {
 	return &b
 }

--- a/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
@@ -186,6 +186,14 @@ func (f *fakeKubernetesClient) UpdateMcpCatalogSourceConfig(ctx context.Context,
 	return nil
 }
 
+func (f *fakeKubernetesClient) GetAllSkillCatalogSourceConfigs(ctx context.Context, namespace string) (corev1.ConfigMap, corev1.ConfigMap, error) {
+	return corev1.ConfigMap{}, corev1.ConfigMap{}, nil
+}
+
+func (f *fakeKubernetesClient) UpdateSkillCatalogSourceConfig(ctx context.Context, namespace string, configMap *corev1.ConfigMap) error {
+	return nil
+}
+
 func (f *fakeKubernetesClient) CreateSecret(ctx context.Context, namespace string, secret *corev1.Secret) (*corev1.Secret, error) {
 	created := secret.DeepCopy()
 	if created.Name == "" {
@@ -203,6 +211,10 @@ func (f *fakeKubernetesClient) PatchSecret(ctx context.Context, namespace string
 }
 
 func (f *fakeKubernetesClient) DeleteSecret(ctx context.Context, namespace string, secretName string) error {
+	return nil
+}
+
+func (f *fakeKubernetesClient) RemoveSecretKey(ctx context.Context, namespace string, secretName string, key string) error {
 	return nil
 }
 

--- a/clients/ui/bff/internal/repositories/repositories.go
+++ b/clients/ui/bff/internal/repositories/repositories.go
@@ -10,6 +10,7 @@ type Repositories struct {
 	ModelCatalogClient             ModelCatalogClientInterface
 	ModelCatalogSettingsRepository *ModelCatalogSettingsRepository
 	McpCatalogSettingsRepository   *McpCatalogSettingsRepository
+	SkillCatalogSettingsRepository *SkillCatalogSettingsRepository
 	User                           *UserRepository
 	Namespace                      *NamespaceRepository
 }
@@ -24,6 +25,7 @@ func NewRepositories(modelRegistryClient ModelRegistryClientInterface, modelCata
 		ModelRegistryClient:            modelRegistryClient,
 		ModelCatalogSettingsRepository: NewModelCatalogSettingsRepository(),
 		McpCatalogSettingsRepository:   NewMcpCatalogSettingsRepository(),
+		SkillCatalogSettingsRepository: NewSkillCatalogSettingsRepository(),
 		User:                           NewUserRepository(),
 		Namespace:                      NewNamespaceRepository(),
 	}

--- a/clients/ui/bff/internal/repositories/skill_catalog.go
+++ b/clients/ui/bff/internal/repositories/skill_catalog.go
@@ -1,0 +1,86 @@
+package repositories
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/httpclient"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+)
+
+const skillPath = "/skills"
+const skillFilterOptionPath = "/skills/filter_options"
+const skillMarketplacePath = "/claude/marketplace.json"
+
+type SkillCatalogInterface interface {
+	GetAllSkills(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillList, error)
+	GetSkillsFilter(client httpclient.HTTPClientInterface) (*models.FilterOptionsList, error)
+	GetSkill(client httpclient.HTTPClientInterface, skillId string, pageValues url.Values) (*models.Skill, error)
+	GetSkillMarketplace(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillMarketplace, error)
+}
+
+type SkillCatalog struct {
+	SkillCatalogInterface
+}
+
+func (s *SkillCatalog) GetAllSkills(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillList, error) {
+	responseData, err := client.GET(UrlWithPageParams(skillPath, pageValues))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching skills list: %w", err)
+	}
+
+	var skills models.SkillList
+	if err := json.Unmarshal(responseData, &skills); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &skills, nil
+}
+
+func (s *SkillCatalog) GetSkillsFilter(client httpclient.HTTPClientInterface) (*models.FilterOptionsList, error) {
+	responseData, err := client.GET(skillFilterOptionPath)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching skill filter options: %w", err)
+	}
+
+	var filters models.FilterOptionsList
+	if err := json.Unmarshal(responseData, &filters); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &filters, nil
+}
+
+func (s *SkillCatalog) GetSkill(client httpclient.HTTPClientInterface, skillId string, pageValues url.Values) (*models.Skill, error) {
+	path, err := url.JoinPath(skillPath, skillId)
+	if err != nil {
+		return nil, err
+	}
+
+	responseData, err := client.GET(UrlWithPageParams(path, pageValues))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching skill: %w", err)
+	}
+
+	var skill models.Skill
+	if err := json.Unmarshal(responseData, &skill); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &skill, nil
+}
+
+func (s *SkillCatalog) GetSkillMarketplace(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillMarketplace, error) {
+	responseData, err := client.GET(UrlWithPageParams(skillMarketplacePath, pageValues))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching skill marketplace: %w", err)
+	}
+
+	var marketplace models.SkillMarketplace
+	if err := json.Unmarshal(responseData, &marketplace); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &marketplace, nil
+}

--- a/clients/ui/bff/internal/repositories/skill_catalog_helpers.go
+++ b/clients/ui/bff/internal/repositories/skill_catalog_helpers.go
@@ -1,0 +1,584 @@
+package repositories
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	"gopkg.in/yaml.v3"
+)
+
+const SkillCatalogTypeGit = "git-skills-plugin"
+
+// validCredentialRef mirrors the catalog service's credentialRef check
+// (catalog/internal/catalog/skillcatalog/source_schema.go): a plain filename with
+// no path separators, so it cannot escape the mounted git-credentials directory.
+var validCredentialRef = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$`)
+
+// validSkillTrustTiers is the closed set defined in catalog-v1.yaml / SkillTrustTier enum.
+var validSkillTrustTiers = map[string]struct{}{
+	"platformProvided":     {},
+	"partnerVerified":      {},
+	"organizationApproved": {},
+	"communityContributed": {},
+}
+
+// validSkillCatalogIdRegex is deliberately more permissive than the shared
+// validateCatalogId (model/mcp catalogs): it allows hyphens so a hand-written or
+// GitOps-managed skill source (kebab-case is the common convention there) doesn't
+// need to be renamed to satisfy validation. This must stay skill-catalog-specific —
+// widening the shared validCatalogIdRegex instead would loosen ID validation for
+// the model and MCP catalogs too.
+var validSkillCatalogIdRegex = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+func validateSkillCatalogId(id string) error {
+	if id == "" {
+		return ErrCatalogSourceIdRequired
+	}
+
+	if !validSkillCatalogIdRegex.MatchString(id) {
+		return fmt.Errorf("invalid catalog ID: must contain only lowercase letters, numbers, hyphens, and underscores")
+	}
+
+	if len(id) > 238 {
+		return fmt.Errorf("%w: '%s' (max 238 characters)", ErrCatalogIDTooLong, id)
+	}
+
+	return nil
+}
+
+func ParseSkillCatalogYaml(raw string, isDefault bool) ([]models.SkillCatalogSourceConfig, error) {
+	var parsed struct {
+		Catalogs []struct {
+			Name       string         `yaml:"name"`
+			Id         string         `yaml:"id"`
+			Type       string         `yaml:"type"`
+			Enabled    *bool          `yaml:"enabled"`
+			Labels     []string       `yaml:"labels"`
+			Properties map[string]any `yaml:"properties"`
+		} `yaml:"skill_catalogs"`
+	}
+
+	if err := yaml.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse skill catalogs yaml: %w", err)
+	}
+
+	catalogs := make([]models.SkillCatalogSourceConfig, 0, len(parsed.Catalogs))
+	for _, c := range parsed.Catalogs {
+		props := c.Properties
+		if props == nil {
+			props = map[string]any{}
+		}
+
+		type rawSkillOverride struct {
+			Name     string   `yaml:"name"`
+			Category string   `yaml:"category"`
+			Labels   []string `yaml:"labels"`
+		}
+
+		type rawRepo struct {
+			URL            string   `yaml:"url"`
+			CanonicalURL   string   `yaml:"canonicalUrl"`
+			Refs           []string `yaml:"refs"`
+			ScanPaths      []string `yaml:"scanPaths"`
+			CredentialRef  string   `yaml:"credentialRef"`
+			Labels         []string `yaml:"labels"`
+			IncludedSkills []string `yaml:"includedSkills"`
+			ExcludedSkills []string `yaml:"excludedSkills"`
+			Provider       string   `yaml:"provider"`
+			Category       string   `yaml:"category"`
+			TrustTier      string   `yaml:"trustTier"`
+			// Read so the write path can put them back; the UI never edits them.
+			SkillOverrides []rawSkillOverride `yaml:"skillOverrides"`
+		}
+
+		var repos []models.SkillRepository
+		var rawRepos []rawRepo
+		if repoList, ok := props["repositories"]; ok {
+			repoBytes, err := yaml.Marshal(repoList)
+			if err != nil {
+				return nil, fmt.Errorf("failed to re-marshal repositories for skill catalog source %q: %w", c.Id, err)
+			}
+			if err := yaml.Unmarshal(repoBytes, &rawRepos); err != nil {
+				return nil, fmt.Errorf("failed to parse repositories for skill catalog source %q: %w", c.Id, err)
+			}
+			for _, r := range rawRepos {
+				repo := models.SkillRepository{
+					URL:            r.URL,
+					Refs:           r.Refs,
+					ScanPaths:      r.ScanPaths,
+					Labels:         r.Labels,
+					IncludedSkills: r.IncludedSkills,
+					ExcludedSkills: r.ExcludedSkills,
+				}
+				if r.CanonicalURL != "" {
+					repo.CanonicalURL = &r.CanonicalURL
+				}
+				if r.CredentialRef != "" {
+					repo.CredentialRef = &r.CredentialRef
+				}
+				for _, ov := range r.SkillOverrides {
+					entry := models.SkillOverride{Name: ov.Name, Labels: ov.Labels}
+					if ov.Category != "" {
+						category := ov.Category
+						entry.Category = &category
+					}
+					repo.SkillOverrides = append(repo.SkillOverrides, entry)
+				}
+				repos = append(repos, repo)
+			}
+		}
+
+		entry := models.SkillCatalogSourceConfig{
+			Id:           c.Id,
+			Name:         c.Name,
+			Type:         c.Type,
+			Enabled:      c.Enabled,
+			Labels:       c.Labels,
+			Repositories: repos,
+			IsDefault:    &isDefault,
+		}
+		// Read category/provider/trustTier from the first repository (canonical location per
+		// the backend schema). A source written through this API has exactly one repository,
+		// so the first entry is the only entry; a hand-written or yamlCatalogPath-backed
+		// source may list more, and only the first one's provenance is surfaced. Fall back to
+		// properties level for backwards compat with manually-created ConfigMaps that placed
+		// them at the source/properties level.
+		if len(rawRepos) > 0 {
+			if rawRepos[0].Provider != "" {
+				entry.Provider = &rawRepos[0].Provider
+			}
+			if rawRepos[0].Category != "" {
+				entry.Category = &rawRepos[0].Category
+			}
+			if rawRepos[0].TrustTier != "" {
+				entry.TrustTier = &rawRepos[0].TrustTier
+			}
+		}
+		if entry.Provider == nil {
+			if v, ok := props["provider"].(string); ok && v != "" {
+				entry.Provider = &v
+			}
+		}
+		if entry.Category == nil {
+			if v, ok := props["category"].(string); ok && v != "" {
+				entry.Category = &v
+			}
+		}
+		if entry.TrustTier == nil {
+			if v, ok := props["trustTier"].(string); ok && v != "" {
+				entry.TrustTier = &v
+			}
+		}
+		catalogs = append(catalogs, entry)
+	}
+
+	return catalogs, nil
+}
+
+func FindSkillCatalogSourceById(sourceYAML string, catalogId string, isDefault bool) *models.SkillCatalogSourceConfig {
+	if sourceYAML == "" {
+		return nil
+	}
+
+	configs, err := ParseSkillCatalogYaml(sourceYAML, isDefault)
+	if err != nil {
+		return nil
+	}
+
+	for i := range configs {
+		if configs[i].Id == catalogId {
+			return &configs[i]
+		}
+	}
+
+	return nil
+}
+
+func AppendSkillCatalogSourceToYaml(existingConfigMapEntry string, newEntry map[string]interface{}) (string, error) {
+	var parsed struct {
+		Catalogs []map[string]interface{} `yaml:"skill_catalogs"`
+	}
+
+	if existingConfigMapEntry != "" {
+		if err := yaml.Unmarshal([]byte(existingConfigMapEntry), &parsed); err != nil {
+			return "", fmt.Errorf("failed to parse existing skill sources.yaml: %w", err)
+		}
+	} else {
+		parsed.Catalogs = []map[string]interface{}{}
+	}
+	parsed.Catalogs = append(parsed.Catalogs, newEntry)
+
+	updatedBytes, err := yaml.Marshal(parsed)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal updated skill sources.yaml: %w", err)
+	}
+
+	return string(updatedBytes), nil
+}
+
+func RemoveSkillCatalogSourceFromYAML(existingYAML string, sourceId string) (string, error) {
+	var parsed struct {
+		Catalogs []map[string]interface{} `yaml:"skill_catalogs"`
+	}
+
+	if err := yaml.Unmarshal([]byte(existingYAML), &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse skill sources.yaml: %w", err)
+	}
+
+	filtered := make([]map[string]interface{}, 0)
+	for _, src := range parsed.Catalogs {
+		if id, ok := src["id"].(string); ok && id != sourceId {
+			filtered = append(filtered, src)
+		}
+	}
+
+	parsed.Catalogs = filtered
+	updatedBytes, err := yaml.Marshal(parsed)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal updated skill sources.yaml: %w", err)
+	}
+
+	return string(updatedBytes), nil
+}
+
+func ConvertSkillSourceConfigToYamlEntry(payload models.SkillCatalogSourceConfigPayload) map[string]interface{} {
+	entry := map[string]interface{}{
+		"id":      payload.Id,
+		"name":    payload.Name,
+		"type":    payload.Type,
+		"enabled": payload.Enabled,
+	}
+
+	if len(payload.Labels) > 0 {
+		entry["labels"] = payload.Labels
+	}
+
+	props := map[string]interface{}{}
+	if len(payload.Repositories) > 0 {
+		props["repositories"] = buildSkillRepoYamlEntries(payload)
+	}
+	entry["properties"] = props
+
+	return entry
+}
+
+// buildSkillRepoYamlEntries serialises payload.Repositories into the
+// properties.repositories[] form the catalog service expects.
+//
+// The catalog service decodes a skill source's properties with
+// DisallowUnknownFields (see catalog/internal/catalog/skillcatalog/source_schema.go),
+// so an unrecognised key here is not ignored — it fails the whole source.
+// Only keys present on the backend's SkillRepository struct may be emitted, and
+// category/provider/trustTier belong on each repository rather than on properties.
+//
+// This is the single writer for repository entries; all update paths must go
+// through it so the two representations cannot drift apart again.
+//
+// Entries are rebuilt from the payload rather than merged into what is stored, so
+// provider/category/trustTier are replace-not-merge: an update that carries
+// repositories but omits those three erases them from the stored entry. That is safe
+// only because the settings form lifts all three into every save
+// (SkillManageSourceForm's optionalFields). Nothing enforces that coupling, so a
+// future change that moves them to be genuinely per-repository — where the catalog
+// schema wants them — must keep sending them here, or start merging them from the
+// existing entry, otherwise every edit silently drops a source's trust tier and its
+// provider/category filter values.
+func buildSkillRepoYamlEntries(payload models.SkillCatalogSourceConfigPayload) []map[string]interface{} {
+	repos := make([]map[string]interface{}, 0, len(payload.Repositories))
+	for _, r := range payload.Repositories {
+		repo := map[string]interface{}{
+			"url": r.URL,
+		}
+		if r.CanonicalURL != nil && *r.CanonicalURL != "" {
+			repo["canonicalUrl"] = *r.CanonicalURL
+		}
+		if len(r.Refs) > 0 {
+			repo["refs"] = r.Refs
+		}
+		if len(r.ScanPaths) > 0 {
+			repo["scanPaths"] = r.ScanPaths
+		}
+		if r.CredentialRef != nil && *r.CredentialRef != "" {
+			repo["credentialRef"] = *r.CredentialRef
+		}
+		if len(r.IncludedSkills) > 0 {
+			repo["includedSkills"] = r.IncludedSkills
+		}
+		if len(r.ExcludedSkills) > 0 {
+			repo["excludedSkills"] = r.ExcludedSkills
+		}
+		// Per-skill labels. Omitting them when empty is how they get cleared: an
+		// update replaces the whole repositories list, so a key left out is gone.
+		if len(r.Labels) > 0 {
+			repo["labels"] = r.Labels
+		}
+		// Round-tripped, never authored here: the form has no per-skill control, so these
+		// arrive only from a previous read of a GitOps-authored source. Omitting them
+		// would delete them, since this rebuilds the entry from scratch.
+		if len(r.SkillOverrides) > 0 {
+			overrides := make([]map[string]interface{}, 0, len(r.SkillOverrides))
+			for _, ov := range r.SkillOverrides {
+				entry := map[string]interface{}{"name": ov.Name}
+				if ov.Category != nil && *ov.Category != "" {
+					entry["category"] = *ov.Category
+				}
+				if len(ov.Labels) > 0 {
+					entry["labels"] = ov.Labels
+				}
+				overrides = append(overrides, entry)
+			}
+			repo["skillOverrides"] = overrides
+		}
+		if payload.Provider != nil && *payload.Provider != "" {
+			repo["provider"] = *payload.Provider
+		}
+		if payload.Category != nil && *payload.Category != "" {
+			repo["category"] = *payload.Category
+		}
+		if payload.TrustTier != nil && *payload.TrustTier != "" {
+			repo["trustTier"] = *payload.TrustTier
+		}
+		repos = append(repos, repo)
+	}
+	return repos
+}
+
+func UpdateSkillCatalogSourceInYAML(
+	existingYAML string,
+	catalogId string,
+	payload models.SkillCatalogSourceConfigPayload,
+) (string, error) {
+	var parsed struct {
+		Catalogs []map[string]interface{} `yaml:"skill_catalogs"`
+	}
+
+	if existingYAML == "" {
+		return "", fmt.Errorf("no existing yaml to update")
+	}
+
+	if err := yaml.Unmarshal([]byte(existingYAML), &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse skill sources.yaml: %w", err)
+	}
+
+	found := false
+	for i, src := range parsed.Catalogs {
+		if id, ok := src["id"].(string); ok && id == catalogId {
+			found = true
+
+			if payload.Name != "" {
+				src["name"] = payload.Name
+			}
+			// nil means the caller did not send labels at all (e.g. a toggle-only
+			// update), so leave them alone. An empty but non-nil slice is an explicit
+			// "remove them all" — writing that back is what lets the settings UI clear
+			// the last label instead of silently keeping it.
+			if payload.Labels != nil {
+				if len(payload.Labels) > 0 {
+					src["labels"] = payload.Labels
+				} else {
+					delete(src, "labels")
+				}
+			}
+			if payload.Enabled != nil {
+				src["enabled"] = *payload.Enabled
+			}
+			existingProps, _ := src["properties"].(map[string]interface{})
+			if existingProps == nil {
+				existingProps = map[string]interface{}{}
+			}
+			if len(payload.Repositories) > 0 {
+				// Drop stale source-level metadata written by earlier BFF versions.
+				// Only done when replacing repos, so a toggle-only update does not
+				// erase fields it was never given a replacement for.
+				delete(existingProps, "provider")
+				delete(existingProps, "category")
+				delete(existingProps, "trustTier")
+				existingProps["repositories"] = buildSkillRepoYamlEntries(payload)
+			}
+			// Only write properties back when there is something in them. An empty map
+			// serialises as `properties: {}`, which is not the same as omitting the key:
+			// MergeCommonSourceFields replaces the base source's Properties whenever the
+			// override's is non-nil, so a default source overridden with `{}` loses its
+			// repositories and then fails to load ("no repositories configured"). This is
+			// reachable by toggling a shipped default off and back on, since the first
+			// toggle writes an override entry that carries no properties at all.
+			if len(existingProps) > 0 {
+				src["properties"] = existingProps
+			}
+
+			parsed.Catalogs[i] = src
+			break
+		}
+	}
+
+	if !found {
+		return "", fmt.Errorf("skill catalog '%s' not found in yaml", catalogId)
+	}
+
+	updatedBytes, err := yaml.Marshal(parsed)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal updated skill sources.yaml: %w", err)
+	}
+
+	return string(updatedBytes), nil
+}
+
+func mergeSkillCatalogSourceConfigs(defaultCatalog, userCatalog models.SkillCatalogSourceConfig) models.SkillCatalogSourceConfig {
+	merged := defaultCatalog
+
+	if userCatalog.Name != "" {
+		merged.Name = userCatalog.Name
+	}
+	if userCatalog.Type != "" {
+		merged.Type = userCatalog.Type
+	}
+	if userCatalog.Enabled != nil {
+		merged.Enabled = userCatalog.Enabled
+	}
+	// Same nil-vs-empty rule as the update path: a user override that clears the
+	// labels of a default source must win, not fall back to the default's labels.
+	if userCatalog.Labels != nil {
+		merged.Labels = userCatalog.Labels
+	}
+	if userCatalog.Provider != nil {
+		merged.Provider = userCatalog.Provider
+	}
+	if userCatalog.Category != nil {
+		merged.Category = userCatalog.Category
+	}
+	if userCatalog.TrustTier != nil {
+		merged.TrustTier = userCatalog.TrustTier
+	}
+	if len(userCatalog.Repositories) > 0 {
+		merged.Repositories = userCatalog.Repositories
+	}
+
+	return merged
+}
+
+func validateSkillCatalogSourceConfigPayload(payload models.SkillCatalogSourceConfigPayload) error {
+	if payload.Id == "" {
+		return fmt.Errorf("%w", ErrSkillCatalogSourceIdRequired)
+	}
+
+	if err := validateSkillCatalogId(payload.Id); err != nil {
+		return fmt.Errorf("%w: %v", ErrSkillCatalogValidationFailed, err)
+	}
+
+	if payload.Name == "" {
+		return fmt.Errorf("%w: name is required", ErrSkillCatalogValidationFailed)
+	}
+
+	if payload.Type == "" {
+		return fmt.Errorf("%w: type is required", ErrSkillCatalogValidationFailed)
+	}
+
+	if payload.Type != SkillCatalogTypeGit {
+		return fmt.Errorf("%w: unsupported skill catalog type: %s (supported: %s)", ErrSkillCatalogValidationFailed, payload.Type, SkillCatalogTypeGit)
+	}
+
+	if len(payload.Repositories) == 0 {
+		return fmt.Errorf("%w: at least one repository is required for git-skills-plugin sources", ErrSkillCatalogValidationFailed)
+	}
+
+	if err := validateSkillRepositories(payload.Repositories); err != nil {
+		return err
+	}
+
+	if err := validateSourceMetadataFields(payload.Category, payload.Provider, payload.TrustTier); err != nil {
+		return fmt.Errorf("%w: %v", ErrSkillCatalogValidationFailed, err)
+	}
+
+	return nil
+}
+
+// validateSkillUpdatePayloadForDefaultOverride mirrors the model and MCP catalogs
+// (validateMcpUpdatePayloadForDefaultOverride): a shipped default source is read-only
+// apart from being enabled or disabled. Allowing repositories through here would let an
+// admin repoint a platform-provided source at an arbitrary git repo while its skills keep
+// the source's trust tier.
+func validateSkillUpdatePayloadForDefaultOverride(payload models.SkillCatalogSourceConfigPayload) error {
+	if payload.Name != "" {
+		return fmt.Errorf("%w: cannot change 'name'", ErrSkillCatalogCannotChangeDefault)
+	}
+
+	if payload.Labels != nil {
+		return fmt.Errorf("%w: cannot change 'labels'", ErrSkillCatalogCannotChangeDefault)
+	}
+
+	if len(payload.Repositories) > 0 {
+		return fmt.Errorf("%w: cannot change 'repositories'", ErrSkillCatalogCannotChangeDefault)
+	}
+
+	if payload.Provider != nil || payload.Category != nil || payload.TrustTier != nil {
+		return fmt.Errorf("%w: cannot change source metadata", ErrSkillCatalogCannotChangeDefault)
+	}
+
+	return nil
+}
+
+func validateSkillCatalogUpdatePayload(payload models.SkillCatalogSourceConfigPayload) error {
+	if err := validateSourceMetadataFields(payload.Category, payload.Provider, payload.TrustTier); err != nil {
+		return fmt.Errorf("%w: %v", ErrSkillCatalogValidationFailed, err)
+	}
+	if err := validateSkillRepositories(payload.Repositories); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateSkillRepositories applies the per-repository checks the catalog service
+// performs at load time, so a bad value is reported to the admin here rather than
+// silently breaking the source on the next sync.
+//
+// A source written through this API carries exactly one repository, matching the
+// catalog service's inline form (resolveRepositories rejects a longer inline list).
+// The write path assumes it: provider/category/trustTier arrive at the source level
+// and are stamped onto every repository entry, and reads recover them from the first
+// entry only — so a second repository could neither carry its own provenance nor be
+// read back. Multi-repository sources are configured through yamlCatalogPath, which
+// this API does not write.
+func validateSkillRepositories(repos []models.SkillRepository) error {
+	if len(repos) > 1 {
+		return fmt.Errorf("%w: a source accepts a single repository (got %d); configure several through yamlCatalogPath, or register one source per repository",
+			ErrSkillCatalogValidationFailed, len(repos))
+	}
+	for i, repo := range repos {
+		if repo.URL == "" {
+			return fmt.Errorf("%w: repository[%d].url is required", ErrSkillCatalogValidationFailed, i)
+		}
+		if repo.CredentialRef != nil && *repo.CredentialRef != "" && !validCredentialRef.MatchString(*repo.CredentialRef) {
+			return fmt.Errorf("%w: repository[%d].credentialRef %q must be a plain filename (letters, digits, '.', '_', '-')",
+				ErrSkillCatalogValidationFailed, i, *repo.CredentialRef)
+		}
+	}
+	return nil
+}
+
+// validateSourceMetadataFields validates category, provider, and trustTier together.
+// All three fields are optional; when provided they must be non-empty, and trustTier
+// must be one of the values defined in the SkillTrustTier enum.
+func validateSourceMetadataFields(category, provider, trustTier *string) error {
+	if category != nil && *category == "" {
+		return fmt.Errorf("category must not be an empty string when provided")
+	}
+	if provider != nil && *provider == "" {
+		return fmt.Errorf("provider must not be an empty string when provided")
+	}
+	return validateTrustTier(trustTier)
+}
+
+func validateTrustTier(trustTier *string) error {
+	if trustTier == nil || *trustTier == "" {
+		return nil
+	}
+	if _, ok := validSkillTrustTiers[*trustTier]; !ok {
+		valid := make([]string, 0, len(validSkillTrustTiers))
+		for k := range validSkillTrustTiers {
+			valid = append(valid, k)
+		}
+		return fmt.Errorf("invalid trustTier %q: must be one of %v", *trustTier, valid)
+	}
+	return nil
+}

--- a/clients/ui/bff/internal/repositories/skill_catalog_helpers_test.go
+++ b/clients/ui/bff/internal/repositories/skill_catalog_helpers_test.go
@@ -1,0 +1,679 @@
+package repositories
+
+import (
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+var _ = Describe("skill catalog helpers", func() {
+
+	ptr := func(s string) *string { return &s }
+
+	Describe("validateSkillCatalogId", func() {
+		It("accepts an id with only lowercase letters, numbers, and underscores", func() {
+			Expect(validateSkillCatalogId("my_source_1")).NotTo(HaveOccurred())
+		})
+
+		It("accepts a hyphenated id, unlike the shared model/mcp catalog validator", func() {
+			Expect(validateSkillCatalogId("my-source")).NotTo(HaveOccurred())
+		})
+
+		It("rejects an empty id", func() {
+			Expect(validateSkillCatalogId("")).To(HaveOccurred())
+		})
+
+		It("rejects an id with disallowed characters", func() {
+			err := validateSkillCatalogId("my source!")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("lowercase letters, numbers, hyphens, and underscores"))
+		})
+	})
+
+	Describe("validateSourceMetadataFields", func() {
+		It("accepts all three fields absent (nil)", func() {
+			Expect(validateSourceMetadataFields(nil, nil, nil)).To(Succeed())
+		})
+		It("accepts all three fields populated with valid values", func() {
+			Expect(validateSourceMetadataFields(
+				ptr("Development"), ptr("Matt"), ptr("communityContributed"),
+			)).To(Succeed())
+		})
+
+		Context("category", func() {
+			It("rejects an empty-string category", func() {
+				Expect(validateSourceMetadataFields(ptr(""), nil, nil)).
+					To(MatchError(ContainSubstring("category must not be an empty string")))
+			})
+			It("accepts a non-empty category", func() {
+				Expect(validateSourceMetadataFields(ptr("productivity"), nil, nil)).To(Succeed())
+			})
+		})
+
+		Context("provider", func() {
+			It("rejects an empty-string provider", func() {
+				Expect(validateSourceMetadataFields(nil, ptr(""), nil)).
+					To(MatchError(ContainSubstring("provider must not be an empty string")))
+			})
+			It("accepts a non-empty provider", func() {
+				Expect(validateSourceMetadataFields(nil, ptr("Red Hat"), nil)).To(Succeed())
+			})
+		})
+
+		Context("trustTier", func() {
+			It("rejects 'Community'", func() {
+				Expect(validateSourceMetadataFields(nil, nil, ptr("Community"))).
+					To(MatchError(ContainSubstring("invalid trustTier")))
+			})
+			It("accepts all valid enum values", func() {
+				for tier := range validSkillTrustTiers {
+					t := tier
+					Expect(validateSourceMetadataFields(nil, nil, &t)).To(Succeed())
+				}
+			})
+		})
+	})
+
+	Describe("validateSkillCatalogSourceConfigPayload (create)", func() {
+		basePayload := func() models.SkillCatalogSourceConfig {
+			return models.SkillCatalogSourceConfig{
+				Id:           "test-source",
+				Name:         "Test Source",
+				Type:         SkillCatalogTypeGit,
+				Repositories: []models.SkillRepository{{URL: "https://github.com/example/skills.git"}},
+			}
+		}
+
+		It("accepts a fully valid payload with all three metadata fields", func() {
+			p := basePayload()
+			p.Category = ptr("Development")
+			p.Provider = ptr("Matt")
+			p.TrustTier = ptr("communityContributed")
+			Expect(validateSkillCatalogSourceConfigPayload(p)).To(Succeed())
+		})
+		It("rejects an empty category", func() {
+			p := basePayload()
+			p.Category = ptr("")
+			Expect(validateSkillCatalogSourceConfigPayload(p)).
+				To(MatchError(ContainSubstring("category must not be an empty string")))
+		})
+		It("rejects an empty provider", func() {
+			p := basePayload()
+			p.Provider = ptr("")
+			Expect(validateSkillCatalogSourceConfigPayload(p)).
+				To(MatchError(ContainSubstring("provider must not be an empty string")))
+		})
+		It("rejects an invalid trustTier", func() {
+			p := basePayload()
+			p.TrustTier = ptr("Community")
+			Expect(validateSkillCatalogSourceConfigPayload(p)).
+				To(MatchError(ContainSubstring("invalid trustTier")))
+		})
+	})
+
+	Describe("validateSkillCatalogUpdatePayload (patch)", func() {
+		It("accepts an empty payload (toggle-only)", func() {
+			Expect(validateSkillCatalogUpdatePayload(models.SkillCatalogSourceConfig{})).To(Succeed())
+		})
+		It("accepts all three metadata fields set to valid values", func() {
+			p := models.SkillCatalogSourceConfig{
+				Category:  ptr("Development"),
+				Provider:  ptr("Matt"),
+				TrustTier: ptr("communityContributed"),
+			}
+			Expect(validateSkillCatalogUpdatePayload(p)).To(Succeed())
+		})
+		It("rejects an empty-string category in a patch", func() {
+			p := models.SkillCatalogSourceConfig{Category: ptr("")}
+			Expect(validateSkillCatalogUpdatePayload(p)).
+				To(MatchError(ContainSubstring("category must not be an empty string")))
+		})
+		It("rejects an empty-string provider in a patch", func() {
+			p := models.SkillCatalogSourceConfig{Provider: ptr("")}
+			Expect(validateSkillCatalogUpdatePayload(p)).
+				To(MatchError(ContainSubstring("provider must not be an empty string")))
+		})
+		It("rejects an invalid trustTier in a patch", func() {
+			p := models.SkillCatalogSourceConfig{TrustTier: ptr("Community")}
+			Expect(validateSkillCatalogUpdatePayload(p)).
+				To(MatchError(ContainSubstring("invalid trustTier")))
+		})
+	})
+
+	Describe("ParseSkillCatalogYaml", func() {
+		It("reads category/provider/trustTier from repository level (canonical)", func() {
+			raw := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      repositories:
+        - url: https://github.com/example/skills.git
+          provider: Matt
+          category: Development
+          trustTier: communityContributed
+`
+			configs, err := ParseSkillCatalogYaml(raw, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs).To(HaveLen(1))
+			Expect(configs[0].Category).To(HaveValue(Equal("Development")))
+			Expect(configs[0].Provider).To(HaveValue(Equal("Matt")))
+			Expect(configs[0].TrustTier).To(HaveValue(Equal("communityContributed")))
+		})
+
+		It("falls back to properties level for hand-written ConfigMaps", func() {
+			raw := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      category: Development
+      provider: Matt
+      trustTier: communityContributed
+      repositories:
+        - url: https://github.com/example/skills.git
+`
+			configs, err := ParseSkillCatalogYaml(raw, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs).To(HaveLen(1))
+			Expect(configs[0].Category).To(HaveValue(Equal("Development")))
+			Expect(configs[0].Provider).To(HaveValue(Equal("Matt")))
+			Expect(configs[0].TrustTier).To(HaveValue(Equal("communityContributed")))
+		})
+
+		It("prefers repository-level values over properties-level when both exist", func() {
+			raw := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      category: WrongLevel
+      provider: WrongLevel
+      trustTier: platformProvided
+      repositories:
+        - url: https://github.com/example/skills.git
+          category: Development
+          provider: Matt
+          trustTier: communityContributed
+`
+			configs, err := ParseSkillCatalogYaml(raw, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Category).To(HaveValue(Equal("Development")))
+			Expect(configs[0].Provider).To(HaveValue(Equal("Matt")))
+			Expect(configs[0].TrustTier).To(HaveValue(Equal("communityContributed")))
+		})
+
+		It("returns an error instead of silently dropping repositories when the shape is malformed", func() {
+			raw := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      repositories: "not-a-list-of-repos"
+`
+			configs, err := ParseSkillCatalogYaml(raw, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("test-source"))
+			Expect(configs).To(BeNil())
+		})
+	})
+
+	Describe("ConvertSkillSourceConfigToYamlEntry", func() {
+		It("writes all three fields inside each repository entry, not at properties level", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id:        "test-source",
+				Name:      "Test Source",
+				Type:      SkillCatalogTypeGit,
+				Provider:  ptr("Matt"),
+				Category:  ptr("Development"),
+				TrustTier: ptr("communityContributed"),
+				Repositories: []models.SkillRepository{
+					{URL: "https://github.com/example/skills.git"},
+				},
+			}
+			entry := ConvertSkillSourceConfigToYamlEntry(payload)
+
+			props, ok := entry["properties"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(props).NotTo(HaveKey("category"), "category must not leak to properties level")
+			Expect(props).NotTo(HaveKey("provider"), "provider must not leak to properties level")
+			Expect(props).NotTo(HaveKey("trustTier"), "trustTier must not leak to properties level")
+
+			repos, ok := props["repositories"].([]map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(repos).To(HaveLen(1))
+			Expect(repos[0]).To(HaveKeyWithValue("category", "Development"))
+			Expect(repos[0]).To(HaveKeyWithValue("provider", "Matt"))
+			Expect(repos[0]).To(HaveKeyWithValue("trustTier", "communityContributed"))
+		})
+	})
+
+	Describe("UpdateSkillCatalogSourceInYAML", func() {
+		It("migrates all three fields from properties level to repository level on update", func() {
+			existing := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      category: Development
+      provider: Matt
+      trustTier: communityContributed
+      repositories:
+        - url: https://github.com/example/skills.git
+`
+			payload := models.SkillCatalogSourceConfig{
+				Category:     ptr("Development"),
+				Provider:     ptr("Matt"),
+				TrustTier:    ptr("communityContributed"),
+				Repositories: []models.SkillRepository{{URL: "https://github.com/example/skills.git"}},
+			}
+			updated, err := UpdateSkillCatalogSourceInYAML(existing, "test-source", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Re-parse and verify all three landed in the repo, not at properties level
+			configs, err := ParseSkillCatalogYaml(updated, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Category).To(HaveValue(Equal("Development")))
+			Expect(configs[0].Provider).To(HaveValue(Equal("Matt")))
+			Expect(configs[0].TrustTier).To(HaveValue(Equal("communityContributed")))
+
+			// Also confirm the fields sit under the repository and not on properties
+			// itself. A substring check cannot tell the two levels apart — the same
+			// "category: Development" text appears either way — so inspect the structure.
+			var doc struct {
+				Catalogs []struct {
+					Properties map[string]interface{} `yaml:"properties"`
+				} `yaml:"skill_catalogs"`
+			}
+			Expect(yaml.Unmarshal([]byte(updated), &doc)).To(Succeed())
+			Expect(doc.Catalogs).To(HaveLen(1))
+			props := doc.Catalogs[0].Properties
+			Expect(props).NotTo(HaveKey("category"), "category must not be at properties level")
+			Expect(props).NotTo(HaveKey("provider"), "provider must not be at properties level")
+			Expect(props).NotTo(HaveKey("trustTier"), "trustTier must not be at properties level")
+			Expect(props).To(HaveKey("repositories"))
+		})
+	})
+
+	Describe("buildSkillRepoYamlEntries", func() {
+		// backendRepoKeys mirrors SkillRepository in
+		// catalog/internal/catalog/skillcatalog/source_schema.go. That struct is decoded
+		// with DisallowUnknownFields, so emitting a key absent from this set does not get
+		// ignored — it fails the entire source at load time. Adding a key here without a
+		// matching backend field is a breaking change.
+		backendRepoKeys := []string{
+			"url", "canonicalUrl", "refs", "scanPaths", "credentialRef",
+			"trustTier", "provider", "category", "labels",
+			"includedSkills", "excludedSkills", "skillOverrides",
+		}
+
+		It("emits only keys the catalog service declares", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id:        "test-source",
+				Provider:  ptr("Matt"),
+				Category:  ptr("Development"),
+				TrustTier: ptr("communityContributed"),
+				Repositories: []models.SkillRepository{{
+					URL:            "https://github.com/example/skills.git",
+					CanonicalURL:   ptr("https://github.com/upstream/skills.git"),
+					Refs:           []string{"v1.2.3"},
+					ScanPaths:      []string{"skills/"},
+					CredentialRef:  ptr("test-source"),
+					IncludedSkills: []string{"a*"},
+					ExcludedSkills: []string{"*-draft"},
+				}},
+			}
+
+			repos := buildSkillRepoYamlEntries(payload)
+			Expect(repos).To(HaveLen(1))
+			for key := range repos[0] {
+				Expect(backendRepoKeys).To(ContainElement(key),
+					"key %q is not declared by the backend SkillRepository struct and will fail "+
+						"its DisallowUnknownFields decode, breaking the whole source", key)
+			}
+		})
+
+		It("writes the credential as credentialRef and never leaks a token", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id: "test-source",
+				Repositories: []models.SkillRepository{{
+					URL:           "https://github.com/example/skills.git",
+					CredentialRef: ptr("test-source"),
+					AuthToken:     ptr("ghp_supersecret"),
+				}},
+			}
+
+			repos := buildSkillRepoYamlEntries(payload)
+			Expect(repos[0]).To(HaveKeyWithValue("credentialRef", "test-source"))
+			Expect(repos[0]).NotTo(HaveKey("authToken"), "the raw token must never reach the ConfigMap")
+			Expect(repos[0]).NotTo(HaveKey("authSecretName"), "authSecretName is not a backend field")
+		})
+
+		It("preserves every repository field, not just url and refs", func() {
+			// Regression guard: the default-source override path previously emitted only
+			// url and refs, silently dropping the rest when a default source was edited.
+			payload := models.SkillCatalogSourceConfig{
+				Id:       "test-source",
+				Provider: ptr("Matt"),
+				Repositories: []models.SkillRepository{{
+					URL:            "https://github.com/example/skills.git",
+					Refs:           []string{"v1.2.3"},
+					ScanPaths:      []string{"skills/"},
+					IncludedSkills: []string{"a*"},
+					ExcludedSkills: []string{"*-draft"},
+					CredentialRef:  ptr("test-source"),
+				}},
+			}
+
+			repos := buildSkillRepoYamlEntries(payload)
+			Expect(repos[0]).To(HaveKeyWithValue("scanPaths", []string{"skills/"}))
+			Expect(repos[0]).To(HaveKeyWithValue("includedSkills", []string{"a*"}))
+			Expect(repos[0]).To(HaveKeyWithValue("excludedSkills", []string{"*-draft"}))
+			Expect(repos[0]).To(HaveKeyWithValue("credentialRef", "test-source"))
+			Expect(repos[0]).To(HaveKeyWithValue("provider", "Matt"))
+		})
+	})
+
+	Describe("repository labels", func() {
+		// Repo labels are stamped onto every skill the repository yields
+		// (catalog/internal/catalog/skillcatalog/entity_builder.go). They are a
+		// different field from the source-level labels that drive sourceLabel
+		// grouping, and both have to survive a round trip independently.
+		It("round-trips repository labels through write then read", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id:     "test-source",
+				Name:   "Test Source",
+				Type:   SkillCatalogTypeGit,
+				Labels: []string{"source-level"},
+				Repositories: []models.SkillRepository{{
+					URL:    "https://github.com/example/skills.git",
+					Labels: []string{"community", "typescript"},
+				}},
+			}
+			yamlStr, err := AppendSkillCatalogSourceToYaml("", ConvertSkillSourceConfigToYamlEntry(payload))
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(yamlStr, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Repositories[0].Labels).To(Equal([]string{"community", "typescript"}))
+			Expect(configs[0].Labels).To(Equal([]string{"source-level"}),
+				"source-level labels must not be overwritten by repository labels")
+		})
+
+		It("writes repository labels inside the repository entry, not at properties level", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id:   "test-source",
+				Type: SkillCatalogTypeGit,
+				Repositories: []models.SkillRepository{{
+					URL:    "https://github.com/example/skills.git",
+					Labels: []string{"community"},
+				}},
+			}
+			entry := ConvertSkillSourceConfigToYamlEntry(payload)
+			props, ok := entry["properties"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(props).NotTo(HaveKey("labels"))
+
+			repos, ok := props["repositories"].([]map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(repos[0]).To(HaveKeyWithValue("labels", []string{"community"}))
+		})
+
+		It("clears repository labels when an update omits them", func() {
+			existing := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      repositories:
+        - url: https://github.com/example/skills.git
+          labels: [community]
+`
+			payload := models.SkillCatalogSourceConfig{
+				Repositories: []models.SkillRepository{{URL: "https://github.com/example/skills.git"}},
+			}
+			updated, err := UpdateSkillCatalogSourceInYAML(existing, "test-source", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(updated, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Repositories[0].Labels).To(BeEmpty())
+		})
+	})
+
+	Describe("source label updates", func() {
+		const existing = `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    labels: [alpha, beta]
+    properties:
+      repositories:
+        - url: https://github.com/example/skills.git
+`
+
+		It("clears source labels when given an empty (non-nil) list", func() {
+			// Regression guard: the old `len(payload.Labels) > 0` check made removing
+			// every label a no-op, which also meant the ConfigMap came back
+			// byte-identical and the catalog never reloaded.
+			payload := models.SkillCatalogSourceConfig{Labels: []string{}}
+			updated, err := UpdateSkillCatalogSourceInYAML(existing, "test-source", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(updated, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Labels).To(BeEmpty())
+		})
+
+		It("leaves source labels alone when they are not sent at all", func() {
+			// A toggle-only update must not wipe labels it was never given.
+			enabled := false
+			payload := models.SkillCatalogSourceConfig{Enabled: &enabled}
+			updated, err := UpdateSkillCatalogSourceInYAML(existing, "test-source", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(updated, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Labels).To(Equal([]string{"alpha", "beta"}))
+			Expect(configs[0].Enabled).To(HaveValue(BeFalse()))
+		})
+
+		It("replaces source labels when given a new list", func() {
+			payload := models.SkillCatalogSourceConfig{Labels: []string{"gamma"}}
+			updated, err := UpdateSkillCatalogSourceInYAML(existing, "test-source", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(updated, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Labels).To(Equal([]string{"gamma"}))
+		})
+	})
+
+	Describe("default-source label overrides", func() {
+		It("keeps an empty label list distinguishable from an absent one after a YAML round trip", func() {
+			// The default-override path writes `labels: []` to mean "clear the
+			// default's labels". That only works if the value survives as a non-nil
+			// empty slice, because mergeSkillCatalogSourceConfigs branches on nil.
+			yamlStr, err := AppendSkillCatalogSourceToYaml("", map[string]interface{}{
+				"id":     "test-source",
+				"labels": []string{},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(yamlStr, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Labels).NotTo(BeNil(), "an explicit clear must not decode as nil")
+			Expect(configs[0].Labels).To(BeEmpty())
+
+			merged := mergeSkillCatalogSourceConfigs(
+				models.SkillCatalogSourceConfig{Id: "test-source", Labels: []string{"shipped"}},
+				configs[0],
+			)
+			Expect(merged.Labels).To(BeEmpty())
+		})
+	})
+
+	Describe("mergeSkillCatalogSourceConfigs", func() {
+		It("lets a user override clear a default source's labels", func() {
+			merged := mergeSkillCatalogSourceConfigs(
+				models.SkillCatalogSourceConfig{Id: "s", Labels: []string{"shipped"}},
+				models.SkillCatalogSourceConfig{Id: "s", Labels: []string{}},
+			)
+			Expect(merged.Labels).To(BeEmpty())
+		})
+
+		It("keeps the default's labels when the override does not mention them", func() {
+			merged := mergeSkillCatalogSourceConfigs(
+				models.SkillCatalogSourceConfig{Id: "s", Labels: []string{"shipped"}},
+				models.SkillCatalogSourceConfig{Id: "s"},
+			)
+			Expect(merged.Labels).To(Equal([]string{"shipped"}))
+		})
+	})
+
+	Describe("validateSkillRepositories", func() {
+		It("accepts a credentialRef that is a plain filename", func() {
+			Expect(validateSkillRepositories([]models.SkillRepository{
+				{URL: "https://github.com/example/skills.git", CredentialRef: ptr("matt-pocock-skills")},
+			})).To(Succeed())
+		})
+		It("rejects a credentialRef containing a path separator", func() {
+			Expect(validateSkillRepositories([]models.SkillRepository{
+				{URL: "https://github.com/example/skills.git", CredentialRef: ptr("../../etc/passwd")},
+			})).To(MatchError(ContainSubstring("must be a plain filename")))
+		})
+		It("still requires a repository url", func() {
+			Expect(validateSkillRepositories([]models.SkillRepository{{URL: ""}})).
+				To(MatchError(ContainSubstring("url is required")))
+		})
+	})
+
+	Describe("credentialRef round-trip", func() {
+		It("survives write then read", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id:   "test-source",
+				Name: "Test Source",
+				Type: SkillCatalogTypeGit,
+				Repositories: []models.SkillRepository{{
+					URL:           "https://github.com/example/skills.git",
+					CredentialRef: ptr("test-source"),
+				}},
+			}
+			yamlStr, err := AppendSkillCatalogSourceToYaml("", ConvertSkillSourceConfigToYamlEntry(payload))
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(yamlStr, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Repositories[0].CredentialRef).To(HaveValue(Equal("test-source")))
+		})
+	})
+})
+
+var _ = Describe("skillOverrides round trip", func() {
+	// The settings UI has no control for skillOverrides, so an edit sends back whatever
+	// the previous read returned. The write path rebuilds properties.repositories from
+	// scratch, so anything it fails to emit is deleted rather than left alone.
+	const sourceYAML = `
+skill_catalogs:
+  - id: acme_skills
+    name: Acme Skills
+    type: git-skills-plugin
+    enabled: true
+    properties:
+      repositories:
+        - url: https://github.com/acme/skills.git
+          category: DevOps
+          skillOverrides:
+            - name: deploy
+              category: SRE
+              labels: [ops, oncall]
+            - name: lint
+              category: QA
+`
+
+	It("reads skillOverrides off a repository entry", func() {
+		parsed, err := ParseSkillCatalogYaml(sourceYAML, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parsed).To(HaveLen(1))
+		Expect(parsed[0].Repositories).To(HaveLen(1))
+
+		overrides := parsed[0].Repositories[0].SkillOverrides
+		Expect(overrides).To(HaveLen(2))
+		Expect(overrides[0].Name).To(Equal("deploy"))
+		Expect(*overrides[0].Category).To(Equal("SRE"))
+		Expect(overrides[0].Labels).To(Equal([]string{"ops", "oncall"}))
+		Expect(overrides[1].Name).To(Equal("lint"))
+		Expect(overrides[1].Labels).To(BeEmpty())
+	})
+
+	It("preserves them through a save that does not touch them", func() {
+		parsed, err := ParseSkillCatalogYaml(sourceYAML, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Feed the parsed config straight back, the way an unrelated UI edit would.
+		updated, err := UpdateSkillCatalogSourceInYAML(sourceYAML, "acme_skills", parsed[0])
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(ContainSubstring("skillOverrides"))
+
+		reparsed, err := ParseSkillCatalogYaml(updated, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reparsed).To(HaveLen(1))
+		Expect(reparsed[0].Repositories[0].SkillOverrides).
+			To(Equal(parsed[0].Repositories[0].SkillOverrides))
+	})
+
+	It("omits the key entirely when a source has no overrides", func() {
+		payload := models.SkillCatalogSourceConfigPayload{
+			Id:   "plain_source",
+			Name: "Plain",
+			Type: SkillCatalogTypeGit,
+			Repositories: []models.SkillRepository{
+				{URL: "https://github.com/acme/plain.git"},
+			},
+		}
+		entry := ConvertSkillSourceConfigToYamlEntry(payload)
+		out, err := AppendSkillCatalogSourceToYaml("", entry)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).NotTo(ContainSubstring("skillOverrides"))
+	})
+})
+
+var _ = Describe("default source override round trip", func() {
+	// Toggling a shipped default off writes an override entry carrying only {id, enabled}.
+	// Toggling it back on then takes the user-source update path. That path must not emit
+	// `properties: {}`: MergeCommonSourceFields replaces the base source's Properties
+	// whenever the override's is non-nil, so an empty map strips the default's
+	// repositories and the source stops loading entirely.
+	It("does not write an empty properties map when the override has none", func() {
+		existing := "skill_catalogs:\n    - enabled: false\n      id: community_skills\n"
+
+		updated, err := UpdateSkillCatalogSourceInYAML(existing, "community_skills",
+			models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(true)})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).NotTo(ContainSubstring("properties"))
+
+		reparsed, err := ParseSkillCatalogYaml(updated, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reparsed).To(HaveLen(1))
+		Expect(*reparsed[0].Enabled).To(BeTrue())
+	})
+
+	It("still writes properties when the update carries repositories", func() {
+		existing := "skill_catalogs:\n    - enabled: true\n      id: custom\n"
+
+		updated, err := UpdateSkillCatalogSourceInYAML(existing, "custom",
+			models.SkillCatalogSourceConfigPayload{
+				Repositories: []models.SkillRepository{{URL: "https://github.com/example/skills"}},
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(ContainSubstring("repositories"))
+	})
+})

--- a/clients/ui/bff/internal/repositories/skill_catalog_settings.go
+++ b/clients/ui/bff/internal/repositories/skill_catalog_settings.go
@@ -1,0 +1,249 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+var (
+	ErrSkillCatalogSourceNotFound      = errors.New("skill catalog source not found")
+	ErrSkillCatalogSourceAlreadyExist  = errors.New("skill catalog source already exists")
+	ErrSkillCatalogSourceIdRequired    = errors.New("skill catalog source ID is required")
+	ErrSkillCatalogSourceConflict      = errors.New("skill catalog source was modified by another request")
+	ErrSkillCatalogCannotChangeDefault = errors.New("cannot change the default skill source")
+	ErrSkillCatalogCannotDeleteDefault = errors.New("cannot delete the default skill source")
+	ErrSkillCatalogValidationFailed    = errors.New("validation failed")
+	ErrSkillCatalogCannotChangeType    = errors.New("cannot change skill catalog source type")
+)
+
+type SkillCatalogSettingsRepository struct{}
+
+func NewSkillCatalogSettingsRepository() *SkillCatalogSettingsRepository {
+	return &SkillCatalogSettingsRepository{}
+}
+
+func (r *SkillCatalogSettingsRepository) GetAllSkillCatalogSourceConfigs(ctx context.Context, client k8s.KubernetesClientInterface, namespace string) (*models.SkillCatalogSourceConfigList, error) {
+	defaultCM, userCM, err := client.GetAllSkillCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch skill catalog source configmaps: %w", err)
+	}
+
+	catalogMap := make(map[string]models.SkillCatalogSourceConfig)
+
+	if raw, ok := defaultCM.Data[k8s.SkillCatalogSourceKey]; ok {
+		defaultSources, err := ParseSkillCatalogYaml(raw, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse default skill catalogs: %w", err)
+		}
+		for _, src := range defaultSources {
+			catalogMap[src.Id] = src
+		}
+	}
+
+	if raw, ok := userCM.Data[k8s.SkillCatalogSourceKey]; ok {
+		userSources, err := ParseSkillCatalogYaml(raw, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse user managed skill catalogs: %w", err)
+		}
+		for _, userSrc := range userSources {
+			if existing, ok := catalogMap[userSrc.Id]; ok {
+				catalogMap[userSrc.Id] = mergeSkillCatalogSourceConfigs(existing, userSrc)
+			} else {
+				catalogMap[userSrc.Id] = userSrc
+			}
+		}
+	}
+
+	list := &models.SkillCatalogSourceConfigList{
+		Catalogs: make([]models.SkillCatalogSourceConfig, 0, len(catalogMap)),
+	}
+	for _, src := range catalogMap {
+		list.Catalogs = append(list.Catalogs, src)
+	}
+
+	return list, nil
+}
+
+func (r *SkillCatalogSettingsRepository) GetSkillCatalogSourceConfig(ctx context.Context, client k8s.KubernetesClientInterface, namespace, sourceID string) (*models.SkillCatalogSourceConfig, error) {
+	defaultCM, userCM, err := client.GetAllSkillCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch skill catalog source configmaps: %w", err)
+	}
+
+	defaultSrc := FindSkillCatalogSourceById(defaultCM.Data[k8s.SkillCatalogSourceKey], sourceID, true)
+	userSrc := FindSkillCatalogSourceById(userCM.Data[k8s.SkillCatalogSourceKey], sourceID, false)
+
+	if userSrc != nil {
+		if defaultSrc != nil {
+			merged := mergeSkillCatalogSourceConfigs(*defaultSrc, *userSrc)
+			return &merged, nil
+		}
+		return userSrc, nil
+	}
+	if defaultSrc != nil {
+		return defaultSrc, nil
+	}
+
+	return nil, fmt.Errorf("%w: %s", ErrSkillCatalogSourceNotFound, sourceID)
+}
+
+func (r *SkillCatalogSettingsRepository) CreateSkillCatalogSourceConfig(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace string,
+	payload models.SkillCatalogSourceConfigPayload,
+) (*models.SkillCatalogSourceConfig, error) {
+	if err := validateSkillCatalogSourceConfigPayload(payload); err != nil {
+		return nil, err
+	}
+
+	defaultCM, userCM, err := client.GetAllSkillCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch skill catalog source configmaps: %w", err)
+	}
+
+	if FindSkillCatalogSourceById(defaultCM.Data[k8s.SkillCatalogSourceKey], payload.Id, true) != nil {
+		return nil, fmt.Errorf("%w: '%s' already exists in default sources", ErrSkillCatalogSourceAlreadyExist, payload.Id)
+	}
+	if FindSkillCatalogSourceById(userCM.Data[k8s.SkillCatalogSourceKey], payload.Id, false) != nil {
+		return nil, fmt.Errorf("%w: '%s' already exists in user managed sources", ErrSkillCatalogSourceAlreadyExist, payload.Id)
+	}
+
+	newEntry := ConvertSkillSourceConfigToYamlEntry(payload)
+	existing := userCM.Data[k8s.SkillCatalogSourceKey]
+
+	updated, err := AppendSkillCatalogSourceToYaml(existing, newEntry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to append skill catalog to yaml: %w", err)
+	}
+
+	if userCM.Data == nil {
+		userCM.Data = make(map[string]string)
+	}
+	userCM.Data[k8s.SkillCatalogSourceKey] = updated
+
+	if err := client.UpdateSkillCatalogSourceConfig(ctx, namespace, &userCM); err != nil {
+		if apierrors.IsConflict(err) {
+			return nil, fmt.Errorf("%w: %v", ErrSkillCatalogSourceConflict, err)
+		}
+		return nil, fmt.Errorf("failed to update user skill catalog configmap: %w", err)
+	}
+
+	return r.GetSkillCatalogSourceConfig(ctx, client, namespace, payload.Id)
+}
+
+func (r *SkillCatalogSettingsRepository) UpdateSkillCatalogSourceConfig(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace, sourceID string,
+	payload models.SkillCatalogSourceConfigPayload,
+) (*models.SkillCatalogSourceConfig, error) {
+	if err := validateSkillCatalogUpdatePayload(payload); err != nil {
+		return nil, err
+	}
+
+	defaultCM, userCM, err := client.GetAllSkillCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch skill catalog source configmaps: %w", err)
+	}
+
+	existingUser := FindSkillCatalogSourceById(userCM.Data[k8s.SkillCatalogSourceKey], sourceID, false)
+	existingDefault := FindSkillCatalogSourceById(defaultCM.Data[k8s.SkillCatalogSourceKey], sourceID, true)
+
+	if existingUser == nil && existingDefault == nil {
+		return nil, fmt.Errorf("%w: '%s'", ErrSkillCatalogSourceNotFound, sourceID)
+	}
+
+	isOverridingDefault := existingDefault != nil
+
+	if payload.Type != "" {
+		existing := existingUser
+		if existing == nil {
+			existing = existingDefault
+		}
+		if payload.Type != existing.Type {
+			return nil, fmt.Errorf("%w: cannot change from '%s' to '%s'", ErrSkillCatalogCannotChangeType, existing.Type, payload.Type)
+		}
+	}
+
+	// Applies whenever a default with this id exists, not only on the first override:
+	// once an enabled-toggle has written a user entry, later updates take the branch
+	// below, which would otherwise let name/repositories through unchecked. This mirrors
+	// where the MCP catalog places the same check.
+	if isOverridingDefault {
+		if err := validateSkillUpdatePayloadForDefaultOverride(payload); err != nil {
+			return nil, err
+		}
+	}
+
+	if userCM.Data == nil {
+		userCM.Data = make(map[string]string)
+	}
+
+	if existingUser != nil {
+		updatedYAML, err := UpdateSkillCatalogSourceInYAML(userCM.Data[k8s.SkillCatalogSourceKey], sourceID, payload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update skill catalog in yaml: %w", err)
+		}
+		userCM.Data[k8s.SkillCatalogSourceKey] = updatedYAML
+	} else if isOverridingDefault {
+		overrideEntry := map[string]interface{}{"id": sourceID}
+		if payload.Enabled != nil {
+			overrideEntry["enabled"] = *payload.Enabled
+		}
+		updatedYAML, err := AppendSkillCatalogSourceToYaml(userCM.Data[k8s.SkillCatalogSourceKey], overrideEntry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to append override entry: %w", err)
+		}
+		userCM.Data[k8s.SkillCatalogSourceKey] = updatedYAML
+	}
+
+	if err := client.UpdateSkillCatalogSourceConfig(ctx, namespace, &userCM); err != nil {
+		if apierrors.IsConflict(err) {
+			return nil, fmt.Errorf("%w: %v", ErrSkillCatalogSourceConflict, err)
+		}
+		return nil, fmt.Errorf("failed to update user skill catalog configmap: %w", err)
+	}
+
+	return r.GetSkillCatalogSourceConfig(ctx, client, namespace, sourceID)
+}
+
+func (r *SkillCatalogSettingsRepository) DeleteSkillCatalogSourceConfig(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace, sourceID string,
+) (*models.SkillCatalogSourceConfig, error) {
+	defaultCM, userCM, err := client.GetAllSkillCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch skill catalog source configmaps: %w", err)
+	}
+
+	if FindSkillCatalogSourceById(defaultCM.Data[k8s.SkillCatalogSourceKey], sourceID, true) != nil {
+		return nil, fmt.Errorf("%w: '%s' is a default source", ErrSkillCatalogCannotDeleteDefault, sourceID)
+	}
+
+	toDelete := FindSkillCatalogSourceById(userCM.Data[k8s.SkillCatalogSourceKey], sourceID, false)
+	if toDelete == nil {
+		return nil, fmt.Errorf("%w: '%s' not found in user sources", ErrSkillCatalogSourceNotFound, sourceID)
+	}
+
+	updatedYAML, err := RemoveSkillCatalogSourceFromYAML(userCM.Data[k8s.SkillCatalogSourceKey], sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove skill catalog from sources.yaml: %w", err)
+	}
+	userCM.Data[k8s.SkillCatalogSourceKey] = updatedYAML
+
+	if err := client.UpdateSkillCatalogSourceConfig(ctx, namespace, &userCM); err != nil {
+		if apierrors.IsConflict(err) {
+			return nil, fmt.Errorf("%w: %v", ErrSkillCatalogSourceConflict, err)
+		}
+		return nil, fmt.Errorf("failed to update configmap after deletion: %w", err)
+	}
+
+	return toDelete, nil
+}

--- a/clients/ui/bff/internal/repositories/skill_catalog_settings_test.go
+++ b/clients/ui/bff/internal/repositories/skill_catalog_settings_test.go
@@ -1,0 +1,321 @@
+package repositories
+
+import (
+	"context"
+
+	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/hub/ui/bff/internal/mocks"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SkillCatalogSettingsRepository", func() {
+	var (
+		repo      *SkillCatalogSettingsRepository
+		k8sClient k8s.KubernetesClientInterface
+		ctx       context.Context
+	)
+
+	BeforeEach(func() {
+		repo = NewSkillCatalogSettingsRepository()
+		var err error
+		k8sClient, err = kubernetesMockedStaticClientFactory.GetClient(mocks.NewMockSessionContextNoParent())
+		Expect(err).NotTo(HaveOccurred())
+		ctx = mocks.NewMockSessionContextNoParent()
+	})
+
+	findById := func(list *models.SkillCatalogSourceConfigList, id string) *models.SkillCatalogSourceConfig {
+		for i := range list.Catalogs {
+			if list.Catalogs[i].Id == id {
+				return &list.Catalogs[i]
+			}
+		}
+		return nil
+	}
+
+	gitSource := func(id, name string) models.SkillCatalogSourceConfigPayload {
+		return models.SkillCatalogSourceConfigPayload{
+			Id:      id,
+			Name:    name,
+			Type:    SkillCatalogTypeGit,
+			Enabled: skillBoolPtr(true),
+			Repositories: []models.SkillRepository{
+				{URL: "https://github.com/example/" + id, Refs: []string{"v1.0.0"}},
+			},
+		}
+	}
+
+	Describe("GetAllSkillCatalogSourceConfigs", func() {
+		It("returns sources merged from both the default and user managed configmaps", func() {
+			list, err := repo.GetAllSkillCatalogSourceConfigs(ctx, k8sClient, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(findById(list, "community_skills")).NotTo(BeNil())
+			Expect(findById(list, "custom_skills")).NotTo(BeNil())
+		})
+
+		It("marks a source from the default configmap as default", func() {
+			list, err := repo.GetAllSkillCatalogSourceConfigs(ctx, k8sClient, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*findById(list, "community_skills").IsDefault).To(BeTrue())
+			Expect(*findById(list, "custom_skills").IsDefault).To(BeFalse())
+		})
+
+		It("lets a user override win over the default it shadows", func() {
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "bella-namespace", "community_skills",
+				models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(false)})
+			Expect(err).NotTo(HaveOccurred())
+
+			list, err := repo.GetAllSkillCatalogSourceConfigs(ctx, k8sClient, "bella-namespace")
+			Expect(err).NotTo(HaveOccurred())
+			merged := findById(list, "community_skills")
+			Expect(merged).NotTo(BeNil())
+			Expect(*merged.Enabled).To(BeFalse())
+			// Fields the override does not carry still come from the default.
+			Expect(merged.Name).To(Equal("Community Skills"))
+			Expect(*merged.IsDefault).To(BeTrue())
+		})
+	})
+
+	Describe("GetSkillCatalogSourceConfig", func() {
+		It("reads repository metadata from the first repository entry", func() {
+			config, err := repo.GetSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_skills")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Type).To(Equal(SkillCatalogTypeGit))
+			Expect(config.Repositories).To(HaveLen(1))
+			Expect(config.Repositories[0].URL).To(Equal("https://github.com/example/community-skills"))
+			Expect(config.Repositories[0].Refs).To(Equal([]string{"v1.0.0"}))
+			Expect(*config.Provider).To(Equal("Community"))
+			Expect(*config.Category).To(Equal("development"))
+			Expect(*config.TrustTier).To(Equal("communityContributed"))
+		})
+
+		It("returns the credentialRef but never an auth token", func() {
+			config, err := repo.GetSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_skills")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*config.Repositories[0].CredentialRef).To(Equal("custom_skills"))
+			Expect(config.Repositories[0].AuthToken).To(BeNil())
+		})
+
+		It("returns ErrSkillCatalogSourceNotFound for an unknown id", func() {
+			_, err := repo.GetSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "does_not_exist")
+			Expect(err).To(MatchError(ErrSkillCatalogSourceNotFound))
+		})
+	})
+
+	Describe("CreateSkillCatalogSourceConfig", func() {
+		It("persists a new source so it can be read back", func() {
+			created, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", gitSource("skill_repo_create", "Skill Repo Create"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(created.Id).To(Equal("skill_repo_create"))
+			Expect(*created.IsDefault).To(BeFalse())
+
+			readBack, err := repo.GetSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_create")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(readBack.Repositories).To(HaveLen(1))
+		})
+
+		It("writes provider, category and trustTier onto the repository entry", func() {
+			payload := gitSource("skill_repo_metadata", "Skill Repo Metadata")
+			payload.Provider = skillStringPtr("Acme")
+			payload.Category = skillStringPtr("security")
+			payload.TrustTier = skillStringPtr("partnerVerified")
+
+			created, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*created.Provider).To(Equal("Acme"))
+			Expect(*created.Category).To(Equal("security"))
+			Expect(*created.TrustTier).To(Equal("partnerVerified"))
+		})
+
+		It("rejects a source that duplicates a default", func() {
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", gitSource("community_skills", "Duplicate"))
+			Expect(err).To(MatchError(ErrSkillCatalogSourceAlreadyExist))
+		})
+
+		It("rejects a source with no id", func() {
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", gitSource("", "No Id"))
+			Expect(err).To(MatchError(ErrSkillCatalogSourceIdRequired))
+		})
+
+		It("rejects a non git-skills-plugin type", func() {
+			payload := gitSource("skill_repo_bad_type", "Bad Type")
+			payload.Type = "yaml"
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+		})
+
+		It("rejects a source with no repositories", func() {
+			payload := gitSource("skill_repo_no_repos", "No Repos")
+			payload.Repositories = nil
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+		})
+
+		It("rejects a source listing more than one repository", func() {
+			payload := gitSource("skill_repo_two_repos", "Two Repos")
+			payload.Repositories = []models.SkillRepository{
+				{URL: "https://github.com/example/one"},
+				{URL: "https://github.com/example/two"},
+			}
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+			Expect(err.Error()).To(ContainSubstring("single repository"))
+		})
+
+		It("rejects a credentialRef that could escape the mounted secret directory", func() {
+			payload := gitSource("skill_repo_bad_ref", "Bad Credential Ref")
+			payload.Repositories[0].CredentialRef = skillStringPtr("../../etc/passwd")
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+		})
+
+		It("rejects a trustTier outside the SkillTrustTier enum", func() {
+			payload := gitSource("skill_repo_bad_tier", "Bad Tier")
+			payload.TrustTier = skillStringPtr("goldPlated")
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+		})
+	})
+
+	Describe("UpdateSkillCatalogSourceConfig", func() {
+		It("updates a user managed source in place", func() {
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", gitSource("skill_repo_update", "Before"))
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_update",
+				models.SkillCatalogSourceConfigPayload{Name: "After", Enabled: skillBoolPtr(false)})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Name).To(Equal("After"))
+			Expect(*updated.Enabled).To(BeFalse())
+		})
+
+		It("clears labels when given an empty but non-nil slice", func() {
+			payload := gitSource("skill_repo_labels", "Labels")
+			payload.Labels = []string{"Keep"}
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_labels",
+				models.SkillCatalogSourceConfigPayload{Labels: []string{}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Labels).To(BeEmpty())
+		})
+
+		It("leaves labels alone when the payload omits them", func() {
+			payload := gitSource("skill_repo_labels_kept", "Labels Kept")
+			payload.Labels = []string{"Keep"}
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_labels_kept",
+				models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(false)})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Labels).To(Equal([]string{"Keep"}))
+		})
+
+		It("refuses every field but enabled on a shipped default", func() {
+			for _, tc := range []struct {
+				field   string
+				payload models.SkillCatalogSourceConfigPayload
+			}{
+				{"name", models.SkillCatalogSourceConfigPayload{Name: "Renamed"}},
+				{"labels", models.SkillCatalogSourceConfigPayload{Labels: []string{"Mine"}}},
+				{"repositories", models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{{URL: "https://github.com/attacker/evil-skills"}},
+				}},
+				{"provider", models.SkillCatalogSourceConfigPayload{Provider: skillStringPtr("Attacker")}},
+				{"trustTier", models.SkillCatalogSourceConfigPayload{TrustTier: skillStringPtr("platformProvided")}},
+			} {
+				_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_skills", tc.payload)
+				Expect(err).To(MatchError(ErrSkillCatalogCannotChangeDefault), "expected %s to be rejected on a default", tc.field)
+			}
+		})
+
+		It("still allows toggling enabled on a shipped default", func() {
+			updated, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_skills",
+				models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(false)})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*updated.Enabled).To(BeFalse())
+			Expect(updated.Name).To(Equal("Community Skills"))
+		})
+
+		It("keeps enforcing the default guard after an override entry already exists", func() {
+			// The first toggle writes a user entry, so a later update takes the
+			// user-source branch. The guard must still apply there.
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "bella-namespace", "community_skills",
+				models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(false)})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "bella-namespace", "community_skills",
+				models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{{URL: "https://github.com/attacker/evil-skills"}},
+				})
+			Expect(err).To(MatchError(ErrSkillCatalogCannotChangeDefault))
+		})
+
+		It("refuses to change the source type", func() {
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_skills",
+				models.SkillCatalogSourceConfigPayload{Type: "yaml"})
+			Expect(err).To(MatchError(ErrSkillCatalogCannotChangeType))
+		})
+
+		It("returns ErrSkillCatalogSourceNotFound for an unknown id", func() {
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "does_not_exist",
+				models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(false)})
+			Expect(err).To(MatchError(ErrSkillCatalogSourceNotFound))
+		})
+
+		It("rejects more than one repository on update too", func() {
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_skills",
+				models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{
+						{URL: "https://github.com/example/one"},
+						{URL: "https://github.com/example/two"},
+					},
+				})
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+			Expect(err.Error()).To(ContainSubstring("single repository"))
+		})
+
+		It("validates repositories on update", func() {
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_skills",
+				models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{{URL: ""}},
+				})
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+		})
+	})
+
+	Describe("DeleteSkillCatalogSourceConfig", func() {
+		It("removes a user managed source", func() {
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", gitSource("skill_repo_delete", "Skill Repo Delete"))
+			Expect(err).NotTo(HaveOccurred())
+
+			deleted, err := repo.DeleteSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_delete")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleted.Id).To(Equal("skill_repo_delete"))
+
+			_, err = repo.GetSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_delete")
+			Expect(err).To(MatchError(ErrSkillCatalogSourceNotFound))
+		})
+
+		It("refuses to delete a default source", func() {
+			_, err := repo.DeleteSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_skills")
+			Expect(err).To(MatchError(ErrSkillCatalogCannotDeleteDefault))
+		})
+
+		It("returns ErrSkillCatalogSourceNotFound for an unknown id", func() {
+			_, err := repo.DeleteSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "does_not_exist")
+			Expect(err).To(MatchError(ErrSkillCatalogSourceNotFound))
+		})
+	})
+})
+
+func skillBoolPtr(b bool) *bool {
+	return &b
+}
+
+func skillStringPtr(s string) *string {
+	return &s
+}

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -17,11 +17,13 @@ networks:
 services:
   model-registry-ui:
     build:
-      context: ./clients/ui
-      dockerfile: Dockerfile.standalone
+      context: .
+      dockerfile: clients/ui/Dockerfile.standalone
       args:
         DEPLOYMENT_MODE: standalone
         STYLE_THEME: mui-theme
+        UI_SOURCE_CODE: ./clients/ui/frontend
+        BFF_SOURCE_CODE: ./clients/ui/bff
     command:
       - --port=9000
       - --mock-k8s-client=true


### PR DESCRIPTION
## Description

The `skill catalog` functionality is defined at [KEP-0005](https://github.com/kubeflow/hub/tree/main/proposals/KEP-0005-skills-catalog)

This PR, adds the BFF layer for the skill catalog: proxy endpoints for [browsing skills and their filter options](https://github.com/kubeflow/hub/blob/43ef2be81724ce7977c8990c02848b9f6d38d38f/api/openapi/catalog-v1.yaml#L816), the Claude Code marketplace manifest, and CRUD for git-backed skill sources written to a user-managed ConfigMap. The UI that consumes these lands separately.

Notable behavior:

- Targets the catalog's v1 skill API. v1alpha1 no longer serves skills (#3103), and v1 renames fields to camelCase, which models.Skill's tags follow (sourceId).
- Shipped default sources are read-only apart from being enabled or disabled, matching the model and MCP catalogs. The guard applies whenever a default with that id exists, not only on first override, so it cannot be bypassed by toggling a source and then editing it.
- A source carries a single repository inline, which is what the catalog service accepts (#3108); several are configured through yamlCatalogPath.
- skillOverrides are round-tripped rather than dropped, so a save does not delete per-skill metadata set through GitOps. The write path rebuilds properties.repositories from the model, so any field absent from it is erased rather than merely uneditable.
- An update that carries no properties omits the key instead of writing an empty map. `properties: {}` is not the same as omitting it: MergeCommonSourceFields replaces the base source's properties whenever the override's is non-nil, so an empty map strips a shipped default's repositories and the source stops loading.
- Git tokens are stored in the shared git-credentials Secret and referenced by credentialRef, never reaching a ConfigMap or a response body. Only a missing Secret falls back to create, so an RBAC failure is reported as itself.
- Filter options come solely from the catalog service, so a filter never offers a value matching no skill.
- The marketplace URL advertised for `/plugin marketplace add` is the catalog service's, which serves marketplace.json unauthenticated; this BFF route is namespace-scoped and authenticated, so an agent cannot use it. Defaults to the in-cluster address, with SKILL_CATALOG_MARKETPLACE_URL for externally exposed deployments.

docker-compose-local.yaml builds from the repository root: Dockerfile.standalone copies pkg/openapi, which the compose build context did not previously include.

Assisted-by: Claude Opus 5

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
