### PR TITLE
[Draft] Skill catalog UI

### DIFF
--- a/clients/ui/bff/cmd/main.go
+++ b/clients/ui/bff/cmd/main.go
@@ -42,6 +42,9 @@ func main() {
 	flag.BoolVar(&cfg.DevMode, "dev-mode", false, "Use development mode for access to local K8s cluster")
 	flag.IntVar(&cfg.DevModeModelRegistryPort, "dev-mode-model-registry-port", getEnvAsInt("DEV_MODE_MODEL_REGISTRY_PORT", 8080), "Use port when in development mode for model registry")
 	flag.IntVar(&cfg.DevModeCatalogPort, "dev-mode-catalog-port", getEnvAsInt("DEV_MODE_CATALOG_PORT", 8081), "Use port when in development mode for catalog")
+	flag.StringVar(&cfg.DevModeCatalogNamespace, "dev-mode-catalog-namespace", getEnvAsString("DEV_MODE_CATALOG_NAMESPACE", ""), "Namespace where the catalog service runs in dev mode (used for skill catalog settings ConfigMap writes)")
+	flag.StringVar(&cfg.SkillCatalogGitCredentialsSecret, "skill-catalog-git-credentials-secret", getEnvAsString("SKILL_CATALOG_GIT_CREDENTIALS_SECRET", "skill-catalog-git-credentials"), "Name of the Secret mounted into the catalog pod holding per-source git tokens, keyed by skill source id")
+	flag.StringVar(&cfg.SkillCatalogMarketplaceURL, "skill-catalog-marketplace-url", getEnvAsString("SKILL_CATALOG_MARKETPLACE_URL", ""), "External URL of the catalog's claude/marketplace.json, shown in skill install instructions. Empty (default) uses the catalog's in-cluster address, which suits agents running in the cluster; set this when the catalog is exposed through a Route or Ingress")
 
 	// New deployment mode flag
 	flag.Var(&cfg.DeploymentMode, "deployment-mode", "Deployment mode (kubeflow, federated, or standalone)")

--- a/clients/ui/bff/internal/api/app.go
+++ b/clients/ui/bff/internal/api/app.go
@@ -108,6 +108,20 @@ const (
 	McpCatalogSettingsPathPrefix           = SettingsPath + "/mcp_catalog"
 	McpCatalogSettingsSourceConfigListPath = McpCatalogSettingsPathPrefix + "/source_configs"
 	McpCatalogSettingsSourceConfigPath     = McpCatalogSettingsSourceConfigListPath + "/:" + CatalogSourceId
+
+	// Skill catalog
+	SkillId                     = "skill_id"
+	SkillCatalogPathPrefix      = ApiPathPrefix + "/skill_catalog"
+	SkillListPath               = SkillCatalogPathPrefix + "/skills"
+	SkillFilterOptionListPath   = SkillCatalogPathPrefix + "/skills_filter_options"
+	SkillPath                   = SkillListPath + "/:" + SkillId
+	SkillCatalogMarketplacePath = SkillCatalogPathPrefix + "/claude/marketplace.json"
+
+	// Skill catalog settings
+	SkillCatalogSettingsPathPrefix           = SettingsPath + "/skill_catalog"
+	SkillCatalogSettingsSourceConfigListPath = SkillCatalogSettingsPathPrefix + "/source_configs"
+	SkillCatalogSettingsSourceConfigPath     = SkillCatalogSettingsSourceConfigListPath + "/:" + CatalogSourceId
+	SkillCatalogSettingsSourcePreviewPath    = SkillCatalogSettingsPathPrefix + "/source_preview"
 )
 
 type App struct {
@@ -362,6 +376,20 @@ func (app *App) Routes() http.Handler {
 		apiRouter.GET(McpCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.GetMcpCatalogSourceConfigHandler)))
 		apiRouter.PATCH(McpCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.UpdateMcpCatalogSourceConfigHandler)))
 		apiRouter.DELETE(McpCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.DeleteMcpCatalogSourceConfigHandler)))
+
+		// Skill catalog endpoints
+		apiRouter.GET(SkillListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetAllSkillsHandler))))
+		apiRouter.GET(SkillFilterOptionListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetSkillsFiltersHandler))))
+		apiRouter.GET(SkillPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetSkillHandler))))
+		apiRouter.GET(SkillCatalogMarketplacePath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.GetSkillMarketplaceHandler))))
+
+		// Skill catalog settings page
+		apiRouter.GET(SkillCatalogSettingsSourceConfigListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.GetAllSkillCatalogSourceConfigsHandler)))
+		apiRouter.POST(SkillCatalogSettingsSourceConfigListPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.CreateSkillCatalogSourceConfigHandler)))
+		apiRouter.GET(SkillCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.GetSkillCatalogSourceConfigHandler)))
+		apiRouter.PATCH(SkillCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.UpdateSkillCatalogSourceConfigHandler)))
+		apiRouter.DELETE(SkillCatalogSettingsSourceConfigPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.DeleteSkillCatalogSourceConfigHandler)))
+		apiRouter.POST(SkillCatalogSettingsSourcePreviewPath, app.AttachNamespace(app.RequireListServiceAccessInNamespace(app.AttachModelCatalogRESTClient(app.CreateCatalogSourcePreviewHandler))))
 	}
 
 	// App Router

--- a/clients/ui/bff/internal/api/middleware.go
+++ b/clients/ui/bff/internal/api/middleware.go
@@ -104,28 +104,38 @@ func (app *App) AttachModelCatalogRESTClient(next func(http.ResponseWriter, *htt
 			return
 		}
 
-		modelCatalog, err := app.repositories.ModelCatalog.GetModelCatalogWithMode(r.Context(), client, namespace, app.config.DeploymentMode.IsFederatedMode())
-		if err != nil {
-			app.notFoundResponse(w, r)
-			return
-		}
 		apiPath := repositories.ModelCatalogAPIPath
 		if strings.HasPrefix(r.URL.Path, McpServerCatalogPathPrefix) {
 			apiPath = repositories.McpCatalogAPIPath
 		} else if strings.HasPrefix(r.URL.Path, AgentCatalogPathPrefix) {
 			apiPath = repositories.AgentCatalogAPIPath
+		} else if strings.HasPrefix(r.URL.Path, SkillCatalogPathPrefix) {
+			apiPath = repositories.SkillCatalogAPIPath
 		}
 
-		modelCatalogBaseURL := modelCatalog.ServerAddress
-		if apiPath != repositories.ModelCatalogAPIPath {
-			modelCatalogBaseURL = strings.Replace(modelCatalogBaseURL, repositories.ModelCatalogAPIPath, apiPath, 1)
-		}
-
-		// If we are in dev mode, we need to resolve the server address to the local host
-		// to allow the client to connect to the model registry via port forwarded from the cluster to the local machine.
-		// If you are in federated mode, we do not want to override the server address.
+		var modelCatalogBaseURL string
+		// In dev mode (non-federated), the catalog is reached via a local port-forward to
+		// the pod's own container port, which always serves plain HTTP here (the catalog
+		// binary is started with no TLS cert/key; any TLS a real deployment terminates
+		// happens at a Service/Route in front of it, which port-forwarding bypasses). Skip
+		// the K8s service lookup entirely in this branch — it also isn't reliable for this
+		// purpose: it requires the Service to carry a plain `component` label matching
+		// ModelCatalogServiceName's expected value, which this repo's own kustomize
+		// manifests don't set (they use `app.kubernetes.io/component` instead), so the
+		// lookup fails even outside dev mode. That mismatch is pre-existing and unrelated
+		// to skills — out of scope here.
 		if app.config.DevMode && !app.config.DeploymentMode.IsFederatedMode() {
-			modelCatalogBaseURL = app.repositories.ModelCatalog.ResolveServerAddress("localhost", int32(app.config.DevModeCatalogPort), modelCatalog.IsHTTPS, "", app.config.DeploymentMode.IsFederatedMode(), apiPath)
+			modelCatalogBaseURL = app.repositories.ModelCatalog.ResolveServerAddress("localhost", int32(app.config.DevModeCatalogPort), false, "", false, apiPath)
+		} else {
+			modelCatalog, err := app.repositories.ModelCatalog.GetModelCatalogWithMode(r.Context(), client, namespace, app.config.DeploymentMode.IsFederatedMode())
+			if err != nil {
+				app.notFoundResponse(w, r)
+				return
+			}
+			modelCatalogBaseURL = modelCatalog.ServerAddress
+			if apiPath != repositories.ModelCatalogAPIPath {
+				modelCatalogBaseURL = strings.Replace(modelCatalogBaseURL, repositories.ModelCatalogAPIPath, apiPath, 1)
+			}
 		}
 
 		// Set up a child logger for the rest client that automatically adds the request id to all statements for

--- a/clients/ui/bff/internal/api/skill_catalog_handler.go
+++ b/clients/ui/bff/internal/api/skill_catalog_handler.go
@@ -1,0 +1,170 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/hub/ui/bff/internal/constants"
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/httpclient"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	"github.com/kubeflow/hub/ui/bff/internal/repositories"
+)
+
+// catalogServicePort is the port the catalog Service exposes
+// (manifests/kustomize/options/catalog/base/service.yaml).
+const catalogServicePort = 8080
+
+type SkillListEnvelope Envelope[*models.SkillList, None]
+type SkillFilterOptionsListEnvelope Envelope[*models.FilterOptionsList, None]
+type SkillEnvelope Envelope[*models.Skill, None]
+
+func (app *App) GetAllSkillsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelCatalogHttpClientKey).(httpclient.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("catalog REST client not found"))
+		return
+	}
+
+	skills, err := app.repositories.ModelCatalogClient.GetAllSkills(client, r.URL.Query())
+	if err != nil {
+		var httpErr *httpclient.HTTPError
+		if errors.As(err, &httpErr) {
+			app.errorResponse(w, r, httpErr)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillListEnvelope{Data: skills}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) GetSkillsFiltersHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	catalogClient, ok := ctx.Value(constants.ModelCatalogHttpClientKey).(httpclient.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("catalog REST client not found"))
+		return
+	}
+
+	filters, err := app.repositories.ModelCatalogClient.GetSkillsFilter(catalogClient)
+	if err != nil {
+		var httpErr *httpclient.HTTPError
+		if errors.As(err, &httpErr) {
+			app.errorResponse(w, r, httpErr)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	// Filter options come solely from the catalog service, which enumerates them from
+	// indexed skills. The BFF used to merge in provider/category/trustTier from the source
+	// ConfigMaps as well; that was redundant once a source synced (buildSkillEntity stamps
+	// those onto every skill, so they are already enumerated) and actively misleading
+	// before it did, offering filter values that matched nothing.
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillFilterOptionsListEnvelope{Data: filters}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) GetSkillHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelCatalogHttpClientKey).(httpclient.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("catalog REST client not found"))
+		return
+	}
+
+	skillId := ps.ByName(SkillId)
+	if skillId == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("skill_id is required"))
+		return
+	}
+
+	skill, err := app.repositories.ModelCatalogClient.GetSkill(client, skillId, r.URL.Query())
+	if err != nil {
+		var httpErr *httpclient.HTTPError
+		if errors.As(err, &httpErr) {
+			app.errorResponse(w, r, httpErr)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillEnvelope{Data: skill}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+// SkillMarketplaceMetadata carries the URL an agent should hand to
+// `/plugin marketplace add`. It is not the URL of this BFF endpoint: this route is
+// namespace-scoped and authenticated, which an agent cannot satisfy, while the catalog
+// service serves marketplace.json unauthenticated.
+type SkillMarketplaceMetadata struct {
+	MarketplaceURL string `json:"marketplaceUrl"`
+	// External is true when an operator configured an externally reachable URL. When
+	// false the URL resolves only inside the cluster, and the UI says so.
+	External bool `json:"external"`
+}
+
+type SkillMarketplaceEnvelope Envelope[*models.SkillMarketplace, SkillMarketplaceMetadata]
+
+// skillMarketplaceURL returns the marketplace.json URL to advertise.
+//
+// The default is the catalog service's in-cluster DNS address, which is what agents
+// running in the cluster need. It is built from constants rather than a Service lookup
+// on purpose: GetModelCatalogWithMode matches on a bare `component` label that this
+// repo's manifests do not set, so the lookup cannot be relied on here.
+//
+// An operator who puts the catalog behind a Route or Ingress sets
+// SkillCatalogMarketplaceURL, and that value wins.
+func (app *App) skillMarketplaceURL(userNamespace string) (string, bool) {
+	if configured := app.config.SkillCatalogMarketplaceURL; configured != "" {
+		return configured, true
+	}
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d%s/claude/marketplace.json",
+		repositories.ModelCatalogServiceName,
+		app.skillCatalogNamespace(userNamespace),
+		catalogServicePort,
+		repositories.SkillCatalogAPIPath,
+	), false
+}
+
+// GetSkillMarketplaceHandler proxies to the catalog service's claude/marketplace.json
+// endpoint, giving the UI the real, backend-computed plugin/marketplace names and
+// pinned commit for building install commands, instead of guessing them client-side.
+func (app *App) GetSkillMarketplaceHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	client, ok := r.Context().Value(constants.ModelCatalogHttpClientKey).(httpclient.HTTPClientInterface)
+	if !ok {
+		app.serverErrorResponse(w, r, errors.New("catalog REST client not found"))
+		return
+	}
+
+	marketplace, err := app.repositories.ModelCatalogClient.GetSkillMarketplace(client, r.URL.Query())
+	if err != nil {
+		var httpErr *httpclient.HTTPError
+		if errors.As(err, &httpErr) {
+			app.errorResponse(w, r, httpErr)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	namespace, _ := r.Context().Value(constants.NamespaceHeaderParameterKey).(string)
+	marketplaceURL, external := app.skillMarketplaceURL(namespace)
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillMarketplaceEnvelope{
+		Data:     marketplace,
+		Metadata: SkillMarketplaceMetadata{MarketplaceURL: marketplaceURL, External: external},
+	}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/clients/ui/bff/internal/api/skill_catalog_handler_test.go
+++ b/clients/ui/bff/internal/api/skill_catalog_handler_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/kubeflow/hub/ui/bff/internal/config"
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestSkillCatalogFilters", func() {
+	var requestIdentity kubernetes.RequestIdentity
+
+	BeforeEach(func() {
+		requestIdentity = kubernetes.RequestIdentity{UserID: "user@example.com"}
+	})
+
+	// Filter options come from the catalog service alone. The BFF used to merge
+	// provider/category/trustTier from the source ConfigMaps on top; that offered filter
+	// values matching no indexed skill, so a user could select one and get nothing back.
+	It("returns only the catalog service's filter options", func() {
+		body, rs, err := setupApiTest[SkillFilterOptionsListEnvelope](
+			http.MethodGet,
+			"/api/v1/skill_catalog/skills_filter_options?namespace=kubeflow",
+			nil,
+			kubernetesMockedStaticClientFactory,
+			requestIdentity,
+			"kubeflow",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+		// The catalog client mock returns no filters, and the seeded ConfigMap sources
+		// carry provider "Community" and trustTier "communityContributed". Neither may
+		// appear now that the ConfigMap merge is gone.
+		if body.Data != nil && body.Data.Filters != nil {
+			Expect(*body.Data.Filters).To(BeEmpty())
+		}
+	})
+})
+
+var _ = Describe("TestSkillMarketplace", func() {
+	var requestIdentity kubernetes.RequestIdentity
+
+	BeforeEach(func() {
+		requestIdentity = kubernetes.RequestIdentity{UserID: "user@example.com"}
+	})
+
+	It("advertises the catalog's in-cluster URL when no override is configured", func() {
+		body, rs, err := setupApiTest[SkillMarketplaceEnvelope](
+			http.MethodGet,
+			"/api/v1/skill_catalog/claude/marketplace.json?namespace=kubeflow",
+			nil,
+			kubernetesMockedStaticClientFactory,
+			requestIdentity,
+			"kubeflow",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+		// Never this BFF route: it is namespace-scoped and authenticated, which an agent
+		// running `/plugin marketplace add` cannot satisfy.
+		Expect(body.Metadata.MarketplaceURL).To(Equal(
+			"http://model-catalog.kubeflow.svc.cluster.local:8080/api/skill_catalog/v1/claude/marketplace.json"))
+		Expect(body.Metadata.External).To(BeFalse())
+	})
+
+	It("uses the catalog namespace in dev mode rather than the request namespace", func() {
+		body, rs, err := setupApiTestWithConfig[SkillMarketplaceEnvelope](
+			http.MethodGet,
+			"/api/v1/skill_catalog/claude/marketplace.json?namespace=bella-namespace",
+			nil,
+			kubernetesMockedStaticClientFactory,
+			requestIdentity,
+			"bella-namespace",
+			func(cfg *config.EnvConfig) {
+				cfg.DevMode = true
+				cfg.DevModeCatalogNamespace = "kubeflow"
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		Expect(body.Metadata.MarketplaceURL).To(ContainSubstring("model-catalog.kubeflow.svc"))
+	})
+
+	It("prefers an operator-configured external URL", func() {
+		body, rs, err := setupApiTestWithConfig[SkillMarketplaceEnvelope](
+			http.MethodGet,
+			"/api/v1/skill_catalog/claude/marketplace.json?namespace=kubeflow",
+			nil,
+			kubernetesMockedStaticClientFactory,
+			requestIdentity,
+			"kubeflow",
+			func(cfg *config.EnvConfig) {
+				cfg.SkillCatalogMarketplaceURL = "https://hub.example.com/api/skill_catalog/v1/claude/marketplace.json"
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rs.StatusCode).To(Equal(http.StatusOK))
+		Expect(body.Metadata.MarketplaceURL).To(Equal(
+			"https://hub.example.com/api/skill_catalog/v1/claude/marketplace.json"))
+		Expect(body.Metadata.External).To(BeTrue())
+	})
+})

--- a/clients/ui/bff/internal/api/skill_catalog_settings_handler.go
+++ b/clients/ui/bff/internal/api/skill_catalog_settings_handler.go
@@ -1,0 +1,391 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/kubeflow/hub/ui/bff/internal/constants"
+	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	"github.com/kubeflow/hub/ui/bff/internal/repositories"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type SkillCatalogSettingsSourceConfigEnvelope Envelope[*models.SkillCatalogSourceConfig, None]
+type SkillCatalogSettingsSourceConfigListEnvelope Envelope[*models.SkillCatalogSourceConfigList, None]
+type SkillCatalogSourcePayloadEnvelope Envelope[*models.SkillCatalogSourceConfigPayload, None]
+
+// skillCatalogNamespace returns the namespace to use for skill catalog ConfigMap reads/writes.
+// In dev mode with a catalog namespace configured, that namespace is used so the catalog service
+// (which may be in a different namespace than the user) can see the changes.
+// In production, user namespace equals catalog namespace, so the user namespace is always correct.
+func (app *App) skillCatalogNamespace(userNamespace string) string {
+	if app.config.DevMode && app.config.DevModeCatalogNamespace != "" {
+		return app.config.DevModeCatalogNamespace
+	}
+	return userNamespace
+}
+
+// pendingSkillCredential is a git token that belongs in the shared git-credentials
+// Secret once the source it belongs to has actually been persisted.
+type pendingSkillCredential struct {
+	key   string
+	token string
+}
+
+// prepareSkillRepoCredentials moves any admin-supplied git token out of the payload
+// and points the repository at where that token will live, via credentialRef. It does
+// not write the Secret: the token is returned for commitSkillRepoCredential to store
+// once the source has been persisted.
+//
+// The catalog service has no Kubernetes API access: it resolves credentialRef as a
+// filename inside the Secret mounted at /etc/skill-catalog/git-credentials (see
+// catalog/internal/catalog/skillcatalog/credentials.go), reading it through
+// GIT_ASKPASS for every clone. So the value written to the ConfigMap must be the
+// *key* within that one Secret, not a Secret name, and credentialRef has to be set
+// before the ConfigMap is written. kubelet refreshes the mount in place, so a newly
+// added key becomes readable without restarting the catalog pod.
+//
+// The token itself is cleared from the payload here so it can never reach the
+// ConfigMap or a response body.
+func (app *App) prepareSkillRepoCredentials(
+	sourceID string,
+	payload *models.SkillCatalogSourceConfigPayload,
+) (*pendingSkillCredential, error) {
+	// A source carries a single repository (validateSkillRepositories enforces it), so
+	// there is at most one token. This runs before that validation, though — the token
+	// must leave the payload before anything can persist it — so the extra repositories
+	// are still rejected here rather than assuming index 0.
+	tokenIdx := -1
+	for i := range payload.Repositories {
+		tok := payload.Repositories[i].AuthToken
+		if tok != nil && *tok != "" {
+			if tokenIdx >= 0 {
+				return nil, fmt.Errorf("%w: a source accepts a single repository, so only one auth token",
+					repositories.ErrSkillCatalogValidationFailed)
+			}
+			tokenIdx = i
+		}
+	}
+
+	if tokenIdx < 0 {
+		// No new token: clear the write-only field and keep any existing
+		// credentialRef the client round-tripped from a previous read.
+		for i := range payload.Repositories {
+			payload.Repositories[i].AuthToken = nil
+		}
+		return nil, nil
+	}
+
+	token := *payload.Repositories[tokenIdx].AuthToken
+	for i := range payload.Repositories {
+		payload.Repositories[i].AuthToken = nil
+	}
+	ref := sourceID
+	payload.Repositories[tokenIdx].CredentialRef = &ref
+
+	return &pendingSkillCredential{key: sourceID, token: token}, nil
+}
+
+// commitSkillRepoCredential stores a prepared token in the shared git-credentials
+// Secret. It runs only after the source has been persisted, so a request that is
+// rejected — a duplicate id, a failed validation, an edit to a read-only default —
+// leaves the Secret untouched. Writing before that check would let a rejected create
+// overwrite the token of the existing source whose id it collided with, breaking a
+// working source through a request the admin saw fail.
+func (app *App) commitSkillRepoCredential(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace string,
+	pending *pendingSkillCredential,
+) error {
+	if pending == nil {
+		return nil
+	}
+
+	secretName := app.config.SkillCatalogGitCredentialsSecret
+	if err := client.PatchSecret(ctx, namespace, secretName, map[string]string{pending.key: pending.token}); err != nil {
+		// Only a missing Secret is recoverable by creating it. Falling back on any error
+		// turns an RBAC or conflict failure into a confusing "already exists" from the
+		// create below, hiding the real cause from the operator.
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to store git token in secret %q: %w", secretName, err)
+		}
+		// The shared Secret may not exist yet on a fresh install; create it with this key.
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			StringData: map[string]string{pending.key: pending.token},
+		}
+		if _, createErr := client.CreateSecret(ctx, namespace, secret); createErr != nil {
+			return fmt.Errorf("failed to store git token in secret %q: %w", secretName, createErr)
+		}
+	}
+
+	return nil
+}
+
+func (app *App) GetAllSkillCatalogSourceConfigsHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	configs, err := app.repositories.SkillCatalogSettingsRepository.GetAllSkillCatalogSourceConfigs(ctx, client, app.skillCatalogNamespace(namespace))
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillCatalogSettingsSourceConfigListEnvelope{Data: configs}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) GetSkillCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	sourceID := ps.ByName(CatalogSourceId)
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	config, err := app.repositories.SkillCatalogSettingsRepository.GetSkillCatalogSourceConfig(ctx, client, app.skillCatalogNamespace(namespace), sourceID)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogSourceNotFound) {
+			app.notFoundResponse(w, r)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillCatalogSettingsSourceConfigEnvelope{Data: config}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) CreateSkillCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	var envelope SkillCatalogSourcePayloadEnvelope
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("error decoding JSON: %w", err))
+		return
+	}
+
+	if envelope.Data == nil {
+		app.badRequestResponse(w, r, fmt.Errorf("missing required field: data"))
+		return
+	}
+
+	payload := *envelope.Data
+	catalogNS := app.skillCatalogNamespace(namespace)
+	pendingCredential, err := app.prepareSkillRepoCredentials(payload.Id, &payload)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogValidationFailed) {
+			app.badRequestResponse(w, r, err)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	created, err := app.repositories.SkillCatalogSettingsRepository.CreateSkillCatalogSourceConfig(ctx, client, catalogNS, payload)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogSourceAlreadyExist) ||
+			errors.Is(err, repositories.ErrSkillCatalogSourceIdRequired) ||
+			errors.Is(err, repositories.ErrSkillCatalogValidationFailed) {
+			app.badRequestResponse(w, r, err)
+		} else if errors.Is(err, repositories.ErrSkillCatalogSourceConflict) {
+			app.conflictResponse(w, r, err.Error())
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	// Only now that the source exists is its token safe to store: a rejected create
+	// above must not touch the Secret, or a duplicate id would overwrite the token of
+	// the source it collided with.
+	if err := app.commitSkillRepoCredential(ctx, client, catalogNS, pendingCredential); err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf(
+			"source %q was created, but storing its git token failed; re-save the source to retry: %w",
+			payload.Id, err))
+		return
+	}
+
+	result := SkillCatalogSettingsSourceConfigEnvelope{Data: created}
+	w.Header().Set("Location", r.URL.JoinPath(result.Data.Id).String())
+	if err = app.WriteJSON(w, http.StatusCreated, result, nil); err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf("error writing JSON"))
+	}
+}
+
+func (app *App) UpdateSkillCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	var envelope SkillCatalogSourcePayloadEnvelope
+	if err := json.NewDecoder(r.Body).Decode(&envelope); err != nil {
+		app.badRequestResponse(w, r, fmt.Errorf("error decoding JSON: %w", err))
+		return
+	}
+
+	if envelope.Data == nil {
+		app.badRequestResponse(w, r, fmt.Errorf("missing required field: data"))
+		return
+	}
+
+	sourceID := ps.ByName(CatalogSourceId)
+	if sourceID == "" {
+		sourceID = envelope.Data.Id
+	}
+
+	updatePayload := *envelope.Data
+	catalogNS := app.skillCatalogNamespace(namespace)
+	pendingCredential, err := app.prepareSkillRepoCredentials(sourceID, &updatePayload)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogValidationFailed) {
+			app.badRequestResponse(w, r, err)
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	updated, err := app.repositories.SkillCatalogSettingsRepository.UpdateSkillCatalogSourceConfig(ctx, client, catalogNS, sourceID, updatePayload)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogSourceNotFound) {
+			app.notFoundResponse(w, r)
+		} else if errors.Is(err, repositories.ErrSkillCatalogValidationFailed) {
+			app.badRequestResponse(w, r, err)
+		} else if errors.Is(err, repositories.ErrSkillCatalogCannotChangeDefault) ||
+			errors.Is(err, repositories.ErrSkillCatalogCannotChangeType) {
+			app.forbiddenResponse(w, r, err.Error())
+		} else if errors.Is(err, repositories.ErrSkillCatalogSourceConflict) {
+			app.conflictResponse(w, r, err.Error())
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	// As on create: the token is stored only once the update has been accepted, so a
+	// 403 on a read-only default or a 404 on a missing source leaves the Secret alone.
+	if err := app.commitSkillRepoCredential(ctx, client, catalogNS, pendingCredential); err != nil {
+		app.serverErrorResponse(w, r, fmt.Errorf(
+			"source %q was updated, but storing its git token failed; re-save the source to retry: %w",
+			sourceID, err))
+		return
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillCatalogSettingsSourceConfigEnvelope{Data: updated}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *App) DeleteSkillCatalogSourceConfigHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	ctx := r.Context()
+
+	namespace, ok := ctx.Value(constants.NamespaceHeaderParameterKey).(string)
+	if !ok || namespace == "" {
+		app.badRequestResponse(w, r, fmt.Errorf("missing namespace in context"))
+		return
+	}
+
+	client, err := app.kubernetesClientFactory.GetClient(ctx)
+	if err != nil {
+		app.serverErrorResponse(w, r, errors.New("catalog client not found"))
+		return
+	}
+
+	sourceID := ps.ByName(CatalogSourceId)
+
+	catalogNS := app.skillCatalogNamespace(namespace)
+	deletedConfig, err := app.repositories.SkillCatalogSettingsRepository.DeleteSkillCatalogSourceConfig(ctx, client, catalogNS, sourceID)
+	if err != nil {
+		if errors.Is(err, repositories.ErrSkillCatalogCannotDeleteDefault) {
+			app.forbiddenResponse(w, r, err.Error())
+		} else if errors.Is(err, repositories.ErrSkillCatalogSourceNotFound) {
+			app.notFoundResponse(w, r)
+		} else if errors.Is(err, repositories.ErrSkillCatalogSourceConflict) {
+			app.conflictResponse(w, r, err.Error())
+		} else {
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	// Best-effort cleanup: drop only this source's key from the shared
+	// git-credentials Secret. Deleting the Secret itself would revoke every other
+	// source's token and break the catalog pod's volume mount.
+	//
+	// A failure here must not fail the delete — the source is already gone from the
+	// ConfigMap — but it leaves a revoked source's git token in the Secret, so it is
+	// logged against the source id an operator can act on.
+	if err := client.RemoveSecretKey(ctx, catalogNS, app.config.SkillCatalogGitCredentialsSecret, sourceID); err != nil {
+		if sessionLogger, ok := ctx.Value(constants.TraceLoggerKey).(*slog.Logger); ok {
+			sessionLogger.Warn("failed to remove git credentials for deleted skill catalog source",
+				"sourceId", sourceID,
+				"namespace", catalogNS,
+				"secret", app.config.SkillCatalogGitCredentialsSecret,
+				"error", err,
+			)
+		}
+	}
+
+	if err = app.WriteJSON(w, http.StatusOK, SkillCatalogSettingsSourceConfigEnvelope{Data: deletedConfig}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/clients/ui/bff/internal/api/skill_catalog_settings_handler_test.go
+++ b/clients/ui/bff/internal/api/skill_catalog_settings_handler_test.go
@@ -1,0 +1,526 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/hub/ui/bff/internal/mocks"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestSkillCatalogSettings", func() {
+	var requestIdentity kubernetes.RequestIdentity
+
+	BeforeEach(func() {
+		requestIdentity = kubernetes.RequestIdentity{
+			UserID: "user@example.com",
+		}
+	})
+
+	newGitSource := func(id, name string) *models.SkillCatalogSourceConfigPayload {
+		return &models.SkillCatalogSourceConfigPayload{
+			Id:      id,
+			Name:    name,
+			Type:    "git-skills-plugin",
+			Enabled: skillHandlerBoolPtr(true),
+			Repositories: []models.SkillRepository{
+				{URL: "https://github.com/example/" + id, Refs: []string{"v1.0.0"}},
+			},
+		}
+	}
+
+	Context("fetching skill catalog source configs", func() {
+		It("GET ALL returns 200 and includes both default and user managed sources", func() {
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigListEnvelope](
+				http.MethodGet,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+			ids := make([]string, 0, len(body.Data.Catalogs))
+			for _, c := range body.Data.Catalogs {
+				ids = append(ids, c.Id)
+			}
+			Expect(ids).To(ContainElements("community_skills", "custom_skills"))
+		})
+
+		It("GET SINGLE returns 200 and never leaks the auth token", func() {
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodGet,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(body.Data.Type).To(Equal("git-skills-plugin"))
+			Expect(*body.Data.IsDefault).To(BeTrue())
+			Expect(body.Data.Repositories).To(HaveLen(1))
+			Expect(body.Data.Repositories[0].AuthToken).To(BeNil())
+			Expect(*body.Data.TrustTier).To(Equal("communityContributed"))
+		})
+
+		It("GET returns 404 for non-existent source", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodGet,
+				"/api/v1/settings/skill_catalog/source_configs/does_not_exist?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("GET returns 400 when namespace is missing", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodGet,
+				"/api/v1/settings/skill_catalog/source_configs",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Context("creating a skill source config", func() {
+		It("POST returns 201 on success", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{Data: newGitSource("skill_handler_test_create", "Skill Handler Test")}
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(body.Data.Id).To(Equal("skill_handler_test_create"))
+			Expect(rs.Header.Get("Location")).To(ContainSubstring("skill_handler_test_create"))
+		})
+
+		It("POST returns 400 when id is missing", func() {
+			source := newGitSource("", "No Id")
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 for a duplicate source", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{Data: newGitSource("custom_skills", "Duplicate")}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 for an unsupported catalog type", func() {
+			source := newGitSource("skill_bad_type", "Bad Type")
+			source.Type = "yaml"
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 when no repository is supplied", func() {
+			source := newGitSource("skill_no_repos", "No Repos")
+			source.Repositories = nil
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 for an invalid trustTier", func() {
+			source := newGitSource("skill_bad_tier", "Bad Tier")
+			source.TrustTier = skillHandlerStringPtr("goldPlated")
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("POST returns 400 when data is missing from the envelope", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				SkillCatalogSourcePayloadEnvelope{},
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Context("credential syncing on create", func() {
+		It("POST moves the auth token into a credentialRef and never echoes it back", func() {
+			source := newGitSource("skill_with_token", "Skill With Token")
+			source.Repositories[0].AuthToken = skillHandlerStringPtr("ghp_secret_value")
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(body.Data.Repositories).To(HaveLen(1))
+			Expect(body.Data.Repositories[0].AuthToken).To(BeNil())
+			// The catalog service resolves credentialRef as a key inside the shared
+			// git-credentials Secret, so it must be the source id.
+			Expect(body.Data.Repositories[0].CredentialRef).NotTo(BeNil())
+			Expect(*body.Data.Repositories[0].CredentialRef).To(Equal("skill_with_token"))
+		})
+
+		It("POST returns 400 when the payload lists more than one repository", func() {
+			source := newGitSource("skill_two_tokens", "Two Tokens")
+			source.Repositories = []models.SkillRepository{
+				{URL: "https://github.com/example/one", AuthToken: skillHandlerStringPtr("token-one")},
+				{URL: "https://github.com/example/two", AuthToken: skillHandlerStringPtr("token-two")},
+			}
+			payload := SkillCatalogSourcePayloadEnvelope{Data: source}
+
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Context("credential writes are gated on the source being persisted", func() {
+		readCredential := func(key string) string {
+			c, err := kubernetesMockedStaticClientFactory.GetClient(mocks.NewMockSessionContextNoParent())
+			Expect(err).NotTo(HaveOccurred())
+			secret, err := c.GetSecret(mocks.NewMockSessionContextNoParent(), "kubeflow", "skill-catalog-git-credentials")
+			if err != nil {
+				return ""
+			}
+			if v, ok := secret.Data[key]; ok {
+				return string(v)
+			}
+			return secret.StringData[key]
+		}
+
+		withToken := func(id, name, token string) SkillCatalogSourcePayloadEnvelope {
+			source := newGitSource(id, name)
+			source.Repositories[0].AuthToken = skillHandlerStringPtr(token)
+			return SkillCatalogSourcePayloadEnvelope{Data: source}
+		}
+
+		// The settings form derives a source id from the source name, so re-using a name
+		// produces a colliding id. The Secret key is that same id, so a create that the
+		// BFF rejects as a duplicate must not overwrite the existing source's token —
+		// the admin saw the request fail and reasonably assumes nothing changed.
+		It("a rejected duplicate create leaves the existing source's token intact", func() {
+			_, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				withToken("acme_skills", "Acme Skills", "REAL-TOKEN"),
+				kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(readCredential("acme_skills")).To(Equal("REAL-TOKEN"))
+
+			_, rs, err = setupApiTest[Envelope[any, any]](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				withToken("acme_skills", "Acme Skills", "WRONG-TOKEN"),
+				kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+			Expect(readCredential("acme_skills")).To(Equal("REAL-TOKEN"),
+				"a rejected create must not overwrite the colliding source's credential")
+		})
+
+		It("a rejected edit of a read-only default stores no credential", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{
+						{URL: "https://github.com/example/community-skills", AuthToken: skillHandlerStringPtr("SNEAKY")},
+					},
+				},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				payload, kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+			Expect(readCredential("community_skills")).To(BeEmpty())
+		})
+
+		It("stores the credential when the source is actually created", func() {
+			_, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				withToken("beta_skills", "Beta Skills", "BETA-TOKEN"),
+				kubernetesMockedStaticClientFactory, requestIdentity, "kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusCreated))
+			Expect(readCredential("beta_skills")).To(Equal("BETA-TOKEN"))
+		})
+	})
+
+	Context("patching a skill source config", func() {
+		It("PATCH returns 200 on success", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{Enabled: skillHandlerBoolPtr(false)},
+			}
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/custom_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(*body.Data.Enabled).To(BeFalse())
+		})
+
+		It("PATCH returns 404 for a non-existent source", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{Enabled: skillHandlerBoolPtr(false)},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/does_not_exist?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("PATCH returns 403 when changing type", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{Type: "yaml"},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/custom_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+		})
+
+		It("PATCH returns 400 for an invalid credentialRef", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{
+						{URL: "https://github.com/example/custom-skills", CredentialRef: skillHandlerStringPtr("../escape")},
+					},
+				},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/custom_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+
+		It("PATCH returns 403 when changing a forbidden field on a default", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{Name: "Renamed Default"},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+		})
+
+		It("PATCH returns 403 when repointing a default's repositories", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{
+						{URL: "https://github.com/attacker/evil-skills"},
+					},
+				},
+			}
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+		})
+
+		It("PATCH toggles enabled on a default source via an override entry", func() {
+			payload := SkillCatalogSourcePayloadEnvelope{
+				Data: &models.SkillCatalogSourceConfigPayload{Enabled: skillHandlerBoolPtr(false)},
+			}
+			body, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPatch,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				payload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+			Expect(*body.Data.Enabled).To(BeFalse())
+			// The default's own fields survive the override.
+			Expect(body.Data.Name).To(Equal("Community Skills"))
+		})
+	})
+
+	Context("deleting a skill source config", func() {
+		It("DELETE returns 200 on success", func() {
+			createPayload := SkillCatalogSourcePayloadEnvelope{Data: newGitSource("skill_delete_handler_test", "Skill Delete Test")}
+			_, _, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodPost,
+				"/api/v1/settings/skill_catalog/source_configs?namespace=kubeflow",
+				createPayload,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, rs, err := setupApiTest[SkillCatalogSettingsSourceConfigEnvelope](
+				http.MethodDelete,
+				"/api/v1/settings/skill_catalog/source_configs/skill_delete_handler_test?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusOK))
+
+			_, rs, err = setupApiTest[Envelope[any, any]](
+				http.MethodGet,
+				"/api/v1/settings/skill_catalog/source_configs/skill_delete_handler_test?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("DELETE returns 404 for a non-existent source", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodDelete,
+				"/api/v1/settings/skill_catalog/source_configs/does_not_exist?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("DELETE returns 403 for a default source", func() {
+			_, rs, err := setupApiTest[Envelope[any, any]](
+				http.MethodDelete,
+				"/api/v1/settings/skill_catalog/source_configs/community_skills?namespace=kubeflow",
+				nil,
+				kubernetesMockedStaticClientFactory,
+				requestIdentity,
+				"kubeflow",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rs.StatusCode).To(Equal(http.StatusForbidden))
+		})
+	})
+})
+
+func skillHandlerBoolPtr(b bool) *bool {
+	return &b
+}
+
+func skillHandlerStringPtr(s string) *string {
+	return &s
+}

--- a/clients/ui/bff/internal/api/test_utils.go
+++ b/clients/ui/bff/internal/api/test_utils.go
@@ -24,6 +24,13 @@ import (
 // the raw response together with its (already read) body. Use it directly for non-JSON
 // responses (e.g. binary payloads); setupApiTest wraps it for JSON envelope responses.
 func serveApiTest(method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string) (*http.Response, []byte, error) {
+	return serveApiTestWithConfig(method, url, body, k8Factory, requestIdentity, namespace, nil)
+}
+
+// serveApiTestWithConfig is serveApiTest with a hook to adjust the App config before
+// the request is served. Use it for behaviour that only differs by configuration —
+// dev mode namespace resolution, for instance. Pass nil for the default config.
+func serveApiTestWithConfig(method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string, configure func(*config.EnvConfig)) (*http.Response, []byte, error) {
 	mockMRClient, err := mocks.NewModelRegistryClient(nil)
 	if err != nil {
 		return nil, nil, err
@@ -37,10 +44,16 @@ func serveApiTest(method string, url string, body interface{}, k8Factory kuberne
 
 	cfg := config.EnvConfig{
 		AuthMethod: config.AuthMethodInternal,
+		// The skill catalog settings handlers write admin-supplied git tokens into
+		// this Secret; without a name they would fail before reaching the repository.
+		SkillCatalogGitCredentialsSecret: "skill-catalog-git-credentials",
 	}
 	//if token is set, use token auth
 	if requestIdentity.Token != "" {
 		cfg.AuthMethod = config.AuthMethodUser
+	}
+	if configure != nil {
+		configure(&cfg)
 	}
 	testApp := App{
 		repositories:            repositories.NewRepositories(mockMRClient, mockModelCatalogClient),
@@ -98,7 +111,12 @@ func serveApiTest(method string, url string, body interface{}, k8Factory kuberne
 }
 
 func setupApiTest[T any](method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string) (T, *http.Response, error) {
-	rs, respBody, err := serveApiTest(method, url, body, k8Factory, requestIdentity, namespace)
+	return setupApiTestWithConfig[T](method, url, body, k8Factory, requestIdentity, namespace, nil)
+}
+
+// setupApiTestWithConfig is setupApiTest over serveApiTestWithConfig.
+func setupApiTestWithConfig[T any](method string, url string, body interface{}, k8Factory kubernetes.KubernetesClientFactory, requestIdentity kubernetes.RequestIdentity, namespace string, configure func(*config.EnvConfig)) (T, *http.Response, error) {
+	rs, respBody, err := serveApiTestWithConfig(method, url, body, k8Factory, requestIdentity, namespace, configure)
 	if err != nil {
 		return *new(T), nil, err
 	}

--- a/clients/ui/bff/internal/config/environment.go
+++ b/clients/ui/bff/internal/config/environment.go
@@ -81,9 +81,22 @@ type EnvConfig struct {
 	DeploymentMode           DeploymentMode
 	DevModeModelRegistryPort int
 	DevModeCatalogPort       int
-	StaticAssetsDir          string
-	LogLevel                 slog.Level
-	AllowedOrigins           []string
+	DevModeCatalogNamespace  string
+	// SkillCatalogGitCredentialsSecret is the single Secret mounted into the catalog
+	// pod at /etc/skill-catalog/git-credentials. Each skill source's git token is
+	// stored under a key named after the source id, and that key name is what the
+	// source's credentialRef points at — the catalog service resolves credentialRef
+	// as a filename in that mount, not as a Secret name.
+	SkillCatalogGitCredentialsSecret string
+	// SkillCatalogMarketplaceURL overrides the marketplace.json URL shown in the skill
+	// install instructions. Leave empty for the default, which is the catalog service's
+	// in-cluster address — reachable by agents running in the cluster, which is the
+	// primary consumer. Set it to an externally reachable URL when the catalog has been
+	// put behind a Route or Ingress, so the command also works from outside the cluster.
+	SkillCatalogMarketplaceURL string
+	StaticAssetsDir            string
+	LogLevel                   slog.Level
+	AllowedOrigins             []string
 	// BundlePaths is a list of filesystem paths to PEM-encoded CA bundle files.
 	// If provided, the application will attempt to load these files and add the
 	// certificates to the HTTP client's Root CAs for outbound TLS connections.

--- a/clients/ui/bff/internal/integrations/kubernetes/client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/client.go
@@ -19,6 +19,10 @@ const McpCatalogSourceKey = "sources.yaml"
 const McpCatalogSourceDefaultConfigMapName = CatalogSourceDefaultConfigMapName
 const McpCatalogSourceUserConfigMapName = "mcp-catalog-sources"
 
+const SkillCatalogSourceKey = "sources.yaml"
+const SkillCatalogSourceDefaultConfigMapName = CatalogSourceDefaultConfigMapName
+const SkillCatalogSourceUserConfigMapName = "skill-catalog-sources"
+
 type KubernetesClientInterface interface {
 	// Service discovery
 	GetServiceNames(ctx context.Context, namespace string) ([]string, error)
@@ -51,10 +55,15 @@ type KubernetesClientInterface interface {
 	CreateSecret(ctx context.Context, namespace string, secret *corev1.Secret) (*corev1.Secret, error)
 	PatchSecret(ctx context.Context, namespace string, secretName string, data map[string]string) error
 	DeleteSecret(ctx context.Context, namespace string, secretName string) error
+	RemoveSecretKey(ctx context.Context, namespace string, secretName string, key string) error
 
 	// MCP Catalog Settings
 	GetAllMcpCatalogSourceConfigs(ctx context.Context, namespace string) (corev1.ConfigMap, corev1.ConfigMap, error)
 	UpdateMcpCatalogSourceConfig(ctx context.Context, namespace string, configMap *corev1.ConfigMap) error
+
+	// Skill Catalog Settings
+	GetAllSkillCatalogSourceConfigs(ctx context.Context, namespace string) (corev1.ConfigMap, corev1.ConfigMap, error)
+	UpdateSkillCatalogSourceConfig(ctx context.Context, namespace string, configMap *corev1.ConfigMap) error
 
 	// Model transfer jobs
 	CanListJobsClusterWide(ctx context.Context, identity *RequestIdentity) (bool, error)

--- a/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/k8mocks/base_testenv.go
@@ -286,6 +286,26 @@ func setupMock(mockK8sClient kubernetes.Interface, ctx context.Context) error {
 		return err
 	}
 
+	err = addSkillDataToDefaultCatalogSourcesConfigMap(mockK8sClient, ctx, "kubeflow")
+	if err != nil {
+		return err
+	}
+
+	err = createSkillCatalogSourcesConfigMap(mockK8sClient, ctx, "kubeflow")
+	if err != nil {
+		return err
+	}
+
+	err = addSkillDataToDefaultCatalogSourcesConfigMap(mockK8sClient, ctx, "bella-namespace")
+	if err != nil {
+		return err
+	}
+
+	err = createSkillCatalogSourcesConfigMap(mockK8sClient, ctx, "bella-namespace")
+	if err != nil {
+		return err
+	}
+
 	err = createHuggingFaceSecret(mockK8sClient, ctx, "kubeflow")
 	if err != nil {
 		return err
@@ -1523,6 +1543,82 @@ mcp_catalogs:
 
 	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create mcp-catalog-sources configmap: %w", err)
+	}
+
+	return nil
+}
+
+func addSkillDataToDefaultCatalogSourcesConfigMap(
+	k8sClient kubernetes.Interface,
+	ctx context.Context,
+	namespace string,
+) error {
+	cm, err := k8sClient.CoreV1().ConfigMaps(namespace).Get(ctx, k8s.CatalogSourceDefaultConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get default-catalog-sources configmap for skill data: %w", err)
+	}
+
+	skillRaw := strings.TrimSpace(`
+skill_catalogs:
+  - name: Community Skills
+    id: community_skills
+    type: git-skills-plugin
+    enabled: true
+    labels:
+      - Community
+    properties:
+      repositories:
+        - url: https://github.com/example/community-skills
+          refs:
+            - v1.0.0
+          provider: Community
+          category: development
+          trustTier: communityContributed
+`)
+
+	existingSources := cm.Data[k8s.SkillCatalogSourceKey]
+	cm.Data[k8s.SkillCatalogSourceKey] = existingSources + "\n" + skillRaw
+
+	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Update(ctx, cm, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update default-catalog-sources configmap with skill data: %w", err)
+	}
+
+	return nil
+}
+
+func createSkillCatalogSourcesConfigMap(
+	k8sClient kubernetes.Interface,
+	ctx context.Context,
+	namespace string,
+) error {
+	raw := strings.TrimSpace(`
+skill_catalogs:
+  - name: Custom Skills
+    id: custom_skills
+    type: git-skills-plugin
+    enabled: true
+    labels:
+      - Custom
+    properties:
+      repositories:
+        - url: https://github.com/example/custom-skills
+          refs:
+            - v2.0.0
+          credentialRef: custom_skills
+`)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8s.SkillCatalogSourceUserConfigMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			k8s.SkillCatalogSourceKey: raw,
+		},
+	}
+
+	if _, err := k8sClient.CoreV1().ConfigMaps(namespace).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("failed to create skill-catalog-sources configmap: %w", err)
 	}
 
 	return nil

--- a/clients/ui/bff/internal/integrations/kubernetes/shared_k8s_client.go
+++ b/clients/ui/bff/internal/integrations/kubernetes/shared_k8s_client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kubeflow/hub/ui/bff/internal/constants"
@@ -306,6 +307,57 @@ func (kc *SharedClientLogic) PatchSecret(ctx context.Context, namespace string, 
 	return nil
 }
 
+// RemoveSecretKey drops a single key from a Secret, leaving the Secret and its
+// other keys in place. Used to retire one skill source's git token from the
+// shared git-credentials Secret without disturbing the other sources sharing it.
+// A missing Secret or a missing key is treated as success, so cleanup is idempotent.
+func (kc *SharedClientLogic) RemoveSecretKey(
+	ctx context.Context,
+	namespace string,
+	secretName string,
+	key string,
+) error {
+	sessionLogger := ctx.Value(constants.TraceLoggerKey).(*slog.Logger)
+
+	secret, err := kc.Client.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		sessionLogger.Error("failed to get secret for key removal",
+			"namespace", namespace,
+			"name", secretName,
+			"error", err,
+		)
+		return fmt.Errorf("failed to get secret %s: %w", secretName, err)
+	}
+
+	if _, ok := secret.Data[key]; !ok {
+		return nil
+	}
+	delete(secret.Data, key)
+	// Data already carries the surviving keys; StringData would be merged back in
+	// on update and resurrect the key we just removed.
+	secret.StringData = nil
+
+	if _, err := kc.Client.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
+		sessionLogger.Error("failed to remove key from secret",
+			"namespace", namespace,
+			"name", secretName,
+			"key", key,
+			"error", err,
+		)
+		return fmt.Errorf("failed to remove key %s from secret %s: %w", key, secretName, err)
+	}
+
+	sessionLogger.Info("successfully removed key from secret",
+		"namespace", namespace,
+		"name", secretName,
+		"key", key,
+	)
+	return nil
+}
+
 func (kc *SharedClientLogic) DeleteSecret(
 	ctx context.Context,
 	namespace string,
@@ -422,6 +474,116 @@ func (kc *SharedClientLogic) UpdateMcpCatalogSourceConfig(
 	}
 
 	sessionLogger.Info("successfully updated MCP catalog sources configmap",
+		"namespace", namespace,
+		"name", configMap.Name,
+	)
+
+	return nil
+}
+
+func (kc *SharedClientLogic) GetAllSkillCatalogSourceConfigs(
+	sessionCtx context.Context,
+	namespace string,
+) (corev1.ConfigMap, corev1.ConfigMap, error) {
+	if namespace == "" {
+		return corev1.ConfigMap{}, corev1.ConfigMap{}, fmt.Errorf("namespace cannot be empty")
+	}
+
+	sessionLogger := sessionCtx.Value(constants.TraceLoggerKey).(*slog.Logger)
+
+	// The default and user ConfigMaps have no data dependency on each other, and this is
+	// called on essentially every skill-catalog-settings request — fetch them concurrently
+	// rather than paying two sequential K8s round trips.
+	var defaultCMVal, userCMVal corev1.ConfigMap
+	var defaultErr, userErr error
+	var wg sync.WaitGroup
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		defaultCM, err := kc.Client.CoreV1().
+			ConfigMaps(namespace).
+			Get(sessionCtx, SkillCatalogSourceDefaultConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				sessionLogger.Info("default skill catalog source configmap not found, using empty",
+					"namespace", namespace,
+					"name", SkillCatalogSourceDefaultConfigMapName,
+				)
+				return
+			}
+			sessionLogger.Error("failed to fetch default skill catalog source configmap",
+				"namespace", namespace,
+				"name", SkillCatalogSourceDefaultConfigMapName,
+				"error", err,
+			)
+			defaultErr = fmt.Errorf("failed to get %s: %w", SkillCatalogSourceDefaultConfigMapName, err)
+			return
+		}
+		defaultCMVal = *defaultCM
+	}()
+	go func() {
+		defer wg.Done()
+		userCM, err := kc.Client.CoreV1().
+			ConfigMaps(namespace).
+			Get(sessionCtx, SkillCatalogSourceUserConfigMapName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			sessionLogger.Error("failed to fetch skill catalog source configmap",
+				"namespace", namespace,
+				"name", SkillCatalogSourceUserConfigMapName,
+				"error", err,
+			)
+			userErr = fmt.Errorf("failed to get %s: %w", SkillCatalogSourceUserConfigMapName, err)
+			return
+		}
+		userCMVal = *userCM
+	}()
+	wg.Wait()
+
+	if defaultErr != nil {
+		return corev1.ConfigMap{}, corev1.ConfigMap{}, defaultErr
+	}
+	if userErr != nil {
+		return corev1.ConfigMap{}, corev1.ConfigMap{}, userErr
+	}
+
+	return defaultCMVal, userCMVal, nil
+}
+
+func (kc *SharedClientLogic) UpdateSkillCatalogSourceConfig(
+	ctx context.Context,
+	namespace string,
+	configMap *corev1.ConfigMap,
+) error {
+	sessionLogger := ctx.Value(constants.TraceLoggerKey).(*slog.Logger)
+
+	if configMap.Name == "" {
+		configMap.Name = SkillCatalogSourceUserConfigMapName
+		configMap.Namespace = namespace
+	}
+
+	_, err := kc.Client.CoreV1().
+		ConfigMaps(namespace).
+		Update(ctx, configMap, metav1.UpdateOptions{})
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			_, err = kc.Client.CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+		}
+		if err != nil {
+			sessionLogger.Error("failed to update skill catalog sources configmap",
+				"namespace", namespace,
+				"name", configMap.Name,
+				"error", err,
+			)
+			return fmt.Errorf("failed to update configmap %s: %w", configMap.Name, err)
+		}
+	}
+
+	sessionLogger.Info("successfully updated skill catalog sources configmap",
 		"namespace", namespace,
 		"name", configMap.Name,
 	)

--- a/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
+++ b/clients/ui/bff/internal/mocks/model_catalog_client_mock.go
@@ -727,3 +727,29 @@ func (m *ModelCatalogClientMock) GetAgentArtifacts(client httpclient.HTTPClientI
 
 	return GetAgentArtifactListMock(agentId), nil
 }
+
+func (m *ModelCatalogClientMock) GetAllSkills(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillList, error) {
+	return &models.SkillList{
+		Items:    []models.Skill{},
+		PageSize: 10,
+		Size:     0,
+	}, nil
+}
+
+func (m *ModelCatalogClientMock) GetSkillsFilter(client httpclient.HTTPClientInterface) (*models.FilterOptionsList, error) {
+	return &models.FilterOptionsList{}, nil
+}
+
+func (m *ModelCatalogClientMock) GetSkill(client httpclient.HTTPClientInterface, skillId string, pageValues url.Values) (*models.Skill, error) {
+	return nil, &httpclient.HTTPError{
+		StatusCode: 404,
+		ErrorResponse: httpclient.ErrorResponse{
+			Code:    "404",
+			Message: fmt.Sprintf("skill not found: %s", skillId),
+		},
+	}
+}
+
+func (m *ModelCatalogClientMock) GetSkillMarketplace(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillMarketplace, error) {
+	return &models.SkillMarketplace{Plugins: []models.SkillMarketplacePlugin{}}, nil
+}

--- a/clients/ui/bff/internal/models/skill_catalog.go
+++ b/clients/ui/bff/internal/models/skill_catalog.go
@@ -1,0 +1,58 @@
+package models
+
+import "github.com/kubeflow/hub/pkg/openapi"
+
+type Skill struct {
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	SourceID        *string  `json:"sourceId,omitempty"`
+	Description     *string  `json:"description,omitempty"`
+	Readme          *string  `json:"readme,omitempty"`
+	License         *string  `json:"license,omitempty"`
+	Author          *string  `json:"author,omitempty"`
+	Compatibility   *string  `json:"compatibility,omitempty"`
+	AllowedTools    []string `json:"allowedTools,omitempty"`
+	Labels          []string `json:"labels,omitempty"`
+	Provider        *string  `json:"provider,omitempty"`
+	Category        *string  `json:"category,omitempty"`
+	TrustTier       *string  `json:"trustTier,omitempty"`
+	Repository      *string  `json:"repository,omitempty"`
+	Path            *string  `json:"path,omitempty"`
+	Version         *string  `json:"version,omitempty"`
+	ResolvedCommit  *string  `json:"resolvedCommit,omitempty"`
+	SupportingFiles []string `json:"supportingFiles,omitempty"`
+	// BodyLineCount is the SKILL.md body length. The catalog service warns above its
+	// maxSkillBodyLines (500) because an agent loads the whole body into its context,
+	// so the UI surfaces it as a quality signal. Display only — the catalog service
+	// deliberately excludes it from filter_options.
+	BodyLineCount    *int32                            `json:"bodyLineCount,omitempty"`
+	CustomProperties *map[string]openapi.MetadataValue `json:"customProperties,omitempty"`
+}
+
+type SkillList struct {
+	NextPageToken string  `json:"nextPageToken"`
+	PageSize      int32   `json:"pageSize"`
+	Size          int32   `json:"size"`
+	Items         []Skill `json:"items"`
+}
+
+// SkillMarketplace and its nested types are a subset pass-through of the Claude
+// Code plugin marketplace document served by the catalog service's
+// claude/marketplace.json endpoint (see catalog/internal/catalog/skillcatalog/marketplace.go).
+// Only the fields the UI needs to build install commands are kept.
+type SkillMarketplace struct {
+	Name    string                   `json:"name"`
+	Plugins []SkillMarketplacePlugin `json:"plugins"`
+}
+
+type SkillMarketplacePlugin struct {
+	Name   string                       `json:"name"`
+	Source SkillMarketplacePluginSource `json:"source"`
+}
+
+type SkillMarketplacePluginSource struct {
+	URL  string `json:"url"`
+	Path string `json:"path"`
+	Ref  string `json:"ref,omitempty"`
+	SHA  string `json:"sha,omitempty"`
+}

--- a/clients/ui/bff/internal/models/skill_catalog_source_configs.go
+++ b/clients/ui/bff/internal/models/skill_catalog_source_configs.go
@@ -1,0 +1,77 @@
+package models
+
+// SkillRepository represents an inline git repository entry in a git-skills-plugin source.
+//
+// Field names mirror the catalog service's SkillRepository
+// (catalog/internal/catalog/skillcatalog/source_schema.go). That struct is decoded
+// with DisallowUnknownFields, so any key written here that it does not declare
+// fails the entire source at load time.
+type SkillRepository struct {
+	URL          string   `json:"url"`
+	CanonicalURL *string  `json:"canonicalUrl,omitempty"`
+	Refs         []string `json:"refs,omitempty"`
+	ScanPaths    []string `json:"scanPaths,omitempty"`
+	// CredentialRef names a key in the git-credentials Secret mounted into the
+	// catalog pod — not a Secret name. It must be a plain filename. The BFF sets
+	// this to the source id when a token is supplied; it is never entered by hand.
+	CredentialRef *string `json:"credentialRef,omitempty"`
+	// AuthToken is a write-only git token from the admin form. The BFF stores it in
+	// the shared git-credentials Secret and clears it before serialisation, so it is
+	// never written to the ConfigMap and never returned on reads.
+	AuthToken *string `json:"authToken,omitempty"`
+	// Labels are stamped onto every skill this repository yields, so they show on
+	// skill cards and in filter_options (catalog service buildSkillEntity).
+	//
+	// Not to be confused with SkillCatalogSourceConfig.Labels: those sit on the
+	// source itself and only drive the sourceLabel grouping of sources.
+	Labels         []string `json:"labels,omitempty"`
+	IncludedSkills []string `json:"includedSkills,omitempty"`
+	ExcludedSkills []string `json:"excludedSkills,omitempty"`
+	// SkillOverrides are not editable in the settings UI; they are preserved verbatim so
+	// a UI save does not delete per-skill metadata a GitOps author set.
+	SkillOverrides []SkillOverride `json:"skillOverrides,omitempty"`
+}
+
+// SkillOverride is a per-skill exception to a repository's custom metadata, matching
+// the catalog service's SkillOverride (skillcatalog/source_schema.go). The repository's
+// own category/labels apply to every skill it yields; an override replaces them for the
+// one skill it names (buildSkillEntity precedence: repo entry -> skillOverride).
+//
+// The settings UI has no control for these — it edits repository-level metadata only —
+// but they are carried through reads and writes so that a source authored by GitOps
+// keeps them. The write path rebuilds properties.repositories from this model, so a
+// field missing here is not merely uneditable, it is erased on the next save.
+type SkillOverride struct {
+	Name     string   `json:"name"`
+	Category *string  `json:"category,omitempty"`
+	Labels   []string `json:"labels,omitempty"`
+}
+
+// SkillCatalogSourceConfig is a catalog source entry for a git-skills-plugin source.
+type SkillCatalogSourceConfig struct {
+	Id      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Enabled *bool  `json:"enabled,omitempty"`
+	// Labels group the source itself for the sourceLabel selector. A nil slice on an
+	// update means "leave as-is"; an empty (non-nil) slice means "clear them", which
+	// is how the settings UI removes the last label. For per-skill labels see
+	// SkillRepository.Labels.
+	Labels    []string `json:"labels,omitempty"`
+	Provider  *string  `json:"provider,omitempty"`
+	Category  *string  `json:"category,omitempty"`
+	TrustTier *string  `json:"trustTier,omitempty"`
+	// Repositories holds exactly one entry for any source this API writes, matching the
+	// catalog service's inline form. Provider/Category/TrustTier above are stamped onto
+	// that entry on write and read back from it, so a second entry could carry neither.
+	// It stays a slice because that is the shape the ConfigMap and the catalog service
+	// use, and a read of a yamlCatalogPath-backed source can return several.
+	Repositories []SkillRepository `json:"repositories,omitempty"`
+	IsDefault    *bool             `json:"isDefault,omitempty"`
+}
+
+type SkillCatalogSourceConfigPayload = SkillCatalogSourceConfig
+
+type SkillCatalogSourceConfigList struct {
+	Catalogs []SkillCatalogSourceConfig `json:"catalogs,omitempty"`
+}

--- a/clients/ui/bff/internal/repositories/catalog_source_preview.go
+++ b/clients/ui/bff/internal/repositories/catalog_source_preview.go
@@ -82,6 +82,12 @@ func (a CatalogSourcePreview) CreateCatalogSourcePreview(client httpclient.HTTPC
 		}
 	}
 
+	if sourcePreviewPayload.Type == CatalogTypeGitSkills {
+		if repos, ok := sourcePreviewPayload.Properties["repositories"]; ok {
+			properties["repositories"] = repos
+		}
+	}
+
 	if len(properties) > 0 {
 		configData["properties"] = properties
 	}

--- a/clients/ui/bff/internal/repositories/model_catalog.go
+++ b/clients/ui/bff/internal/repositories/model_catalog.go
@@ -13,6 +13,11 @@ const (
 	ModelCatalogAPIPath     = "/api/model_catalog/v1alpha1"
 	McpCatalogAPIPath       = "/api/mcp_catalog/v1alpha1"
 	AgentCatalogAPIPath     = "/api/agent_catalog/v1alpha1"
+	// Skills are served only at v1: the catalog service dropped the skill v1alpha1
+	// routes. v1 also renames fields to camelCase (source_id -> sourceId), which
+	// models.Skill's tags must match.
+	SkillCatalogAPIPath  = "/api/skill_catalog/v1"
+	CatalogTypeGitSkills = "git-skills-plugin"
 )
 
 type ModelCatalogRepository struct {

--- a/clients/ui/bff/internal/repositories/model_catalog_client.go
+++ b/clients/ui/bff/internal/repositories/model_catalog_client.go
@@ -10,6 +10,7 @@ type ModelCatalogClientInterface interface {
 	CatalogSourcePreviewInterface
 	McpServerCatalogInterface
 	AgentCatalogInterface
+	SkillCatalogInterface
 }
 
 type ModelCatalogClient struct {
@@ -19,6 +20,7 @@ type ModelCatalogClient struct {
 	CatalogSourcePreview
 	McpServerCatalog
 	AgentCatalog
+	SkillCatalog
 }
 
 func NewModelCatalogClient(logger *slog.Logger) (ModelCatalogClientInterface, error) {

--- a/clients/ui/bff/internal/repositories/model_catalog_settings_test.go
+++ b/clients/ui/bff/internal/repositories/model_catalog_settings_test.go
@@ -574,6 +574,18 @@ var _ = Describe("ModelCatalogSettingRepository", func() {
 	})
 })
 
+var _ = Describe("validateCatalogId", func() {
+	It("accepts an id with only lowercase letters, numbers, and underscores", func() {
+		Expect(validateCatalogId("my_source_1")).NotTo(HaveOccurred())
+	})
+
+	It("rejects a hyphenated id (model/mcp catalogs never accepted hyphens)", func() {
+		err := validateCatalogId("my-source")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("lowercase letters, numbers, and underscores"))
+	})
+})
+
 func boolPtr(b bool) *bool {
 	return &b
 }

--- a/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
+++ b/clients/ui/bff/internal/repositories/model_transfer_jobs_test.go
@@ -186,6 +186,14 @@ func (f *fakeKubernetesClient) UpdateMcpCatalogSourceConfig(ctx context.Context,
 	return nil
 }
 
+func (f *fakeKubernetesClient) GetAllSkillCatalogSourceConfigs(ctx context.Context, namespace string) (corev1.ConfigMap, corev1.ConfigMap, error) {
+	return corev1.ConfigMap{}, corev1.ConfigMap{}, nil
+}
+
+func (f *fakeKubernetesClient) UpdateSkillCatalogSourceConfig(ctx context.Context, namespace string, configMap *corev1.ConfigMap) error {
+	return nil
+}
+
 func (f *fakeKubernetesClient) CreateSecret(ctx context.Context, namespace string, secret *corev1.Secret) (*corev1.Secret, error) {
 	created := secret.DeepCopy()
 	if created.Name == "" {
@@ -203,6 +211,10 @@ func (f *fakeKubernetesClient) PatchSecret(ctx context.Context, namespace string
 }
 
 func (f *fakeKubernetesClient) DeleteSecret(ctx context.Context, namespace string, secretName string) error {
+	return nil
+}
+
+func (f *fakeKubernetesClient) RemoveSecretKey(ctx context.Context, namespace string, secretName string, key string) error {
 	return nil
 }
 

--- a/clients/ui/bff/internal/repositories/repositories.go
+++ b/clients/ui/bff/internal/repositories/repositories.go
@@ -10,6 +10,7 @@ type Repositories struct {
 	ModelCatalogClient             ModelCatalogClientInterface
 	ModelCatalogSettingsRepository *ModelCatalogSettingsRepository
 	McpCatalogSettingsRepository   *McpCatalogSettingsRepository
+	SkillCatalogSettingsRepository *SkillCatalogSettingsRepository
 	User                           *UserRepository
 	Namespace                      *NamespaceRepository
 }
@@ -24,6 +25,7 @@ func NewRepositories(modelRegistryClient ModelRegistryClientInterface, modelCata
 		ModelRegistryClient:            modelRegistryClient,
 		ModelCatalogSettingsRepository: NewModelCatalogSettingsRepository(),
 		McpCatalogSettingsRepository:   NewMcpCatalogSettingsRepository(),
+		SkillCatalogSettingsRepository: NewSkillCatalogSettingsRepository(),
 		User:                           NewUserRepository(),
 		Namespace:                      NewNamespaceRepository(),
 	}

--- a/clients/ui/bff/internal/repositories/skill_catalog.go
+++ b/clients/ui/bff/internal/repositories/skill_catalog.go
@@ -1,0 +1,86 @@
+package repositories
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/kubeflow/hub/ui/bff/internal/integrations/httpclient"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+)
+
+const skillPath = "/skills"
+const skillFilterOptionPath = "/skills/filter_options"
+const skillMarketplacePath = "/claude/marketplace.json"
+
+type SkillCatalogInterface interface {
+	GetAllSkills(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillList, error)
+	GetSkillsFilter(client httpclient.HTTPClientInterface) (*models.FilterOptionsList, error)
+	GetSkill(client httpclient.HTTPClientInterface, skillId string, pageValues url.Values) (*models.Skill, error)
+	GetSkillMarketplace(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillMarketplace, error)
+}
+
+type SkillCatalog struct {
+	SkillCatalogInterface
+}
+
+func (s *SkillCatalog) GetAllSkills(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillList, error) {
+	responseData, err := client.GET(UrlWithPageParams(skillPath, pageValues))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching skills list: %w", err)
+	}
+
+	var skills models.SkillList
+	if err := json.Unmarshal(responseData, &skills); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &skills, nil
+}
+
+func (s *SkillCatalog) GetSkillsFilter(client httpclient.HTTPClientInterface) (*models.FilterOptionsList, error) {
+	responseData, err := client.GET(skillFilterOptionPath)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching skill filter options: %w", err)
+	}
+
+	var filters models.FilterOptionsList
+	if err := json.Unmarshal(responseData, &filters); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &filters, nil
+}
+
+func (s *SkillCatalog) GetSkill(client httpclient.HTTPClientInterface, skillId string, pageValues url.Values) (*models.Skill, error) {
+	path, err := url.JoinPath(skillPath, skillId)
+	if err != nil {
+		return nil, err
+	}
+
+	responseData, err := client.GET(UrlWithPageParams(path, pageValues))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching skill: %w", err)
+	}
+
+	var skill models.Skill
+	if err := json.Unmarshal(responseData, &skill); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &skill, nil
+}
+
+func (s *SkillCatalog) GetSkillMarketplace(client httpclient.HTTPClientInterface, pageValues url.Values) (*models.SkillMarketplace, error) {
+	responseData, err := client.GET(UrlWithPageParams(skillMarketplacePath, pageValues))
+	if err != nil {
+		return nil, fmt.Errorf("error fetching skill marketplace: %w", err)
+	}
+
+	var marketplace models.SkillMarketplace
+	if err := json.Unmarshal(responseData, &marketplace); err != nil {
+		return nil, fmt.Errorf("error decoding response data: %w", err)
+	}
+
+	return &marketplace, nil
+}

--- a/clients/ui/bff/internal/repositories/skill_catalog_helpers.go
+++ b/clients/ui/bff/internal/repositories/skill_catalog_helpers.go
@@ -1,0 +1,584 @@
+package repositories
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	"gopkg.in/yaml.v3"
+)
+
+const SkillCatalogTypeGit = "git-skills-plugin"
+
+// validCredentialRef mirrors the catalog service's credentialRef check
+// (catalog/internal/catalog/skillcatalog/source_schema.go): a plain filename with
+// no path separators, so it cannot escape the mounted git-credentials directory.
+var validCredentialRef = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?$`)
+
+// validSkillTrustTiers is the closed set defined in catalog-v1.yaml / SkillTrustTier enum.
+var validSkillTrustTiers = map[string]struct{}{
+	"platformProvided":     {},
+	"partnerVerified":      {},
+	"organizationApproved": {},
+	"communityContributed": {},
+}
+
+// validSkillCatalogIdRegex is deliberately more permissive than the shared
+// validateCatalogId (model/mcp catalogs): it allows hyphens so a hand-written or
+// GitOps-managed skill source (kebab-case is the common convention there) doesn't
+// need to be renamed to satisfy validation. This must stay skill-catalog-specific —
+// widening the shared validCatalogIdRegex instead would loosen ID validation for
+// the model and MCP catalogs too.
+var validSkillCatalogIdRegex = regexp.MustCompile(`^[a-z0-9_-]+$`)
+
+func validateSkillCatalogId(id string) error {
+	if id == "" {
+		return ErrCatalogSourceIdRequired
+	}
+
+	if !validSkillCatalogIdRegex.MatchString(id) {
+		return fmt.Errorf("invalid catalog ID: must contain only lowercase letters, numbers, hyphens, and underscores")
+	}
+
+	if len(id) > 238 {
+		return fmt.Errorf("%w: '%s' (max 238 characters)", ErrCatalogIDTooLong, id)
+	}
+
+	return nil
+}
+
+func ParseSkillCatalogYaml(raw string, isDefault bool) ([]models.SkillCatalogSourceConfig, error) {
+	var parsed struct {
+		Catalogs []struct {
+			Name       string         `yaml:"name"`
+			Id         string         `yaml:"id"`
+			Type       string         `yaml:"type"`
+			Enabled    *bool          `yaml:"enabled"`
+			Labels     []string       `yaml:"labels"`
+			Properties map[string]any `yaml:"properties"`
+		} `yaml:"skill_catalogs"`
+	}
+
+	if err := yaml.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse skill catalogs yaml: %w", err)
+	}
+
+	catalogs := make([]models.SkillCatalogSourceConfig, 0, len(parsed.Catalogs))
+	for _, c := range parsed.Catalogs {
+		props := c.Properties
+		if props == nil {
+			props = map[string]any{}
+		}
+
+		type rawSkillOverride struct {
+			Name     string   `yaml:"name"`
+			Category string   `yaml:"category"`
+			Labels   []string `yaml:"labels"`
+		}
+
+		type rawRepo struct {
+			URL            string   `yaml:"url"`
+			CanonicalURL   string   `yaml:"canonicalUrl"`
+			Refs           []string `yaml:"refs"`
+			ScanPaths      []string `yaml:"scanPaths"`
+			CredentialRef  string   `yaml:"credentialRef"`
+			Labels         []string `yaml:"labels"`
+			IncludedSkills []string `yaml:"includedSkills"`
+			ExcludedSkills []string `yaml:"excludedSkills"`
+			Provider       string   `yaml:"provider"`
+			Category       string   `yaml:"category"`
+			TrustTier      string   `yaml:"trustTier"`
+			// Read so the write path can put them back; the UI never edits them.
+			SkillOverrides []rawSkillOverride `yaml:"skillOverrides"`
+		}
+
+		var repos []models.SkillRepository
+		var rawRepos []rawRepo
+		if repoList, ok := props["repositories"]; ok {
+			repoBytes, err := yaml.Marshal(repoList)
+			if err != nil {
+				return nil, fmt.Errorf("failed to re-marshal repositories for skill catalog source %q: %w", c.Id, err)
+			}
+			if err := yaml.Unmarshal(repoBytes, &rawRepos); err != nil {
+				return nil, fmt.Errorf("failed to parse repositories for skill catalog source %q: %w", c.Id, err)
+			}
+			for _, r := range rawRepos {
+				repo := models.SkillRepository{
+					URL:            r.URL,
+					Refs:           r.Refs,
+					ScanPaths:      r.ScanPaths,
+					Labels:         r.Labels,
+					IncludedSkills: r.IncludedSkills,
+					ExcludedSkills: r.ExcludedSkills,
+				}
+				if r.CanonicalURL != "" {
+					repo.CanonicalURL = &r.CanonicalURL
+				}
+				if r.CredentialRef != "" {
+					repo.CredentialRef = &r.CredentialRef
+				}
+				for _, ov := range r.SkillOverrides {
+					entry := models.SkillOverride{Name: ov.Name, Labels: ov.Labels}
+					if ov.Category != "" {
+						category := ov.Category
+						entry.Category = &category
+					}
+					repo.SkillOverrides = append(repo.SkillOverrides, entry)
+				}
+				repos = append(repos, repo)
+			}
+		}
+
+		entry := models.SkillCatalogSourceConfig{
+			Id:           c.Id,
+			Name:         c.Name,
+			Type:         c.Type,
+			Enabled:      c.Enabled,
+			Labels:       c.Labels,
+			Repositories: repos,
+			IsDefault:    &isDefault,
+		}
+		// Read category/provider/trustTier from the first repository (canonical location per
+		// the backend schema). A source written through this API has exactly one repository,
+		// so the first entry is the only entry; a hand-written or yamlCatalogPath-backed
+		// source may list more, and only the first one's provenance is surfaced. Fall back to
+		// properties level for backwards compat with manually-created ConfigMaps that placed
+		// them at the source/properties level.
+		if len(rawRepos) > 0 {
+			if rawRepos[0].Provider != "" {
+				entry.Provider = &rawRepos[0].Provider
+			}
+			if rawRepos[0].Category != "" {
+				entry.Category = &rawRepos[0].Category
+			}
+			if rawRepos[0].TrustTier != "" {
+				entry.TrustTier = &rawRepos[0].TrustTier
+			}
+		}
+		if entry.Provider == nil {
+			if v, ok := props["provider"].(string); ok && v != "" {
+				entry.Provider = &v
+			}
+		}
+		if entry.Category == nil {
+			if v, ok := props["category"].(string); ok && v != "" {
+				entry.Category = &v
+			}
+		}
+		if entry.TrustTier == nil {
+			if v, ok := props["trustTier"].(string); ok && v != "" {
+				entry.TrustTier = &v
+			}
+		}
+		catalogs = append(catalogs, entry)
+	}
+
+	return catalogs, nil
+}
+
+func FindSkillCatalogSourceById(sourceYAML string, catalogId string, isDefault bool) *models.SkillCatalogSourceConfig {
+	if sourceYAML == "" {
+		return nil
+	}
+
+	configs, err := ParseSkillCatalogYaml(sourceYAML, isDefault)
+	if err != nil {
+		return nil
+	}
+
+	for i := range configs {
+		if configs[i].Id == catalogId {
+			return &configs[i]
+		}
+	}
+
+	return nil
+}
+
+func AppendSkillCatalogSourceToYaml(existingConfigMapEntry string, newEntry map[string]interface{}) (string, error) {
+	var parsed struct {
+		Catalogs []map[string]interface{} `yaml:"skill_catalogs"`
+	}
+
+	if existingConfigMapEntry != "" {
+		if err := yaml.Unmarshal([]byte(existingConfigMapEntry), &parsed); err != nil {
+			return "", fmt.Errorf("failed to parse existing skill sources.yaml: %w", err)
+		}
+	} else {
+		parsed.Catalogs = []map[string]interface{}{}
+	}
+	parsed.Catalogs = append(parsed.Catalogs, newEntry)
+
+	updatedBytes, err := yaml.Marshal(parsed)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal updated skill sources.yaml: %w", err)
+	}
+
+	return string(updatedBytes), nil
+}
+
+func RemoveSkillCatalogSourceFromYAML(existingYAML string, sourceId string) (string, error) {
+	var parsed struct {
+		Catalogs []map[string]interface{} `yaml:"skill_catalogs"`
+	}
+
+	if err := yaml.Unmarshal([]byte(existingYAML), &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse skill sources.yaml: %w", err)
+	}
+
+	filtered := make([]map[string]interface{}, 0)
+	for _, src := range parsed.Catalogs {
+		if id, ok := src["id"].(string); ok && id != sourceId {
+			filtered = append(filtered, src)
+		}
+	}
+
+	parsed.Catalogs = filtered
+	updatedBytes, err := yaml.Marshal(parsed)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal updated skill sources.yaml: %w", err)
+	}
+
+	return string(updatedBytes), nil
+}
+
+func ConvertSkillSourceConfigToYamlEntry(payload models.SkillCatalogSourceConfigPayload) map[string]interface{} {
+	entry := map[string]interface{}{
+		"id":      payload.Id,
+		"name":    payload.Name,
+		"type":    payload.Type,
+		"enabled": payload.Enabled,
+	}
+
+	if len(payload.Labels) > 0 {
+		entry["labels"] = payload.Labels
+	}
+
+	props := map[string]interface{}{}
+	if len(payload.Repositories) > 0 {
+		props["repositories"] = buildSkillRepoYamlEntries(payload)
+	}
+	entry["properties"] = props
+
+	return entry
+}
+
+// buildSkillRepoYamlEntries serialises payload.Repositories into the
+// properties.repositories[] form the catalog service expects.
+//
+// The catalog service decodes a skill source's properties with
+// DisallowUnknownFields (see catalog/internal/catalog/skillcatalog/source_schema.go),
+// so an unrecognised key here is not ignored — it fails the whole source.
+// Only keys present on the backend's SkillRepository struct may be emitted, and
+// category/provider/trustTier belong on each repository rather than on properties.
+//
+// This is the single writer for repository entries; all update paths must go
+// through it so the two representations cannot drift apart again.
+//
+// Entries are rebuilt from the payload rather than merged into what is stored, so
+// provider/category/trustTier are replace-not-merge: an update that carries
+// repositories but omits those three erases them from the stored entry. That is safe
+// only because the settings form lifts all three into every save
+// (SkillManageSourceForm's optionalFields). Nothing enforces that coupling, so a
+// future change that moves them to be genuinely per-repository — where the catalog
+// schema wants them — must keep sending them here, or start merging them from the
+// existing entry, otherwise every edit silently drops a source's trust tier and its
+// provider/category filter values.
+func buildSkillRepoYamlEntries(payload models.SkillCatalogSourceConfigPayload) []map[string]interface{} {
+	repos := make([]map[string]interface{}, 0, len(payload.Repositories))
+	for _, r := range payload.Repositories {
+		repo := map[string]interface{}{
+			"url": r.URL,
+		}
+		if r.CanonicalURL != nil && *r.CanonicalURL != "" {
+			repo["canonicalUrl"] = *r.CanonicalURL
+		}
+		if len(r.Refs) > 0 {
+			repo["refs"] = r.Refs
+		}
+		if len(r.ScanPaths) > 0 {
+			repo["scanPaths"] = r.ScanPaths
+		}
+		if r.CredentialRef != nil && *r.CredentialRef != "" {
+			repo["credentialRef"] = *r.CredentialRef
+		}
+		if len(r.IncludedSkills) > 0 {
+			repo["includedSkills"] = r.IncludedSkills
+		}
+		if len(r.ExcludedSkills) > 0 {
+			repo["excludedSkills"] = r.ExcludedSkills
+		}
+		// Per-skill labels. Omitting them when empty is how they get cleared: an
+		// update replaces the whole repositories list, so a key left out is gone.
+		if len(r.Labels) > 0 {
+			repo["labels"] = r.Labels
+		}
+		// Round-tripped, never authored here: the form has no per-skill control, so these
+		// arrive only from a previous read of a GitOps-authored source. Omitting them
+		// would delete them, since this rebuilds the entry from scratch.
+		if len(r.SkillOverrides) > 0 {
+			overrides := make([]map[string]interface{}, 0, len(r.SkillOverrides))
+			for _, ov := range r.SkillOverrides {
+				entry := map[string]interface{}{"name": ov.Name}
+				if ov.Category != nil && *ov.Category != "" {
+					entry["category"] = *ov.Category
+				}
+				if len(ov.Labels) > 0 {
+					entry["labels"] = ov.Labels
+				}
+				overrides = append(overrides, entry)
+			}
+			repo["skillOverrides"] = overrides
+		}
+		if payload.Provider != nil && *payload.Provider != "" {
+			repo["provider"] = *payload.Provider
+		}
+		if payload.Category != nil && *payload.Category != "" {
+			repo["category"] = *payload.Category
+		}
+		if payload.TrustTier != nil && *payload.TrustTier != "" {
+			repo["trustTier"] = *payload.TrustTier
+		}
+		repos = append(repos, repo)
+	}
+	return repos
+}
+
+func UpdateSkillCatalogSourceInYAML(
+	existingYAML string,
+	catalogId string,
+	payload models.SkillCatalogSourceConfigPayload,
+) (string, error) {
+	var parsed struct {
+		Catalogs []map[string]interface{} `yaml:"skill_catalogs"`
+	}
+
+	if existingYAML == "" {
+		return "", fmt.Errorf("no existing yaml to update")
+	}
+
+	if err := yaml.Unmarshal([]byte(existingYAML), &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse skill sources.yaml: %w", err)
+	}
+
+	found := false
+	for i, src := range parsed.Catalogs {
+		if id, ok := src["id"].(string); ok && id == catalogId {
+			found = true
+
+			if payload.Name != "" {
+				src["name"] = payload.Name
+			}
+			// nil means the caller did not send labels at all (e.g. a toggle-only
+			// update), so leave them alone. An empty but non-nil slice is an explicit
+			// "remove them all" — writing that back is what lets the settings UI clear
+			// the last label instead of silently keeping it.
+			if payload.Labels != nil {
+				if len(payload.Labels) > 0 {
+					src["labels"] = payload.Labels
+				} else {
+					delete(src, "labels")
+				}
+			}
+			if payload.Enabled != nil {
+				src["enabled"] = *payload.Enabled
+			}
+			existingProps, _ := src["properties"].(map[string]interface{})
+			if existingProps == nil {
+				existingProps = map[string]interface{}{}
+			}
+			if len(payload.Repositories) > 0 {
+				// Drop stale source-level metadata written by earlier BFF versions.
+				// Only done when replacing repos, so a toggle-only update does not
+				// erase fields it was never given a replacement for.
+				delete(existingProps, "provider")
+				delete(existingProps, "category")
+				delete(existingProps, "trustTier")
+				existingProps["repositories"] = buildSkillRepoYamlEntries(payload)
+			}
+			// Only write properties back when there is something in them. An empty map
+			// serialises as `properties: {}`, which is not the same as omitting the key:
+			// MergeCommonSourceFields replaces the base source's Properties whenever the
+			// override's is non-nil, so a default source overridden with `{}` loses its
+			// repositories and then fails to load ("no repositories configured"). This is
+			// reachable by toggling a shipped default off and back on, since the first
+			// toggle writes an override entry that carries no properties at all.
+			if len(existingProps) > 0 {
+				src["properties"] = existingProps
+			}
+
+			parsed.Catalogs[i] = src
+			break
+		}
+	}
+
+	if !found {
+		return "", fmt.Errorf("skill catalog '%s' not found in yaml", catalogId)
+	}
+
+	updatedBytes, err := yaml.Marshal(parsed)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal updated skill sources.yaml: %w", err)
+	}
+
+	return string(updatedBytes), nil
+}
+
+func mergeSkillCatalogSourceConfigs(defaultCatalog, userCatalog models.SkillCatalogSourceConfig) models.SkillCatalogSourceConfig {
+	merged := defaultCatalog
+
+	if userCatalog.Name != "" {
+		merged.Name = userCatalog.Name
+	}
+	if userCatalog.Type != "" {
+		merged.Type = userCatalog.Type
+	}
+	if userCatalog.Enabled != nil {
+		merged.Enabled = userCatalog.Enabled
+	}
+	// Same nil-vs-empty rule as the update path: a user override that clears the
+	// labels of a default source must win, not fall back to the default's labels.
+	if userCatalog.Labels != nil {
+		merged.Labels = userCatalog.Labels
+	}
+	if userCatalog.Provider != nil {
+		merged.Provider = userCatalog.Provider
+	}
+	if userCatalog.Category != nil {
+		merged.Category = userCatalog.Category
+	}
+	if userCatalog.TrustTier != nil {
+		merged.TrustTier = userCatalog.TrustTier
+	}
+	if len(userCatalog.Repositories) > 0 {
+		merged.Repositories = userCatalog.Repositories
+	}
+
+	return merged
+}
+
+func validateSkillCatalogSourceConfigPayload(payload models.SkillCatalogSourceConfigPayload) error {
+	if payload.Id == "" {
+		return fmt.Errorf("%w", ErrSkillCatalogSourceIdRequired)
+	}
+
+	if err := validateSkillCatalogId(payload.Id); err != nil {
+		return fmt.Errorf("%w: %v", ErrSkillCatalogValidationFailed, err)
+	}
+
+	if payload.Name == "" {
+		return fmt.Errorf("%w: name is required", ErrSkillCatalogValidationFailed)
+	}
+
+	if payload.Type == "" {
+		return fmt.Errorf("%w: type is required", ErrSkillCatalogValidationFailed)
+	}
+
+	if payload.Type != SkillCatalogTypeGit {
+		return fmt.Errorf("%w: unsupported skill catalog type: %s (supported: %s)", ErrSkillCatalogValidationFailed, payload.Type, SkillCatalogTypeGit)
+	}
+
+	if len(payload.Repositories) == 0 {
+		return fmt.Errorf("%w: at least one repository is required for git-skills-plugin sources", ErrSkillCatalogValidationFailed)
+	}
+
+	if err := validateSkillRepositories(payload.Repositories); err != nil {
+		return err
+	}
+
+	if err := validateSourceMetadataFields(payload.Category, payload.Provider, payload.TrustTier); err != nil {
+		return fmt.Errorf("%w: %v", ErrSkillCatalogValidationFailed, err)
+	}
+
+	return nil
+}
+
+// validateSkillUpdatePayloadForDefaultOverride mirrors the model and MCP catalogs
+// (validateMcpUpdatePayloadForDefaultOverride): a shipped default source is read-only
+// apart from being enabled or disabled. Allowing repositories through here would let an
+// admin repoint a platform-provided source at an arbitrary git repo while its skills keep
+// the source's trust tier.
+func validateSkillUpdatePayloadForDefaultOverride(payload models.SkillCatalogSourceConfigPayload) error {
+	if payload.Name != "" {
+		return fmt.Errorf("%w: cannot change 'name'", ErrSkillCatalogCannotChangeDefault)
+	}
+
+	if payload.Labels != nil {
+		return fmt.Errorf("%w: cannot change 'labels'", ErrSkillCatalogCannotChangeDefault)
+	}
+
+	if len(payload.Repositories) > 0 {
+		return fmt.Errorf("%w: cannot change 'repositories'", ErrSkillCatalogCannotChangeDefault)
+	}
+
+	if payload.Provider != nil || payload.Category != nil || payload.TrustTier != nil {
+		return fmt.Errorf("%w: cannot change source metadata", ErrSkillCatalogCannotChangeDefault)
+	}
+
+	return nil
+}
+
+func validateSkillCatalogUpdatePayload(payload models.SkillCatalogSourceConfigPayload) error {
+	if err := validateSourceMetadataFields(payload.Category, payload.Provider, payload.TrustTier); err != nil {
+		return fmt.Errorf("%w: %v", ErrSkillCatalogValidationFailed, err)
+	}
+	if err := validateSkillRepositories(payload.Repositories); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateSkillRepositories applies the per-repository checks the catalog service
+// performs at load time, so a bad value is reported to the admin here rather than
+// silently breaking the source on the next sync.
+//
+// A source written through this API carries exactly one repository, matching the
+// catalog service's inline form (resolveRepositories rejects a longer inline list).
+// The write path assumes it: provider/category/trustTier arrive at the source level
+// and are stamped onto every repository entry, and reads recover them from the first
+// entry only — so a second repository could neither carry its own provenance nor be
+// read back. Multi-repository sources are configured through yamlCatalogPath, which
+// this API does not write.
+func validateSkillRepositories(repos []models.SkillRepository) error {
+	if len(repos) > 1 {
+		return fmt.Errorf("%w: a source accepts a single repository (got %d); configure several through yamlCatalogPath, or register one source per repository",
+			ErrSkillCatalogValidationFailed, len(repos))
+	}
+	for i, repo := range repos {
+		if repo.URL == "" {
+			return fmt.Errorf("%w: repository[%d].url is required", ErrSkillCatalogValidationFailed, i)
+		}
+		if repo.CredentialRef != nil && *repo.CredentialRef != "" && !validCredentialRef.MatchString(*repo.CredentialRef) {
+			return fmt.Errorf("%w: repository[%d].credentialRef %q must be a plain filename (letters, digits, '.', '_', '-')",
+				ErrSkillCatalogValidationFailed, i, *repo.CredentialRef)
+		}
+	}
+	return nil
+}
+
+// validateSourceMetadataFields validates category, provider, and trustTier together.
+// All three fields are optional; when provided they must be non-empty, and trustTier
+// must be one of the values defined in the SkillTrustTier enum.
+func validateSourceMetadataFields(category, provider, trustTier *string) error {
+	if category != nil && *category == "" {
+		return fmt.Errorf("category must not be an empty string when provided")
+	}
+	if provider != nil && *provider == "" {
+		return fmt.Errorf("provider must not be an empty string when provided")
+	}
+	return validateTrustTier(trustTier)
+}
+
+func validateTrustTier(trustTier *string) error {
+	if trustTier == nil || *trustTier == "" {
+		return nil
+	}
+	if _, ok := validSkillTrustTiers[*trustTier]; !ok {
+		valid := make([]string, 0, len(validSkillTrustTiers))
+		for k := range validSkillTrustTiers {
+			valid = append(valid, k)
+		}
+		return fmt.Errorf("invalid trustTier %q: must be one of %v", *trustTier, valid)
+	}
+	return nil
+}

--- a/clients/ui/bff/internal/repositories/skill_catalog_helpers_test.go
+++ b/clients/ui/bff/internal/repositories/skill_catalog_helpers_test.go
@@ -1,0 +1,679 @@
+package repositories
+
+import (
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+var _ = Describe("skill catalog helpers", func() {
+
+	ptr := func(s string) *string { return &s }
+
+	Describe("validateSkillCatalogId", func() {
+		It("accepts an id with only lowercase letters, numbers, and underscores", func() {
+			Expect(validateSkillCatalogId("my_source_1")).NotTo(HaveOccurred())
+		})
+
+		It("accepts a hyphenated id, unlike the shared model/mcp catalog validator", func() {
+			Expect(validateSkillCatalogId("my-source")).NotTo(HaveOccurred())
+		})
+
+		It("rejects an empty id", func() {
+			Expect(validateSkillCatalogId("")).To(HaveOccurred())
+		})
+
+		It("rejects an id with disallowed characters", func() {
+			err := validateSkillCatalogId("my source!")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("lowercase letters, numbers, hyphens, and underscores"))
+		})
+	})
+
+	Describe("validateSourceMetadataFields", func() {
+		It("accepts all three fields absent (nil)", func() {
+			Expect(validateSourceMetadataFields(nil, nil, nil)).To(Succeed())
+		})
+		It("accepts all three fields populated with valid values", func() {
+			Expect(validateSourceMetadataFields(
+				ptr("Development"), ptr("Matt"), ptr("communityContributed"),
+			)).To(Succeed())
+		})
+
+		Context("category", func() {
+			It("rejects an empty-string category", func() {
+				Expect(validateSourceMetadataFields(ptr(""), nil, nil)).
+					To(MatchError(ContainSubstring("category must not be an empty string")))
+			})
+			It("accepts a non-empty category", func() {
+				Expect(validateSourceMetadataFields(ptr("productivity"), nil, nil)).To(Succeed())
+			})
+		})
+
+		Context("provider", func() {
+			It("rejects an empty-string provider", func() {
+				Expect(validateSourceMetadataFields(nil, ptr(""), nil)).
+					To(MatchError(ContainSubstring("provider must not be an empty string")))
+			})
+			It("accepts a non-empty provider", func() {
+				Expect(validateSourceMetadataFields(nil, ptr("Red Hat"), nil)).To(Succeed())
+			})
+		})
+
+		Context("trustTier", func() {
+			It("rejects 'Community'", func() {
+				Expect(validateSourceMetadataFields(nil, nil, ptr("Community"))).
+					To(MatchError(ContainSubstring("invalid trustTier")))
+			})
+			It("accepts all valid enum values", func() {
+				for tier := range validSkillTrustTiers {
+					t := tier
+					Expect(validateSourceMetadataFields(nil, nil, &t)).To(Succeed())
+				}
+			})
+		})
+	})
+
+	Describe("validateSkillCatalogSourceConfigPayload (create)", func() {
+		basePayload := func() models.SkillCatalogSourceConfig {
+			return models.SkillCatalogSourceConfig{
+				Id:           "test-source",
+				Name:         "Test Source",
+				Type:         SkillCatalogTypeGit,
+				Repositories: []models.SkillRepository{{URL: "https://github.com/example/skills.git"}},
+			}
+		}
+
+		It("accepts a fully valid payload with all three metadata fields", func() {
+			p := basePayload()
+			p.Category = ptr("Development")
+			p.Provider = ptr("Matt")
+			p.TrustTier = ptr("communityContributed")
+			Expect(validateSkillCatalogSourceConfigPayload(p)).To(Succeed())
+		})
+		It("rejects an empty category", func() {
+			p := basePayload()
+			p.Category = ptr("")
+			Expect(validateSkillCatalogSourceConfigPayload(p)).
+				To(MatchError(ContainSubstring("category must not be an empty string")))
+		})
+		It("rejects an empty provider", func() {
+			p := basePayload()
+			p.Provider = ptr("")
+			Expect(validateSkillCatalogSourceConfigPayload(p)).
+				To(MatchError(ContainSubstring("provider must not be an empty string")))
+		})
+		It("rejects an invalid trustTier", func() {
+			p := basePayload()
+			p.TrustTier = ptr("Community")
+			Expect(validateSkillCatalogSourceConfigPayload(p)).
+				To(MatchError(ContainSubstring("invalid trustTier")))
+		})
+	})
+
+	Describe("validateSkillCatalogUpdatePayload (patch)", func() {
+		It("accepts an empty payload (toggle-only)", func() {
+			Expect(validateSkillCatalogUpdatePayload(models.SkillCatalogSourceConfig{})).To(Succeed())
+		})
+		It("accepts all three metadata fields set to valid values", func() {
+			p := models.SkillCatalogSourceConfig{
+				Category:  ptr("Development"),
+				Provider:  ptr("Matt"),
+				TrustTier: ptr("communityContributed"),
+			}
+			Expect(validateSkillCatalogUpdatePayload(p)).To(Succeed())
+		})
+		It("rejects an empty-string category in a patch", func() {
+			p := models.SkillCatalogSourceConfig{Category: ptr("")}
+			Expect(validateSkillCatalogUpdatePayload(p)).
+				To(MatchError(ContainSubstring("category must not be an empty string")))
+		})
+		It("rejects an empty-string provider in a patch", func() {
+			p := models.SkillCatalogSourceConfig{Provider: ptr("")}
+			Expect(validateSkillCatalogUpdatePayload(p)).
+				To(MatchError(ContainSubstring("provider must not be an empty string")))
+		})
+		It("rejects an invalid trustTier in a patch", func() {
+			p := models.SkillCatalogSourceConfig{TrustTier: ptr("Community")}
+			Expect(validateSkillCatalogUpdatePayload(p)).
+				To(MatchError(ContainSubstring("invalid trustTier")))
+		})
+	})
+
+	Describe("ParseSkillCatalogYaml", func() {
+		It("reads category/provider/trustTier from repository level (canonical)", func() {
+			raw := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      repositories:
+        - url: https://github.com/example/skills.git
+          provider: Matt
+          category: Development
+          trustTier: communityContributed
+`
+			configs, err := ParseSkillCatalogYaml(raw, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs).To(HaveLen(1))
+			Expect(configs[0].Category).To(HaveValue(Equal("Development")))
+			Expect(configs[0].Provider).To(HaveValue(Equal("Matt")))
+			Expect(configs[0].TrustTier).To(HaveValue(Equal("communityContributed")))
+		})
+
+		It("falls back to properties level for hand-written ConfigMaps", func() {
+			raw := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      category: Development
+      provider: Matt
+      trustTier: communityContributed
+      repositories:
+        - url: https://github.com/example/skills.git
+`
+			configs, err := ParseSkillCatalogYaml(raw, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs).To(HaveLen(1))
+			Expect(configs[0].Category).To(HaveValue(Equal("Development")))
+			Expect(configs[0].Provider).To(HaveValue(Equal("Matt")))
+			Expect(configs[0].TrustTier).To(HaveValue(Equal("communityContributed")))
+		})
+
+		It("prefers repository-level values over properties-level when both exist", func() {
+			raw := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      category: WrongLevel
+      provider: WrongLevel
+      trustTier: platformProvided
+      repositories:
+        - url: https://github.com/example/skills.git
+          category: Development
+          provider: Matt
+          trustTier: communityContributed
+`
+			configs, err := ParseSkillCatalogYaml(raw, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Category).To(HaveValue(Equal("Development")))
+			Expect(configs[0].Provider).To(HaveValue(Equal("Matt")))
+			Expect(configs[0].TrustTier).To(HaveValue(Equal("communityContributed")))
+		})
+
+		It("returns an error instead of silently dropping repositories when the shape is malformed", func() {
+			raw := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      repositories: "not-a-list-of-repos"
+`
+			configs, err := ParseSkillCatalogYaml(raw, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("test-source"))
+			Expect(configs).To(BeNil())
+		})
+	})
+
+	Describe("ConvertSkillSourceConfigToYamlEntry", func() {
+		It("writes all three fields inside each repository entry, not at properties level", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id:        "test-source",
+				Name:      "Test Source",
+				Type:      SkillCatalogTypeGit,
+				Provider:  ptr("Matt"),
+				Category:  ptr("Development"),
+				TrustTier: ptr("communityContributed"),
+				Repositories: []models.SkillRepository{
+					{URL: "https://github.com/example/skills.git"},
+				},
+			}
+			entry := ConvertSkillSourceConfigToYamlEntry(payload)
+
+			props, ok := entry["properties"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(props).NotTo(HaveKey("category"), "category must not leak to properties level")
+			Expect(props).NotTo(HaveKey("provider"), "provider must not leak to properties level")
+			Expect(props).NotTo(HaveKey("trustTier"), "trustTier must not leak to properties level")
+
+			repos, ok := props["repositories"].([]map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(repos).To(HaveLen(1))
+			Expect(repos[0]).To(HaveKeyWithValue("category", "Development"))
+			Expect(repos[0]).To(HaveKeyWithValue("provider", "Matt"))
+			Expect(repos[0]).To(HaveKeyWithValue("trustTier", "communityContributed"))
+		})
+	})
+
+	Describe("UpdateSkillCatalogSourceInYAML", func() {
+		It("migrates all three fields from properties level to repository level on update", func() {
+			existing := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      category: Development
+      provider: Matt
+      trustTier: communityContributed
+      repositories:
+        - url: https://github.com/example/skills.git
+`
+			payload := models.SkillCatalogSourceConfig{
+				Category:     ptr("Development"),
+				Provider:     ptr("Matt"),
+				TrustTier:    ptr("communityContributed"),
+				Repositories: []models.SkillRepository{{URL: "https://github.com/example/skills.git"}},
+			}
+			updated, err := UpdateSkillCatalogSourceInYAML(existing, "test-source", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Re-parse and verify all three landed in the repo, not at properties level
+			configs, err := ParseSkillCatalogYaml(updated, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Category).To(HaveValue(Equal("Development")))
+			Expect(configs[0].Provider).To(HaveValue(Equal("Matt")))
+			Expect(configs[0].TrustTier).To(HaveValue(Equal("communityContributed")))
+
+			// Also confirm the fields sit under the repository and not on properties
+			// itself. A substring check cannot tell the two levels apart — the same
+			// "category: Development" text appears either way — so inspect the structure.
+			var doc struct {
+				Catalogs []struct {
+					Properties map[string]interface{} `yaml:"properties"`
+				} `yaml:"skill_catalogs"`
+			}
+			Expect(yaml.Unmarshal([]byte(updated), &doc)).To(Succeed())
+			Expect(doc.Catalogs).To(HaveLen(1))
+			props := doc.Catalogs[0].Properties
+			Expect(props).NotTo(HaveKey("category"), "category must not be at properties level")
+			Expect(props).NotTo(HaveKey("provider"), "provider must not be at properties level")
+			Expect(props).NotTo(HaveKey("trustTier"), "trustTier must not be at properties level")
+			Expect(props).To(HaveKey("repositories"))
+		})
+	})
+
+	Describe("buildSkillRepoYamlEntries", func() {
+		// backendRepoKeys mirrors SkillRepository in
+		// catalog/internal/catalog/skillcatalog/source_schema.go. That struct is decoded
+		// with DisallowUnknownFields, so emitting a key absent from this set does not get
+		// ignored — it fails the entire source at load time. Adding a key here without a
+		// matching backend field is a breaking change.
+		backendRepoKeys := []string{
+			"url", "canonicalUrl", "refs", "scanPaths", "credentialRef",
+			"trustTier", "provider", "category", "labels",
+			"includedSkills", "excludedSkills", "skillOverrides",
+		}
+
+		It("emits only keys the catalog service declares", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id:        "test-source",
+				Provider:  ptr("Matt"),
+				Category:  ptr("Development"),
+				TrustTier: ptr("communityContributed"),
+				Repositories: []models.SkillRepository{{
+					URL:            "https://github.com/example/skills.git",
+					CanonicalURL:   ptr("https://github.com/upstream/skills.git"),
+					Refs:           []string{"v1.2.3"},
+					ScanPaths:      []string{"skills/"},
+					CredentialRef:  ptr("test-source"),
+					IncludedSkills: []string{"a*"},
+					ExcludedSkills: []string{"*-draft"},
+				}},
+			}
+
+			repos := buildSkillRepoYamlEntries(payload)
+			Expect(repos).To(HaveLen(1))
+			for key := range repos[0] {
+				Expect(backendRepoKeys).To(ContainElement(key),
+					"key %q is not declared by the backend SkillRepository struct and will fail "+
+						"its DisallowUnknownFields decode, breaking the whole source", key)
+			}
+		})
+
+		It("writes the credential as credentialRef and never leaks a token", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id: "test-source",
+				Repositories: []models.SkillRepository{{
+					URL:           "https://github.com/example/skills.git",
+					CredentialRef: ptr("test-source"),
+					AuthToken:     ptr("ghp_supersecret"),
+				}},
+			}
+
+			repos := buildSkillRepoYamlEntries(payload)
+			Expect(repos[0]).To(HaveKeyWithValue("credentialRef", "test-source"))
+			Expect(repos[0]).NotTo(HaveKey("authToken"), "the raw token must never reach the ConfigMap")
+			Expect(repos[0]).NotTo(HaveKey("authSecretName"), "authSecretName is not a backend field")
+		})
+
+		It("preserves every repository field, not just url and refs", func() {
+			// Regression guard: the default-source override path previously emitted only
+			// url and refs, silently dropping the rest when a default source was edited.
+			payload := models.SkillCatalogSourceConfig{
+				Id:       "test-source",
+				Provider: ptr("Matt"),
+				Repositories: []models.SkillRepository{{
+					URL:            "https://github.com/example/skills.git",
+					Refs:           []string{"v1.2.3"},
+					ScanPaths:      []string{"skills/"},
+					IncludedSkills: []string{"a*"},
+					ExcludedSkills: []string{"*-draft"},
+					CredentialRef:  ptr("test-source"),
+				}},
+			}
+
+			repos := buildSkillRepoYamlEntries(payload)
+			Expect(repos[0]).To(HaveKeyWithValue("scanPaths", []string{"skills/"}))
+			Expect(repos[0]).To(HaveKeyWithValue("includedSkills", []string{"a*"}))
+			Expect(repos[0]).To(HaveKeyWithValue("excludedSkills", []string{"*-draft"}))
+			Expect(repos[0]).To(HaveKeyWithValue("credentialRef", "test-source"))
+			Expect(repos[0]).To(HaveKeyWithValue("provider", "Matt"))
+		})
+	})
+
+	Describe("repository labels", func() {
+		// Repo labels are stamped onto every skill the repository yields
+		// (catalog/internal/catalog/skillcatalog/entity_builder.go). They are a
+		// different field from the source-level labels that drive sourceLabel
+		// grouping, and both have to survive a round trip independently.
+		It("round-trips repository labels through write then read", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id:     "test-source",
+				Name:   "Test Source",
+				Type:   SkillCatalogTypeGit,
+				Labels: []string{"source-level"},
+				Repositories: []models.SkillRepository{{
+					URL:    "https://github.com/example/skills.git",
+					Labels: []string{"community", "typescript"},
+				}},
+			}
+			yamlStr, err := AppendSkillCatalogSourceToYaml("", ConvertSkillSourceConfigToYamlEntry(payload))
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(yamlStr, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Repositories[0].Labels).To(Equal([]string{"community", "typescript"}))
+			Expect(configs[0].Labels).To(Equal([]string{"source-level"}),
+				"source-level labels must not be overwritten by repository labels")
+		})
+
+		It("writes repository labels inside the repository entry, not at properties level", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id:   "test-source",
+				Type: SkillCatalogTypeGit,
+				Repositories: []models.SkillRepository{{
+					URL:    "https://github.com/example/skills.git",
+					Labels: []string{"community"},
+				}},
+			}
+			entry := ConvertSkillSourceConfigToYamlEntry(payload)
+			props, ok := entry["properties"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(props).NotTo(HaveKey("labels"))
+
+			repos, ok := props["repositories"].([]map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(repos[0]).To(HaveKeyWithValue("labels", []string{"community"}))
+		})
+
+		It("clears repository labels when an update omits them", func() {
+			existing := `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    properties:
+      repositories:
+        - url: https://github.com/example/skills.git
+          labels: [community]
+`
+			payload := models.SkillCatalogSourceConfig{
+				Repositories: []models.SkillRepository{{URL: "https://github.com/example/skills.git"}},
+			}
+			updated, err := UpdateSkillCatalogSourceInYAML(existing, "test-source", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(updated, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Repositories[0].Labels).To(BeEmpty())
+		})
+	})
+
+	Describe("source label updates", func() {
+		const existing = `
+skill_catalogs:
+  - id: test-source
+    name: Test Source
+    type: git-skills-plugin
+    labels: [alpha, beta]
+    properties:
+      repositories:
+        - url: https://github.com/example/skills.git
+`
+
+		It("clears source labels when given an empty (non-nil) list", func() {
+			// Regression guard: the old `len(payload.Labels) > 0` check made removing
+			// every label a no-op, which also meant the ConfigMap came back
+			// byte-identical and the catalog never reloaded.
+			payload := models.SkillCatalogSourceConfig{Labels: []string{}}
+			updated, err := UpdateSkillCatalogSourceInYAML(existing, "test-source", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(updated, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Labels).To(BeEmpty())
+		})
+
+		It("leaves source labels alone when they are not sent at all", func() {
+			// A toggle-only update must not wipe labels it was never given.
+			enabled := false
+			payload := models.SkillCatalogSourceConfig{Enabled: &enabled}
+			updated, err := UpdateSkillCatalogSourceInYAML(existing, "test-source", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(updated, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Labels).To(Equal([]string{"alpha", "beta"}))
+			Expect(configs[0].Enabled).To(HaveValue(BeFalse()))
+		})
+
+		It("replaces source labels when given a new list", func() {
+			payload := models.SkillCatalogSourceConfig{Labels: []string{"gamma"}}
+			updated, err := UpdateSkillCatalogSourceInYAML(existing, "test-source", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(updated, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Labels).To(Equal([]string{"gamma"}))
+		})
+	})
+
+	Describe("default-source label overrides", func() {
+		It("keeps an empty label list distinguishable from an absent one after a YAML round trip", func() {
+			// The default-override path writes `labels: []` to mean "clear the
+			// default's labels". That only works if the value survives as a non-nil
+			// empty slice, because mergeSkillCatalogSourceConfigs branches on nil.
+			yamlStr, err := AppendSkillCatalogSourceToYaml("", map[string]interface{}{
+				"id":     "test-source",
+				"labels": []string{},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(yamlStr, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Labels).NotTo(BeNil(), "an explicit clear must not decode as nil")
+			Expect(configs[0].Labels).To(BeEmpty())
+
+			merged := mergeSkillCatalogSourceConfigs(
+				models.SkillCatalogSourceConfig{Id: "test-source", Labels: []string{"shipped"}},
+				configs[0],
+			)
+			Expect(merged.Labels).To(BeEmpty())
+		})
+	})
+
+	Describe("mergeSkillCatalogSourceConfigs", func() {
+		It("lets a user override clear a default source's labels", func() {
+			merged := mergeSkillCatalogSourceConfigs(
+				models.SkillCatalogSourceConfig{Id: "s", Labels: []string{"shipped"}},
+				models.SkillCatalogSourceConfig{Id: "s", Labels: []string{}},
+			)
+			Expect(merged.Labels).To(BeEmpty())
+		})
+
+		It("keeps the default's labels when the override does not mention them", func() {
+			merged := mergeSkillCatalogSourceConfigs(
+				models.SkillCatalogSourceConfig{Id: "s", Labels: []string{"shipped"}},
+				models.SkillCatalogSourceConfig{Id: "s"},
+			)
+			Expect(merged.Labels).To(Equal([]string{"shipped"}))
+		})
+	})
+
+	Describe("validateSkillRepositories", func() {
+		It("accepts a credentialRef that is a plain filename", func() {
+			Expect(validateSkillRepositories([]models.SkillRepository{
+				{URL: "https://github.com/example/skills.git", CredentialRef: ptr("matt-pocock-skills")},
+			})).To(Succeed())
+		})
+		It("rejects a credentialRef containing a path separator", func() {
+			Expect(validateSkillRepositories([]models.SkillRepository{
+				{URL: "https://github.com/example/skills.git", CredentialRef: ptr("../../etc/passwd")},
+			})).To(MatchError(ContainSubstring("must be a plain filename")))
+		})
+		It("still requires a repository url", func() {
+			Expect(validateSkillRepositories([]models.SkillRepository{{URL: ""}})).
+				To(MatchError(ContainSubstring("url is required")))
+		})
+	})
+
+	Describe("credentialRef round-trip", func() {
+		It("survives write then read", func() {
+			payload := models.SkillCatalogSourceConfig{
+				Id:   "test-source",
+				Name: "Test Source",
+				Type: SkillCatalogTypeGit,
+				Repositories: []models.SkillRepository{{
+					URL:           "https://github.com/example/skills.git",
+					CredentialRef: ptr("test-source"),
+				}},
+			}
+			yamlStr, err := AppendSkillCatalogSourceToYaml("", ConvertSkillSourceConfigToYamlEntry(payload))
+			Expect(err).NotTo(HaveOccurred())
+
+			configs, err := ParseSkillCatalogYaml(yamlStr, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(configs[0].Repositories[0].CredentialRef).To(HaveValue(Equal("test-source")))
+		})
+	})
+})
+
+var _ = Describe("skillOverrides round trip", func() {
+	// The settings UI has no control for skillOverrides, so an edit sends back whatever
+	// the previous read returned. The write path rebuilds properties.repositories from
+	// scratch, so anything it fails to emit is deleted rather than left alone.
+	const sourceYAML = `
+skill_catalogs:
+  - id: acme_skills
+    name: Acme Skills
+    type: git-skills-plugin
+    enabled: true
+    properties:
+      repositories:
+        - url: https://github.com/acme/skills.git
+          category: DevOps
+          skillOverrides:
+            - name: deploy
+              category: SRE
+              labels: [ops, oncall]
+            - name: lint
+              category: QA
+`
+
+	It("reads skillOverrides off a repository entry", func() {
+		parsed, err := ParseSkillCatalogYaml(sourceYAML, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parsed).To(HaveLen(1))
+		Expect(parsed[0].Repositories).To(HaveLen(1))
+
+		overrides := parsed[0].Repositories[0].SkillOverrides
+		Expect(overrides).To(HaveLen(2))
+		Expect(overrides[0].Name).To(Equal("deploy"))
+		Expect(*overrides[0].Category).To(Equal("SRE"))
+		Expect(overrides[0].Labels).To(Equal([]string{"ops", "oncall"}))
+		Expect(overrides[1].Name).To(Equal("lint"))
+		Expect(overrides[1].Labels).To(BeEmpty())
+	})
+
+	It("preserves them through a save that does not touch them", func() {
+		parsed, err := ParseSkillCatalogYaml(sourceYAML, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Feed the parsed config straight back, the way an unrelated UI edit would.
+		updated, err := UpdateSkillCatalogSourceInYAML(sourceYAML, "acme_skills", parsed[0])
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(ContainSubstring("skillOverrides"))
+
+		reparsed, err := ParseSkillCatalogYaml(updated, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reparsed).To(HaveLen(1))
+		Expect(reparsed[0].Repositories[0].SkillOverrides).
+			To(Equal(parsed[0].Repositories[0].SkillOverrides))
+	})
+
+	It("omits the key entirely when a source has no overrides", func() {
+		payload := models.SkillCatalogSourceConfigPayload{
+			Id:   "plain_source",
+			Name: "Plain",
+			Type: SkillCatalogTypeGit,
+			Repositories: []models.SkillRepository{
+				{URL: "https://github.com/acme/plain.git"},
+			},
+		}
+		entry := ConvertSkillSourceConfigToYamlEntry(payload)
+		out, err := AppendSkillCatalogSourceToYaml("", entry)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).NotTo(ContainSubstring("skillOverrides"))
+	})
+})
+
+var _ = Describe("default source override round trip", func() {
+	// Toggling a shipped default off writes an override entry carrying only {id, enabled}.
+	// Toggling it back on then takes the user-source update path. That path must not emit
+	// `properties: {}`: MergeCommonSourceFields replaces the base source's Properties
+	// whenever the override's is non-nil, so an empty map strips the default's
+	// repositories and the source stops loading entirely.
+	It("does not write an empty properties map when the override has none", func() {
+		existing := "skill_catalogs:\n    - enabled: false\n      id: community_skills\n"
+
+		updated, err := UpdateSkillCatalogSourceInYAML(existing, "community_skills",
+			models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(true)})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).NotTo(ContainSubstring("properties"))
+
+		reparsed, err := ParseSkillCatalogYaml(updated, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reparsed).To(HaveLen(1))
+		Expect(*reparsed[0].Enabled).To(BeTrue())
+	})
+
+	It("still writes properties when the update carries repositories", func() {
+		existing := "skill_catalogs:\n    - enabled: true\n      id: custom\n"
+
+		updated, err := UpdateSkillCatalogSourceInYAML(existing, "custom",
+			models.SkillCatalogSourceConfigPayload{
+				Repositories: []models.SkillRepository{{URL: "https://github.com/example/skills"}},
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(ContainSubstring("repositories"))
+	})
+})

--- a/clients/ui/bff/internal/repositories/skill_catalog_settings.go
+++ b/clients/ui/bff/internal/repositories/skill_catalog_settings.go
@@ -1,0 +1,249 @@
+package repositories
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+var (
+	ErrSkillCatalogSourceNotFound      = errors.New("skill catalog source not found")
+	ErrSkillCatalogSourceAlreadyExist  = errors.New("skill catalog source already exists")
+	ErrSkillCatalogSourceIdRequired    = errors.New("skill catalog source ID is required")
+	ErrSkillCatalogSourceConflict      = errors.New("skill catalog source was modified by another request")
+	ErrSkillCatalogCannotChangeDefault = errors.New("cannot change the default skill source")
+	ErrSkillCatalogCannotDeleteDefault = errors.New("cannot delete the default skill source")
+	ErrSkillCatalogValidationFailed    = errors.New("validation failed")
+	ErrSkillCatalogCannotChangeType    = errors.New("cannot change skill catalog source type")
+)
+
+type SkillCatalogSettingsRepository struct{}
+
+func NewSkillCatalogSettingsRepository() *SkillCatalogSettingsRepository {
+	return &SkillCatalogSettingsRepository{}
+}
+
+func (r *SkillCatalogSettingsRepository) GetAllSkillCatalogSourceConfigs(ctx context.Context, client k8s.KubernetesClientInterface, namespace string) (*models.SkillCatalogSourceConfigList, error) {
+	defaultCM, userCM, err := client.GetAllSkillCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch skill catalog source configmaps: %w", err)
+	}
+
+	catalogMap := make(map[string]models.SkillCatalogSourceConfig)
+
+	if raw, ok := defaultCM.Data[k8s.SkillCatalogSourceKey]; ok {
+		defaultSources, err := ParseSkillCatalogYaml(raw, true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse default skill catalogs: %w", err)
+		}
+		for _, src := range defaultSources {
+			catalogMap[src.Id] = src
+		}
+	}
+
+	if raw, ok := userCM.Data[k8s.SkillCatalogSourceKey]; ok {
+		userSources, err := ParseSkillCatalogYaml(raw, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse user managed skill catalogs: %w", err)
+		}
+		for _, userSrc := range userSources {
+			if existing, ok := catalogMap[userSrc.Id]; ok {
+				catalogMap[userSrc.Id] = mergeSkillCatalogSourceConfigs(existing, userSrc)
+			} else {
+				catalogMap[userSrc.Id] = userSrc
+			}
+		}
+	}
+
+	list := &models.SkillCatalogSourceConfigList{
+		Catalogs: make([]models.SkillCatalogSourceConfig, 0, len(catalogMap)),
+	}
+	for _, src := range catalogMap {
+		list.Catalogs = append(list.Catalogs, src)
+	}
+
+	return list, nil
+}
+
+func (r *SkillCatalogSettingsRepository) GetSkillCatalogSourceConfig(ctx context.Context, client k8s.KubernetesClientInterface, namespace, sourceID string) (*models.SkillCatalogSourceConfig, error) {
+	defaultCM, userCM, err := client.GetAllSkillCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch skill catalog source configmaps: %w", err)
+	}
+
+	defaultSrc := FindSkillCatalogSourceById(defaultCM.Data[k8s.SkillCatalogSourceKey], sourceID, true)
+	userSrc := FindSkillCatalogSourceById(userCM.Data[k8s.SkillCatalogSourceKey], sourceID, false)
+
+	if userSrc != nil {
+		if defaultSrc != nil {
+			merged := mergeSkillCatalogSourceConfigs(*defaultSrc, *userSrc)
+			return &merged, nil
+		}
+		return userSrc, nil
+	}
+	if defaultSrc != nil {
+		return defaultSrc, nil
+	}
+
+	return nil, fmt.Errorf("%w: %s", ErrSkillCatalogSourceNotFound, sourceID)
+}
+
+func (r *SkillCatalogSettingsRepository) CreateSkillCatalogSourceConfig(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace string,
+	payload models.SkillCatalogSourceConfigPayload,
+) (*models.SkillCatalogSourceConfig, error) {
+	if err := validateSkillCatalogSourceConfigPayload(payload); err != nil {
+		return nil, err
+	}
+
+	defaultCM, userCM, err := client.GetAllSkillCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch skill catalog source configmaps: %w", err)
+	}
+
+	if FindSkillCatalogSourceById(defaultCM.Data[k8s.SkillCatalogSourceKey], payload.Id, true) != nil {
+		return nil, fmt.Errorf("%w: '%s' already exists in default sources", ErrSkillCatalogSourceAlreadyExist, payload.Id)
+	}
+	if FindSkillCatalogSourceById(userCM.Data[k8s.SkillCatalogSourceKey], payload.Id, false) != nil {
+		return nil, fmt.Errorf("%w: '%s' already exists in user managed sources", ErrSkillCatalogSourceAlreadyExist, payload.Id)
+	}
+
+	newEntry := ConvertSkillSourceConfigToYamlEntry(payload)
+	existing := userCM.Data[k8s.SkillCatalogSourceKey]
+
+	updated, err := AppendSkillCatalogSourceToYaml(existing, newEntry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to append skill catalog to yaml: %w", err)
+	}
+
+	if userCM.Data == nil {
+		userCM.Data = make(map[string]string)
+	}
+	userCM.Data[k8s.SkillCatalogSourceKey] = updated
+
+	if err := client.UpdateSkillCatalogSourceConfig(ctx, namespace, &userCM); err != nil {
+		if apierrors.IsConflict(err) {
+			return nil, fmt.Errorf("%w: %v", ErrSkillCatalogSourceConflict, err)
+		}
+		return nil, fmt.Errorf("failed to update user skill catalog configmap: %w", err)
+	}
+
+	return r.GetSkillCatalogSourceConfig(ctx, client, namespace, payload.Id)
+}
+
+func (r *SkillCatalogSettingsRepository) UpdateSkillCatalogSourceConfig(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace, sourceID string,
+	payload models.SkillCatalogSourceConfigPayload,
+) (*models.SkillCatalogSourceConfig, error) {
+	if err := validateSkillCatalogUpdatePayload(payload); err != nil {
+		return nil, err
+	}
+
+	defaultCM, userCM, err := client.GetAllSkillCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch skill catalog source configmaps: %w", err)
+	}
+
+	existingUser := FindSkillCatalogSourceById(userCM.Data[k8s.SkillCatalogSourceKey], sourceID, false)
+	existingDefault := FindSkillCatalogSourceById(defaultCM.Data[k8s.SkillCatalogSourceKey], sourceID, true)
+
+	if existingUser == nil && existingDefault == nil {
+		return nil, fmt.Errorf("%w: '%s'", ErrSkillCatalogSourceNotFound, sourceID)
+	}
+
+	isOverridingDefault := existingDefault != nil
+
+	if payload.Type != "" {
+		existing := existingUser
+		if existing == nil {
+			existing = existingDefault
+		}
+		if payload.Type != existing.Type {
+			return nil, fmt.Errorf("%w: cannot change from '%s' to '%s'", ErrSkillCatalogCannotChangeType, existing.Type, payload.Type)
+		}
+	}
+
+	// Applies whenever a default with this id exists, not only on the first override:
+	// once an enabled-toggle has written a user entry, later updates take the branch
+	// below, which would otherwise let name/repositories through unchecked. This mirrors
+	// where the MCP catalog places the same check.
+	if isOverridingDefault {
+		if err := validateSkillUpdatePayloadForDefaultOverride(payload); err != nil {
+			return nil, err
+		}
+	}
+
+	if userCM.Data == nil {
+		userCM.Data = make(map[string]string)
+	}
+
+	if existingUser != nil {
+		updatedYAML, err := UpdateSkillCatalogSourceInYAML(userCM.Data[k8s.SkillCatalogSourceKey], sourceID, payload)
+		if err != nil {
+			return nil, fmt.Errorf("failed to update skill catalog in yaml: %w", err)
+		}
+		userCM.Data[k8s.SkillCatalogSourceKey] = updatedYAML
+	} else if isOverridingDefault {
+		overrideEntry := map[string]interface{}{"id": sourceID}
+		if payload.Enabled != nil {
+			overrideEntry["enabled"] = *payload.Enabled
+		}
+		updatedYAML, err := AppendSkillCatalogSourceToYaml(userCM.Data[k8s.SkillCatalogSourceKey], overrideEntry)
+		if err != nil {
+			return nil, fmt.Errorf("failed to append override entry: %w", err)
+		}
+		userCM.Data[k8s.SkillCatalogSourceKey] = updatedYAML
+	}
+
+	if err := client.UpdateSkillCatalogSourceConfig(ctx, namespace, &userCM); err != nil {
+		if apierrors.IsConflict(err) {
+			return nil, fmt.Errorf("%w: %v", ErrSkillCatalogSourceConflict, err)
+		}
+		return nil, fmt.Errorf("failed to update user skill catalog configmap: %w", err)
+	}
+
+	return r.GetSkillCatalogSourceConfig(ctx, client, namespace, sourceID)
+}
+
+func (r *SkillCatalogSettingsRepository) DeleteSkillCatalogSourceConfig(
+	ctx context.Context,
+	client k8s.KubernetesClientInterface,
+	namespace, sourceID string,
+) (*models.SkillCatalogSourceConfig, error) {
+	defaultCM, userCM, err := client.GetAllSkillCatalogSourceConfigs(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch skill catalog source configmaps: %w", err)
+	}
+
+	if FindSkillCatalogSourceById(defaultCM.Data[k8s.SkillCatalogSourceKey], sourceID, true) != nil {
+		return nil, fmt.Errorf("%w: '%s' is a default source", ErrSkillCatalogCannotDeleteDefault, sourceID)
+	}
+
+	toDelete := FindSkillCatalogSourceById(userCM.Data[k8s.SkillCatalogSourceKey], sourceID, false)
+	if toDelete == nil {
+		return nil, fmt.Errorf("%w: '%s' not found in user sources", ErrSkillCatalogSourceNotFound, sourceID)
+	}
+
+	updatedYAML, err := RemoveSkillCatalogSourceFromYAML(userCM.Data[k8s.SkillCatalogSourceKey], sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to remove skill catalog from sources.yaml: %w", err)
+	}
+	userCM.Data[k8s.SkillCatalogSourceKey] = updatedYAML
+
+	if err := client.UpdateSkillCatalogSourceConfig(ctx, namespace, &userCM); err != nil {
+		if apierrors.IsConflict(err) {
+			return nil, fmt.Errorf("%w: %v", ErrSkillCatalogSourceConflict, err)
+		}
+		return nil, fmt.Errorf("failed to update configmap after deletion: %w", err)
+	}
+
+	return toDelete, nil
+}

--- a/clients/ui/bff/internal/repositories/skill_catalog_settings_test.go
+++ b/clients/ui/bff/internal/repositories/skill_catalog_settings_test.go
@@ -1,0 +1,321 @@
+package repositories
+
+import (
+	"context"
+
+	k8s "github.com/kubeflow/hub/ui/bff/internal/integrations/kubernetes"
+	"github.com/kubeflow/hub/ui/bff/internal/mocks"
+	"github.com/kubeflow/hub/ui/bff/internal/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SkillCatalogSettingsRepository", func() {
+	var (
+		repo      *SkillCatalogSettingsRepository
+		k8sClient k8s.KubernetesClientInterface
+		ctx       context.Context
+	)
+
+	BeforeEach(func() {
+		repo = NewSkillCatalogSettingsRepository()
+		var err error
+		k8sClient, err = kubernetesMockedStaticClientFactory.GetClient(mocks.NewMockSessionContextNoParent())
+		Expect(err).NotTo(HaveOccurred())
+		ctx = mocks.NewMockSessionContextNoParent()
+	})
+
+	findById := func(list *models.SkillCatalogSourceConfigList, id string) *models.SkillCatalogSourceConfig {
+		for i := range list.Catalogs {
+			if list.Catalogs[i].Id == id {
+				return &list.Catalogs[i]
+			}
+		}
+		return nil
+	}
+
+	gitSource := func(id, name string) models.SkillCatalogSourceConfigPayload {
+		return models.SkillCatalogSourceConfigPayload{
+			Id:      id,
+			Name:    name,
+			Type:    SkillCatalogTypeGit,
+			Enabled: skillBoolPtr(true),
+			Repositories: []models.SkillRepository{
+				{URL: "https://github.com/example/" + id, Refs: []string{"v1.0.0"}},
+			},
+		}
+	}
+
+	Describe("GetAllSkillCatalogSourceConfigs", func() {
+		It("returns sources merged from both the default and user managed configmaps", func() {
+			list, err := repo.GetAllSkillCatalogSourceConfigs(ctx, k8sClient, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(findById(list, "community_skills")).NotTo(BeNil())
+			Expect(findById(list, "custom_skills")).NotTo(BeNil())
+		})
+
+		It("marks a source from the default configmap as default", func() {
+			list, err := repo.GetAllSkillCatalogSourceConfigs(ctx, k8sClient, "kubeflow")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*findById(list, "community_skills").IsDefault).To(BeTrue())
+			Expect(*findById(list, "custom_skills").IsDefault).To(BeFalse())
+		})
+
+		It("lets a user override win over the default it shadows", func() {
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "bella-namespace", "community_skills",
+				models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(false)})
+			Expect(err).NotTo(HaveOccurred())
+
+			list, err := repo.GetAllSkillCatalogSourceConfigs(ctx, k8sClient, "bella-namespace")
+			Expect(err).NotTo(HaveOccurred())
+			merged := findById(list, "community_skills")
+			Expect(merged).NotTo(BeNil())
+			Expect(*merged.Enabled).To(BeFalse())
+			// Fields the override does not carry still come from the default.
+			Expect(merged.Name).To(Equal("Community Skills"))
+			Expect(*merged.IsDefault).To(BeTrue())
+		})
+	})
+
+	Describe("GetSkillCatalogSourceConfig", func() {
+		It("reads repository metadata from the first repository entry", func() {
+			config, err := repo.GetSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_skills")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config.Type).To(Equal(SkillCatalogTypeGit))
+			Expect(config.Repositories).To(HaveLen(1))
+			Expect(config.Repositories[0].URL).To(Equal("https://github.com/example/community-skills"))
+			Expect(config.Repositories[0].Refs).To(Equal([]string{"v1.0.0"}))
+			Expect(*config.Provider).To(Equal("Community"))
+			Expect(*config.Category).To(Equal("development"))
+			Expect(*config.TrustTier).To(Equal("communityContributed"))
+		})
+
+		It("returns the credentialRef but never an auth token", func() {
+			config, err := repo.GetSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_skills")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*config.Repositories[0].CredentialRef).To(Equal("custom_skills"))
+			Expect(config.Repositories[0].AuthToken).To(BeNil())
+		})
+
+		It("returns ErrSkillCatalogSourceNotFound for an unknown id", func() {
+			_, err := repo.GetSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "does_not_exist")
+			Expect(err).To(MatchError(ErrSkillCatalogSourceNotFound))
+		})
+	})
+
+	Describe("CreateSkillCatalogSourceConfig", func() {
+		It("persists a new source so it can be read back", func() {
+			created, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", gitSource("skill_repo_create", "Skill Repo Create"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(created.Id).To(Equal("skill_repo_create"))
+			Expect(*created.IsDefault).To(BeFalse())
+
+			readBack, err := repo.GetSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_create")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(readBack.Repositories).To(HaveLen(1))
+		})
+
+		It("writes provider, category and trustTier onto the repository entry", func() {
+			payload := gitSource("skill_repo_metadata", "Skill Repo Metadata")
+			payload.Provider = skillStringPtr("Acme")
+			payload.Category = skillStringPtr("security")
+			payload.TrustTier = skillStringPtr("partnerVerified")
+
+			created, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*created.Provider).To(Equal("Acme"))
+			Expect(*created.Category).To(Equal("security"))
+			Expect(*created.TrustTier).To(Equal("partnerVerified"))
+		})
+
+		It("rejects a source that duplicates a default", func() {
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", gitSource("community_skills", "Duplicate"))
+			Expect(err).To(MatchError(ErrSkillCatalogSourceAlreadyExist))
+		})
+
+		It("rejects a source with no id", func() {
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", gitSource("", "No Id"))
+			Expect(err).To(MatchError(ErrSkillCatalogSourceIdRequired))
+		})
+
+		It("rejects a non git-skills-plugin type", func() {
+			payload := gitSource("skill_repo_bad_type", "Bad Type")
+			payload.Type = "yaml"
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+		})
+
+		It("rejects a source with no repositories", func() {
+			payload := gitSource("skill_repo_no_repos", "No Repos")
+			payload.Repositories = nil
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+		})
+
+		It("rejects a source listing more than one repository", func() {
+			payload := gitSource("skill_repo_two_repos", "Two Repos")
+			payload.Repositories = []models.SkillRepository{
+				{URL: "https://github.com/example/one"},
+				{URL: "https://github.com/example/two"},
+			}
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+			Expect(err.Error()).To(ContainSubstring("single repository"))
+		})
+
+		It("rejects a credentialRef that could escape the mounted secret directory", func() {
+			payload := gitSource("skill_repo_bad_ref", "Bad Credential Ref")
+			payload.Repositories[0].CredentialRef = skillStringPtr("../../etc/passwd")
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+		})
+
+		It("rejects a trustTier outside the SkillTrustTier enum", func() {
+			payload := gitSource("skill_repo_bad_tier", "Bad Tier")
+			payload.TrustTier = skillStringPtr("goldPlated")
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+		})
+	})
+
+	Describe("UpdateSkillCatalogSourceConfig", func() {
+		It("updates a user managed source in place", func() {
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", gitSource("skill_repo_update", "Before"))
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_update",
+				models.SkillCatalogSourceConfigPayload{Name: "After", Enabled: skillBoolPtr(false)})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Name).To(Equal("After"))
+			Expect(*updated.Enabled).To(BeFalse())
+		})
+
+		It("clears labels when given an empty but non-nil slice", func() {
+			payload := gitSource("skill_repo_labels", "Labels")
+			payload.Labels = []string{"Keep"}
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_labels",
+				models.SkillCatalogSourceConfigPayload{Labels: []string{}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Labels).To(BeEmpty())
+		})
+
+		It("leaves labels alone when the payload omits them", func() {
+			payload := gitSource("skill_repo_labels_kept", "Labels Kept")
+			payload.Labels = []string{"Keep"}
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", payload)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_labels_kept",
+				models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(false)})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Labels).To(Equal([]string{"Keep"}))
+		})
+
+		It("refuses every field but enabled on a shipped default", func() {
+			for _, tc := range []struct {
+				field   string
+				payload models.SkillCatalogSourceConfigPayload
+			}{
+				{"name", models.SkillCatalogSourceConfigPayload{Name: "Renamed"}},
+				{"labels", models.SkillCatalogSourceConfigPayload{Labels: []string{"Mine"}}},
+				{"repositories", models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{{URL: "https://github.com/attacker/evil-skills"}},
+				}},
+				{"provider", models.SkillCatalogSourceConfigPayload{Provider: skillStringPtr("Attacker")}},
+				{"trustTier", models.SkillCatalogSourceConfigPayload{TrustTier: skillStringPtr("platformProvided")}},
+			} {
+				_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_skills", tc.payload)
+				Expect(err).To(MatchError(ErrSkillCatalogCannotChangeDefault), "expected %s to be rejected on a default", tc.field)
+			}
+		})
+
+		It("still allows toggling enabled on a shipped default", func() {
+			updated, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_skills",
+				models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(false)})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*updated.Enabled).To(BeFalse())
+			Expect(updated.Name).To(Equal("Community Skills"))
+		})
+
+		It("keeps enforcing the default guard after an override entry already exists", func() {
+			// The first toggle writes a user entry, so a later update takes the
+			// user-source branch. The guard must still apply there.
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "bella-namespace", "community_skills",
+				models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(false)})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "bella-namespace", "community_skills",
+				models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{{URL: "https://github.com/attacker/evil-skills"}},
+				})
+			Expect(err).To(MatchError(ErrSkillCatalogCannotChangeDefault))
+		})
+
+		It("refuses to change the source type", func() {
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_skills",
+				models.SkillCatalogSourceConfigPayload{Type: "yaml"})
+			Expect(err).To(MatchError(ErrSkillCatalogCannotChangeType))
+		})
+
+		It("returns ErrSkillCatalogSourceNotFound for an unknown id", func() {
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "does_not_exist",
+				models.SkillCatalogSourceConfigPayload{Enabled: skillBoolPtr(false)})
+			Expect(err).To(MatchError(ErrSkillCatalogSourceNotFound))
+		})
+
+		It("rejects more than one repository on update too", func() {
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_skills",
+				models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{
+						{URL: "https://github.com/example/one"},
+						{URL: "https://github.com/example/two"},
+					},
+				})
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+			Expect(err.Error()).To(ContainSubstring("single repository"))
+		})
+
+		It("validates repositories on update", func() {
+			_, err := repo.UpdateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "custom_skills",
+				models.SkillCatalogSourceConfigPayload{
+					Repositories: []models.SkillRepository{{URL: ""}},
+				})
+			Expect(err).To(MatchError(ErrSkillCatalogValidationFailed))
+		})
+	})
+
+	Describe("DeleteSkillCatalogSourceConfig", func() {
+		It("removes a user managed source", func() {
+			_, err := repo.CreateSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", gitSource("skill_repo_delete", "Skill Repo Delete"))
+			Expect(err).NotTo(HaveOccurred())
+
+			deleted, err := repo.DeleteSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_delete")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleted.Id).To(Equal("skill_repo_delete"))
+
+			_, err = repo.GetSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "skill_repo_delete")
+			Expect(err).To(MatchError(ErrSkillCatalogSourceNotFound))
+		})
+
+		It("refuses to delete a default source", func() {
+			_, err := repo.DeleteSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "community_skills")
+			Expect(err).To(MatchError(ErrSkillCatalogCannotDeleteDefault))
+		})
+
+		It("returns ErrSkillCatalogSourceNotFound for an unknown id", func() {
+			_, err := repo.DeleteSkillCatalogSourceConfig(ctx, k8sClient, "kubeflow", "does_not_exist")
+			Expect(err).To(MatchError(ErrSkillCatalogSourceNotFound))
+		})
+	})
+})
+
+func skillBoolPtr(b bool) *bool {
+	return &b
+}
+
+func skillStringPtr(s string) *string {
+	return &s
+}

--- a/clients/ui/frontend/src/app/AppRoutes.tsx
+++ b/clients/ui/frontend/src/app/AppRoutes.tsx
@@ -8,11 +8,14 @@ import ModelRegistryRoutes from './pages/modelRegistry/ModelRegistryRoutes';
 import ModelCatalogRoutes from './pages/modelCatalog/ModelCatalogRoutes';
 import McpCatalogRoutes from './pages/mcpCatalog/McpCatalogRoutes';
 import AgentsCatalogRoutes from './pages/agentsCatalog/AgentsCatalogRoutes';
+import SkillCatalogRoutes from './pages/skillCatalog/SkillCatalogRoutes';
 import ModelCatalogSettingsRoutes from './pages/modelCatalogSettings/ModelCatalogSettingsRoutes';
 import McpCatalogSettingsRoutes from './pages/mcpCatalogSettings/McpCatalogSettingsRoutes';
+import SkillCatalogSettingsRoutes from './pages/skillCatalogSettings/SkillCatalogSettingsRoutes';
 import { modelCatalogUrl } from './routes/modelCatalog/catalogModel';
 import { mcpCatalogUrl } from './routes/mcpCatalog/mcpCatalog';
 import { agentsCatalogUrl } from './routes/agentsCatalog/agentsCatalog';
+import { skillCatalogUrl, SKILL_CATALOG_TITLE } from './routes/skillCatalog/skillCatalog';
 import {
   catalogSettingsUrl,
   CATALOG_SETTINGS_PAGE_TITLE,
@@ -21,6 +24,10 @@ import {
   mcpCatalogSettingsUrl,
   MCP_CATALOG_SETTINGS_PAGE_TITLE,
 } from './routes/mcpCatalogSettings/mcpCatalogSettings';
+import {
+  skillCatalogSettingsUrl,
+  SKILL_CATALOG_SETTINGS_PAGE_TITLE,
+} from './routes/skillCatalogSettings/skillCatalogSettings';
 import { modelRegistryUrl } from './pages/modelRegistry/screens/routeUtils';
 import { MODEL_CATALOG_TITLE } from './pages/modelCatalog/const';
 import { MCP_CATALOG_TITLE } from './pages/mcpCatalog/const';
@@ -45,6 +52,10 @@ export const useAdminSettings = (): NavDataItem[] => {
     settingsChildren.push({
       label: MCP_CATALOG_SETTINGS_PAGE_TITLE,
       path: mcpCatalogSettingsUrl(),
+    });
+    settingsChildren.push({
+      label: SKILL_CATALOG_SETTINGS_PAGE_TITLE,
+      path: skillCatalogSettingsUrl(),
     });
   }
 
@@ -74,6 +85,7 @@ export const useNavData = (): NavDataItem[] => {
       { label: MODEL_CATALOG_TITLE, path: modelCatalogUrl() },
       { label: MCP_CATALOG_TITLE, path: mcpCatalogUrl() },
       { label: AGENTS_CATALOG_TITLE, path: agentsCatalogUrl() },
+      { label: SKILL_CATALOG_TITLE, path: skillCatalogUrl() },
     );
   }
 
@@ -96,8 +108,10 @@ const AppRoutes: React.FC = () => {
           <Route path={`${modelCatalogUrl()}/*`} element={<ModelCatalogRoutes />} />
           <Route path={`${mcpCatalogUrl()}/*`} element={<McpCatalogRoutes />} />
           <Route path={`${agentsCatalogUrl()}/*`} element={<AgentsCatalogRoutes />} />
+          <Route path={`${skillCatalogUrl()}/*`} element={<SkillCatalogRoutes />} />
           <Route path={`${catalogSettingsUrl()}/*`} element={<ModelCatalogSettingsRoutes />} />
           <Route path={`${mcpCatalogSettingsUrl()}/*`} element={<McpCatalogSettingsRoutes />} />
+          <Route path={`${skillCatalogSettingsUrl()}/*`} element={<SkillCatalogSettingsRoutes />} />
         </>
       )}
       <Route path="*" element={<NotFound />} />

--- a/clients/ui/frontend/src/app/api/skillCatalog/service.ts
+++ b/clients/ui/frontend/src/app/api/skillCatalog/service.ts
@@ -1,0 +1,72 @@
+import { APIOptions, handleRestFailures, isModArchResponse, restGET } from 'mod-arch-core';
+import {
+  Skill,
+  SkillList,
+  SkillListParams,
+  SkillMarketplace,
+  SkillMarketplaceResult,
+} from '~/app/skillCatalogTypes';
+import { CatalogFilterOptionsList } from '~/app/modelCatalogTypes';
+
+export const getSkillList =
+  (hostPath: string, queryParams: Record<string, unknown> = {}) =>
+  (opts: APIOptions, listParams?: SkillListParams): Promise<SkillList> => {
+    const pageSize = listParams?.pageSize !== undefined ? String(listParams.pageSize) : undefined;
+    const allParams = {
+      ...queryParams,
+      ...(listParams?.sourceLabel !== undefined && { sourceLabel: listParams.sourceLabel }),
+      ...(listParams?.nextPageToken !== undefined && { nextPageToken: listParams.nextPageToken }),
+      ...(pageSize !== undefined && { pageSize }),
+      ...(listParams?.filterQuery !== undefined &&
+        listParams.filterQuery !== '' && { filterQuery: listParams.filterQuery }),
+      ...(listParams?.q !== undefined && listParams.q !== '' && { q: listParams.q }),
+    };
+    return handleRestFailures(restGET(hostPath, '/skills', allParams, opts)).then((response) => {
+      if (isModArchResponse<SkillList>(response)) {
+        return response.data;
+      }
+      throw new Error('Invalid response format');
+    });
+  };
+
+export const getSkillFilterOptionList =
+  (hostPath: string, queryParams: Record<string, unknown> = {}) =>
+  (opts: APIOptions): Promise<CatalogFilterOptionsList> =>
+    handleRestFailures(restGET(hostPath, '/skills_filter_options', queryParams, opts)).then(
+      (response) => {
+        if (isModArchResponse<CatalogFilterOptionsList>(response)) {
+          return response.data;
+        }
+        throw new Error('Invalid response format');
+      },
+    );
+
+export const getSkill =
+  (hostPath: string, queryParams: Record<string, unknown> = {}) =>
+  (opts: APIOptions, skillId: string): Promise<Skill> =>
+    handleRestFailures(restGET(hostPath, `/skills/${skillId}`, queryParams, opts)).then(
+      (response) => {
+        if (isModArchResponse<Skill>(response)) {
+          return response.data;
+        }
+        throw new Error('Invalid response format');
+      },
+    );
+
+export const getSkillMarketplace =
+  (hostPath: string, queryParams: Record<string, unknown> = {}) =>
+  (opts: APIOptions): Promise<SkillMarketplaceResult> =>
+    handleRestFailures(restGET(hostPath, '/claude/marketplace.json', queryParams, opts)).then(
+      (response) => {
+        if (isModArchResponse<SkillMarketplace>(response)) {
+          const metadata = response.metadata ?? {};
+          return {
+            marketplace: response.data,
+            marketplaceUrl:
+              typeof metadata.marketplaceUrl === 'string' ? metadata.marketplaceUrl : '',
+            external: metadata.external === true,
+          };
+        }
+        throw new Error('Invalid response format');
+      },
+    );

--- a/clients/ui/frontend/src/app/api/skillCatalogSettings/service.ts
+++ b/clients/ui/frontend/src/app/api/skillCatalogSettings/service.ts
@@ -1,0 +1,25 @@
+import {
+  SkillCatalogSourceConfig,
+  SkillCatalogSourceConfigList,
+  SkillCatalogSourceConfigPayload,
+  SkillCatalogSourcePreviewRequest,
+  SkillCatalogSourcePreviewResult,
+} from '~/app/skillCatalogTypes';
+import { createSourceConfigService } from '~/app/shared/catalogSettings/api/createSourceConfigService';
+
+const service = createSourceConfigService<
+  SkillCatalogSourceConfig,
+  SkillCatalogSourceConfigList,
+  SkillCatalogSourceConfigPayload,
+  SkillCatalogSourcePreviewRequest,
+  SkillCatalogSourcePreviewResult
+>({
+  previewExtraQueryParams: { assetType: 'skills' },
+});
+
+export const getSkillCatalogSourceConfigs = service.getSourceConfigs;
+export const createSkillCatalogSourceConfig = service.createSourceConfig;
+export const getSkillCatalogSourceConfig = service.getSourceConfig;
+export const updateSkillCatalogSourceConfig = service.updateSourceConfig;
+export const deleteSkillCatalogSourceConfig = service.deleteSourceConfig;
+export const previewSkillCatalogSource = service.previewSource;

--- a/clients/ui/frontend/src/app/context/skillCatalog/SkillCatalogContext.tsx
+++ b/clients/ui/frontend/src/app/context/skillCatalog/SkillCatalogContext.tsx
@@ -1,0 +1,167 @@
+import * as React from 'react';
+import { useQueryParamNamespaces } from 'mod-arch-core';
+import { BFF_API_VERSION, URL_PREFIX } from '~/app/utilities/const';
+import {
+  createCatalogContext,
+  CatalogCommonData,
+  CatalogProviderState,
+} from '~/app/context/catalogContext/createCatalogContext';
+import useModelCatalogAPIState from '~/app/hooks/modelCatalog/useModelCatalogAPIState';
+import { useCatalogSources } from '~/app/hooks/modelCatalog/useCatalogSources';
+import { useCatalogLabels } from '~/app/hooks/modelCatalog/useCatalogLabels';
+import { useSkillFilterOptionListWithAPI } from '~/app/hooks/skillCatalog/useSkillFilterOptionList';
+import useEmptyCategoryTracking from '~/app/hooks/useEmptyCategoryTracking';
+import type {
+  SkillCatalogFiltersState,
+  SkillCatalogFilterOptionsList,
+} from '~/app/pages/skillCatalog/types/skillCatalogFilterOptions';
+import { useSkillUrlSync } from '~/app/pages/skillCatalog/hooks/useSkillUrlSync';
+import type { SkillCatalogExtension, SkillCatalogPaginationState } from './types';
+
+export type {
+  SkillCatalogContextType,
+  SkillCatalogExtension,
+  SkillCatalogPaginationState,
+} from './types';
+export type { SkillCatalogFiltersState } from '~/app/pages/skillCatalog/types/skillCatalogFilterOptions';
+
+const SKILL_CATALOG_PATH = `${URL_PREFIX}/api/${BFF_API_VERSION}/skill_catalog`;
+const MODEL_CATALOG_PATH = `${URL_PREFIX}/api/${BFF_API_VERSION}/model_catalog`;
+
+const defaultPagination: SkillCatalogPaginationState = {
+  page: 1,
+  pageSize: 10,
+  totalItems: 0,
+};
+
+function useSkillCatalogSetup(providerState: CatalogProviderState) {
+  const queryParams = useQueryParamNamespaces();
+  const [apiStateSkillCatalog] = useModelCatalogAPIState(SKILL_CATALOG_PATH, queryParams);
+  // Sources and labels are served by the generic model_catalog plugin, discriminated by
+  // assetType — the same route MCP and models use, rather than a skill-specific proxy.
+  const [apiStateModelCatalog] = useModelCatalogAPIState(MODEL_CATALOG_PATH, queryParams);
+
+  const skillListParams = React.useMemo(() => ({ assetType: 'skills' as const }), []);
+  const [catalogSources, catalogSourcesLoaded, catalogSourcesLoadError] = useCatalogSources(
+    apiStateModelCatalog,
+    skillListParams,
+  );
+  const [catalogLabels, catalogLabelsLoaded, catalogLabelsLoadError] = useCatalogLabels(
+    apiStateModelCatalog,
+    skillListParams,
+  );
+
+  const [filterOptions, filterOptionsLoaded, filterOptionsLoadError] =
+    useSkillFilterOptionListWithAPI(apiStateSkillCatalog);
+
+  const { initialState, syncToUrl } = useSkillUrlSync();
+
+  const [filters, setFilters] = React.useState<SkillCatalogFiltersState>(initialState.filters);
+  const [searchQuery, setSearchQuery] = React.useState(initialState.searchQuery);
+  const [pagination, setPaginationState] =
+    React.useState<SkillCatalogPaginationState>(defaultPagination);
+
+  const { setSelectedSourceLabel } = providerState;
+  const { emptyCategoryLabels, categoriesResolved, reportCategoryEmpty, setCategoryCount } =
+    useEmptyCategoryTracking();
+
+  React.useEffect(() => {
+    setSelectedSourceLabel(initialState.selectedSourceLabel);
+  }, [setSelectedSourceLabel, initialState.selectedSourceLabel]);
+
+  React.useEffect(() => {
+    syncToUrl({
+      searchQuery,
+      filters,
+      selectedSourceLabel: providerState.selectedSourceLabel,
+    });
+  }, [searchQuery, filters, providerState.selectedSourceLabel, syncToUrl]);
+
+  const setPage = React.useCallback((page: number) => {
+    setPaginationState((prev) => ({ ...prev, page }));
+  }, []);
+
+  const setPageSize = React.useCallback((pageSize: number) => {
+    setPaginationState((prev) => ({ ...prev, pageSize, page: 1 }));
+  }, []);
+
+  const setTotalItems = React.useCallback((totalItems: number) => {
+    setPaginationState((prev) => ({ ...prev, totalItems }));
+  }, []);
+
+  const clearAllFilters = React.useCallback(() => {
+    setSearchQuery('');
+    setFilters({});
+  }, []);
+
+  const catalogData = React.useMemo<CatalogCommonData<SkillCatalogFilterOptionsList>>(
+    () => ({
+      catalogSources,
+      catalogSourcesLoaded,
+      catalogSourcesLoadError,
+      catalogLabels,
+      catalogLabelsLoaded,
+      catalogLabelsLoadError,
+      filterOptions,
+      filterOptionsLoaded,
+      filterOptionsLoadError,
+    }),
+    [
+      catalogSources,
+      catalogSourcesLoaded,
+      catalogSourcesLoadError,
+      catalogLabels,
+      catalogLabelsLoaded,
+      catalogLabelsLoadError,
+      filterOptions,
+      filterOptionsLoaded,
+      filterOptionsLoadError,
+    ],
+  );
+
+  const extension = React.useMemo(
+    () => ({
+      searchQuery,
+      setSearchQuery,
+      filters,
+      setFilters,
+      pagination,
+      setPage,
+      setPageSize,
+      setTotalItems,
+      clearAllFilters,
+      skillApiState: apiStateSkillCatalog,
+      emptyCategoryLabels,
+      categoriesResolved,
+      reportCategoryEmpty,
+      setCategoryCount,
+    }),
+    [
+      apiStateSkillCatalog,
+      searchQuery,
+      filters,
+      pagination,
+      setPage,
+      setPageSize,
+      setTotalItems,
+      clearAllFilters,
+      emptyCategoryLabels,
+      categoriesResolved,
+      reportCategoryEmpty,
+      setCategoryCount,
+    ],
+  );
+
+  return { catalogData, extension };
+}
+
+const {
+  Context: SkillCatalogContext,
+  Provider: SkillCatalogContextProvider,
+  useContext: useSkillCatalogContext,
+} = createCatalogContext<SkillCatalogFilterOptionsList, SkillCatalogExtension>({
+  displayName: 'SkillCatalogContextProvider',
+  useSetup: useSkillCatalogSetup,
+});
+
+export { SkillCatalogContext, SkillCatalogContextProvider, useSkillCatalogContext };

--- a/clients/ui/frontend/src/app/context/skillCatalog/types.ts
+++ b/clients/ui/frontend/src/app/context/skillCatalog/types.ts
@@ -1,0 +1,33 @@
+import type * as React from 'react';
+import type { ModelCatalogAPIState } from '~/app/hooks/modelCatalog/useModelCatalogAPIState';
+import type { CatalogContextValue } from '~/app/context/catalogContext/createCatalogContext';
+import type {
+  SkillCatalogFiltersState,
+  SkillCatalogFilterOptionsList,
+} from '~/app/pages/skillCatalog/types/skillCatalogFilterOptions';
+
+export type SkillCatalogPaginationState = {
+  page: number;
+  pageSize: number;
+  totalItems: number;
+};
+
+export type SkillCatalogExtension = {
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  filters: SkillCatalogFiltersState;
+  setFilters: React.Dispatch<React.SetStateAction<SkillCatalogFiltersState>>;
+  pagination: SkillCatalogPaginationState;
+  setPage: (page: number) => void;
+  setPageSize: (pageSize: number) => void;
+  setTotalItems: (totalItems: number) => void;
+  clearAllFilters: () => void;
+  skillApiState: ModelCatalogAPIState;
+  emptyCategoryLabels: Set<string>;
+  categoriesResolved: boolean;
+  reportCategoryEmpty: (label: string, isEmpty: boolean) => void;
+  setCategoryCount: (count: number) => void;
+};
+
+export type SkillCatalogContextType = CatalogContextValue<SkillCatalogFilterOptionsList> &
+  SkillCatalogExtension;

--- a/clients/ui/frontend/src/app/context/skillCatalogSettings/SkillCatalogSettingsContext.tsx
+++ b/clients/ui/frontend/src/app/context/skillCatalogSettings/SkillCatalogSettingsContext.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import useSkillCatalogSettingsAPIState, {
+  SkillCatalogSettingsAPIState,
+} from '~/app/hooks/skillCatalogSettings/useSkillCatalogSettingsAPIState';
+import { useSkillCatalogSourceConfigs } from '~/app/hooks/skillCatalogSettings/useSkillCatalogSourceConfigs';
+import type { SkillCatalogSourceConfigList } from '~/app/skillCatalogTypes';
+import type { CatalogSourceList } from '~/app/shared/types/catalogTypes';
+import { BFF_API_VERSION, URL_PREFIX } from '~/app/utilities/const';
+import { createCatalogSettingsContext } from '~/app/shared/catalogSettings/createCatalogSettingsContext';
+
+const { useCatalogSettingsValue } = createCatalogSettingsContext<
+  SkillCatalogSettingsAPIState,
+  SkillCatalogSourceConfigList
+>({
+  settingsHostPath: `${URL_PREFIX}/api/${BFF_API_VERSION}/settings/skill_catalog`,
+  catalogHostPath: `${URL_PREFIX}/api/${BFF_API_VERSION}/model_catalog`,
+  catalogExtraQueryParams: { assetType: 'skills' },
+  useSettingsAPIState: useSkillCatalogSettingsAPIState,
+  useSourceConfigsList: useSkillCatalogSourceConfigs,
+});
+
+export type SkillCatalogSettingsContextType = {
+  apiState: SkillCatalogSettingsAPIState;
+  refreshAPIState: () => void;
+  skillCatalogSourceConfigs: SkillCatalogSourceConfigList | null;
+  skillCatalogSourceConfigsLoaded: boolean;
+  skillCatalogSourceConfigsLoadError?: Error;
+  refreshSkillCatalogSourceConfigs: () => void;
+  skillCatalogSources: CatalogSourceList | null;
+  skillCatalogSourcesLoaded: boolean;
+  skillCatalogSourcesLoadError?: Error;
+  refreshSkillCatalogSources: () => void;
+  /**
+   * True between saving a source and the catalog confirming it reloaded. The
+   * status column shows "Syncing" while this holds, because the status the
+   * catalog reports until then describes the previous sync, not the edit.
+   */
+  isSkillSourceSyncPending: (sourceId: string) => boolean;
+  /** Call after a successful create/update/toggle so the status column reflects it. */
+  markSkillSourceSyncPending: (sourceId: string) => void;
+};
+
+type SkillCatalogSettingsContextProviderProps = {
+  children: React.ReactNode;
+};
+
+export const SkillCatalogSettingsContext = React.createContext<SkillCatalogSettingsContextType>({
+  apiState: {
+    apiAvailable: false,
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    api: null as unknown as SkillCatalogSettingsAPIState['api'],
+  },
+  refreshAPIState: () => undefined,
+  skillCatalogSourceConfigs: null,
+  skillCatalogSourceConfigsLoaded: false,
+  skillCatalogSourceConfigsLoadError: undefined,
+  refreshSkillCatalogSourceConfigs: () => undefined,
+  skillCatalogSources: null,
+  skillCatalogSourcesLoaded: false,
+  skillCatalogSourcesLoadError: undefined,
+  refreshSkillCatalogSources: () => undefined,
+  isSkillSourceSyncPending: () => false,
+  markSkillSourceSyncPending: () => undefined,
+});
+
+export const SkillCatalogSettingsContextProvider: React.FC<
+  SkillCatalogSettingsContextProviderProps
+> = ({ children }) => {
+  const {
+    apiState,
+    refreshAPIState,
+    sourceConfigs: skillCatalogSourceConfigs,
+    sourceConfigsLoaded: skillCatalogSourceConfigsLoaded,
+    sourceConfigsLoadError: skillCatalogSourceConfigsLoadError,
+    refreshSourceConfigs: refreshSkillCatalogSourceConfigs,
+    catalogSources: skillCatalogSources,
+    catalogSourcesLoaded: skillCatalogSourcesLoaded,
+    catalogSourcesLoadError: skillCatalogSourcesLoadError,
+    refreshCatalogSources: refreshSkillCatalogSources,
+    isSyncPending: isSkillSourceSyncPending,
+    markSyncPending: markSkillSourceSyncPending,
+  } = useCatalogSettingsValue();
+
+  const contextValue = React.useMemo(
+    () => ({
+      apiState,
+      refreshAPIState,
+      skillCatalogSourceConfigs,
+      skillCatalogSourceConfigsLoaded,
+      skillCatalogSourceConfigsLoadError,
+      refreshSkillCatalogSourceConfigs,
+      skillCatalogSources,
+      skillCatalogSourcesLoaded,
+      skillCatalogSourcesLoadError,
+      refreshSkillCatalogSources,
+      isSkillSourceSyncPending,
+      markSkillSourceSyncPending,
+    }),
+    [
+      apiState,
+      refreshAPIState,
+      skillCatalogSourceConfigs,
+      skillCatalogSourceConfigsLoaded,
+      skillCatalogSourceConfigsLoadError,
+      refreshSkillCatalogSourceConfigs,
+      skillCatalogSources,
+      skillCatalogSourcesLoaded,
+      skillCatalogSourcesLoadError,
+      refreshSkillCatalogSources,
+      isSkillSourceSyncPending,
+      markSkillSourceSyncPending,
+    ],
+  );
+
+  return (
+    <SkillCatalogSettingsContext.Provider value={contextValue}>
+      {children}
+    </SkillCatalogSettingsContext.Provider>
+  );
+};

--- a/clients/ui/frontend/src/app/hooks/modelCatalog/useModelCatalogAPIState.tsx
+++ b/clients/ui/frontend/src/app/hooks/modelCatalog/useModelCatalogAPIState.tsx
@@ -2,6 +2,12 @@ import { APIState, useAPIState } from 'mod-arch-core';
 import React from 'react';
 import { getAgentFilterOptionList, getAgent, getAgentList } from '~/app/api/agentsCatalog/service';
 import {
+  getSkill,
+  getSkillFilterOptionList,
+  getSkillList,
+  getSkillMarketplace,
+} from '~/app/api/skillCatalog/service';
+import {
   getMcpServerFilterOptionList,
   getMcpServer,
   getMcpServerList,
@@ -40,6 +46,10 @@ const useModelCatalogAPIState = (
       getAgentList: getAgentList(path, queryParameters),
       getAgentFilterOptionList: getAgentFilterOptionList(path, queryParameters),
       getAgent: getAgent(path, queryParameters),
+      getSkillList: getSkillList(path, queryParameters),
+      getSkillFilterOptionList: getSkillFilterOptionList(path, queryParameters),
+      getSkill: getSkill(path, queryParameters),
+      getSkillMarketplace: getSkillMarketplace(path, queryParameters),
     }),
     [queryParameters],
   );

--- a/clients/ui/frontend/src/app/hooks/skillCatalog/useSkill.ts
+++ b/clients/ui/frontend/src/app/hooks/skillCatalog/useSkill.ts
@@ -1,0 +1,33 @@
+import { FetchState, FetchStateCallbackPromise, NotReadyError, useFetchState } from 'mod-arch-core';
+import React from 'react';
+import { Skill } from '~/app/skillCatalogTypes';
+import { SkillCatalogContext } from '~/app/context/skillCatalog/SkillCatalogContext';
+import type { ModelCatalogAPIState } from '~/app/hooks/modelCatalog/useModelCatalogAPIState';
+
+type State = Skill | null;
+
+export const useSkillWithAPI = (
+  apiState: ModelCatalogAPIState,
+  skillId: string,
+): FetchState<State> => {
+  const { api, apiAvailable } = apiState;
+
+  const call = React.useCallback<FetchStateCallbackPromise<State>>(
+    (opts) => {
+      if (!apiAvailable) {
+        return Promise.reject(new Error('API not yet available'));
+      }
+      if (!skillId) {
+        return Promise.reject(new NotReadyError('No skill id'));
+      }
+      return api.getSkill(opts, skillId);
+    },
+    [api, apiAvailable, skillId],
+  );
+  return useFetchState(call, null, { initialPromisePurity: true });
+};
+
+export const useSkill = (skillId: string): FetchState<State> => {
+  const { skillApiState } = React.useContext(SkillCatalogContext);
+  return useSkillWithAPI(skillApiState, skillId);
+};

--- a/clients/ui/frontend/src/app/hooks/skillCatalog/useSkillFilterOptionList.ts
+++ b/clients/ui/frontend/src/app/hooks/skillCatalog/useSkillFilterOptionList.ts
@@ -1,0 +1,59 @@
+import { FetchState, FetchStateCallbackPromise, useFetchState } from 'mod-arch-core';
+import * as React from 'react';
+import { CatalogFilterOptionsList } from '~/app/modelCatalogTypes';
+import type { ModelCatalogAPIState } from '~/app/hooks/modelCatalog/useModelCatalogAPIState';
+import {
+  BACKEND_TO_FRONTEND_SKILL_FILTER_KEY,
+  SKILL_FILTER_KEYS,
+} from '~/app/pages/skillCatalog/const';
+import type { CatalogFilterStringOption } from '~/app/shared/components/catalog';
+import type {
+  SkillCatalogFilterOptionsList,
+  SkillFilterCategoryKey,
+} from '~/app/pages/skillCatalog/types/skillCatalogFilterOptions';
+
+function isSkillFilterCategoryKey(s: string): s is SkillFilterCategoryKey {
+  return SKILL_FILTER_KEYS.some((k) => k === s);
+}
+
+function isFilterStringOption(v: unknown): v is CatalogFilterStringOption {
+  if (typeof v !== 'object' || v === null || !('type' in v)) {
+    return false;
+  }
+  const typeVal = Object.getOwnPropertyDescriptor(v, 'type')?.value;
+  return typeVal === 'string';
+}
+
+export function mapBackendFilterOptions(
+  raw: CatalogFilterOptionsList,
+): SkillCatalogFilterOptionsList {
+  if (!raw.filters) {
+    return { filters: undefined };
+  }
+  const mapped: SkillCatalogFilterOptionsList['filters'] = {};
+  for (const [key, value] of Object.entries(raw.filters)) {
+    const frontendKey = BACKEND_TO_FRONTEND_SKILL_FILTER_KEY[key] ?? key;
+    if (isSkillFilterCategoryKey(frontendKey) && isFilterStringOption(value)) {
+      mapped[frontendKey] = value;
+    }
+  }
+  return { filters: mapped };
+}
+
+type State = SkillCatalogFilterOptionsList | null;
+
+export const useSkillFilterOptionListWithAPI = (
+  apiState: ModelCatalogAPIState,
+): FetchState<State> => {
+  const { api, apiAvailable } = apiState;
+  const call = React.useCallback<FetchStateCallbackPromise<State>>(
+    (opts) => {
+      if (!apiAvailable) {
+        return Promise.reject(new Error('API not yet available'));
+      }
+      return api.getSkillFilterOptionList(opts).then(mapBackendFilterOptions);
+    },
+    [api, apiAvailable],
+  );
+  return useFetchState(call, null, { initialPromisePurity: true });
+};

--- a/clients/ui/frontend/src/app/hooks/skillCatalog/useSkillMarketplace.ts
+++ b/clients/ui/frontend/src/app/hooks/skillCatalog/useSkillMarketplace.ts
@@ -1,0 +1,27 @@
+import { FetchState, FetchStateCallbackPromise, useFetchState } from 'mod-arch-core';
+import React from 'react';
+import { SkillMarketplaceResult } from '~/app/skillCatalogTypes';
+import { SkillCatalogContext } from '~/app/context/skillCatalog/SkillCatalogContext';
+import type { ModelCatalogAPIState } from '~/app/hooks/modelCatalog/useModelCatalogAPIState';
+
+type State = SkillMarketplaceResult | null;
+
+export const useSkillMarketplaceWithAPI = (apiState: ModelCatalogAPIState): FetchState<State> => {
+  const { api, apiAvailable } = apiState;
+
+  const call = React.useCallback<FetchStateCallbackPromise<State>>(
+    (opts) => {
+      if (!apiAvailable) {
+        return Promise.reject(new Error('API not yet available'));
+      }
+      return api.getSkillMarketplace(opts);
+    },
+    [api, apiAvailable],
+  );
+  return useFetchState(call, null, { initialPromisePurity: true });
+};
+
+export const useSkillMarketplace = (): FetchState<State> => {
+  const { skillApiState } = React.useContext(SkillCatalogContext);
+  return useSkillMarketplaceWithAPI(skillApiState);
+};

--- a/clients/ui/frontend/src/app/hooks/skillCatalog/useSkillsBySourceLabel.ts
+++ b/clients/ui/frontend/src/app/hooks/skillCatalog/useSkillsBySourceLabel.ts
@@ -1,0 +1,151 @@
+import React from 'react';
+import { FetchStateCallbackPromise, useFetchState } from 'mod-arch-core';
+import { Skill, SkillList, SkillListParams } from '~/app/skillCatalogTypes';
+import { SkillCatalogContext } from '~/app/context/skillCatalog/SkillCatalogContext';
+import type { ModelCatalogAPIState } from '~/app/hooks/modelCatalog/useModelCatalogAPIState';
+
+type PaginatedSkillList = {
+  items: Skill[];
+  size: number;
+  pageSize: number;
+  nextPageToken: string;
+  loadMore: () => void;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  refresh: () => void;
+  loadMoreError?: Error;
+};
+
+export type SkillsResult = {
+  skills: PaginatedSkillList;
+  skillsLoaded: boolean;
+  skillsLoadError: Error | undefined;
+  refresh: () => void;
+};
+
+type UseSkillsBySourceLabelParams = {
+  sourceLabel?: string;
+  pageSize?: number;
+  searchQuery?: string;
+  filterQuery?: string;
+};
+
+export function useSkillsBySourceLabelWithAPI(
+  apiState: ModelCatalogAPIState,
+  params: UseSkillsBySourceLabelParams,
+): SkillsResult {
+  const { sourceLabel, pageSize = 10, searchQuery = '', filterQuery } = params;
+  const { api, apiAvailable } = apiState;
+
+  const [allItems, setAllItems] = React.useState<Skill[]>([]);
+  const [totalSize, setTotalSize] = React.useState(0);
+  const [nextPageTokenValue, setNextPageTokenValue] = React.useState('');
+  const [isLoadingMore, setIsLoadingMore] = React.useState(false);
+  const [loadMoreError, setLoadMoreError] = React.useState<Error | undefined>();
+
+  const buildSkillListParams = React.useCallback(
+    (nextPageToken?: string): SkillListParams => ({
+      sourceLabel,
+      pageSize: pageSize.toString(),
+      ...(nextPageToken !== undefined && nextPageToken !== '' && { nextPageToken }),
+      q: searchQuery.trim() || undefined,
+      filterQuery,
+    }),
+    [sourceLabel, pageSize, searchQuery, filterQuery],
+  );
+
+  const fetchSkills = React.useCallback<FetchStateCallbackPromise<SkillList>>(
+    (opts) => {
+      if (!apiAvailable) {
+        return Promise.reject(new Error('API not yet available'));
+      }
+      return api.getSkillList(opts, buildSkillListParams());
+    },
+    [api, apiAvailable, buildSkillListParams],
+  );
+
+  const [firstPageData, loaded, error, refetch] = useFetchState(
+    fetchSkills,
+    { items: [], size: 0, pageSize: 10, nextPageToken: '' },
+    { initialPromisePurity: true },
+  );
+
+  React.useEffect(() => {
+    if (loaded && !error) {
+      setAllItems(firstPageData.items ?? []);
+      setTotalSize(firstPageData.size);
+      setNextPageTokenValue(firstPageData.nextPageToken);
+    }
+  }, [firstPageData, loaded, error]);
+
+  const loadMore = React.useCallback(async () => {
+    if (!nextPageTokenValue || isLoadingMore || !apiAvailable) {
+      return;
+    }
+    setIsLoadingMore(true);
+    setLoadMoreError(undefined);
+    try {
+      const response = await api.getSkillList({}, buildSkillListParams(nextPageTokenValue));
+      setAllItems((prev) => [...prev, ...(response.items ?? [])]);
+      setTotalSize(response.size);
+      setNextPageTokenValue(response.nextPageToken);
+    } catch (err) {
+      setLoadMoreError(
+        new Error(
+          `Failed to load more skills: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [api, apiAvailable, buildSkillListParams, isLoadingMore, nextPageTokenValue]);
+
+  React.useEffect(() => {
+    setAllItems([]);
+    setTotalSize(0);
+    setNextPageTokenValue('');
+    setIsLoadingMore(false);
+    setLoadMoreError(undefined);
+  }, [sourceLabel, pageSize, searchQuery, filterQuery]);
+
+  const refresh = React.useCallback(() => {
+    setAllItems([]);
+    setTotalSize(0);
+    setNextPageTokenValue('');
+    setIsLoadingMore(false);
+    setLoadMoreError(undefined);
+    refetch();
+  }, [refetch]);
+
+  return {
+    skills: {
+      items: allItems,
+      size: totalSize,
+      pageSize: firstPageData.pageSize,
+      nextPageToken: nextPageTokenValue,
+      loadMore,
+      isLoadingMore,
+      hasMore: Boolean(nextPageTokenValue),
+      refresh,
+      loadMoreError,
+    },
+    skillsLoaded: loaded,
+    skillsLoadError: error,
+    refresh,
+  };
+}
+
+export const useSkillsBySourceLabel = (
+  sourceLabel?: string,
+  pageSize = 10,
+  searchQuery = '',
+  filterQuery?: string,
+): SkillsResult => {
+  const { skillApiState } = React.useContext(SkillCatalogContext);
+  return useSkillsBySourceLabelWithAPI(skillApiState, {
+    sourceLabel,
+    pageSize,
+    searchQuery,
+    filterQuery,
+  });
+};

--- a/clients/ui/frontend/src/app/hooks/skillCatalogSettings/useSkillCatalogSettingsAPI.ts
+++ b/clients/ui/frontend/src/app/hooks/skillCatalogSettings/useSkillCatalogSettingsAPI.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+import { SkillCatalogSettingsContext } from '~/app/context/skillCatalogSettings/SkillCatalogSettingsContext';
+import { SkillCatalogSettingsAPIState } from './useSkillCatalogSettingsAPIState';
+
+type UseSkillCatalogSettingsAPI = SkillCatalogSettingsAPIState & {
+  refreshAllAPI: () => void;
+};
+
+export const useSkillCatalogSettingsAPI = (): UseSkillCatalogSettingsAPI => {
+  const { apiState, refreshAPIState: refreshAllAPI } = React.useContext(
+    SkillCatalogSettingsContext,
+  );
+
+  return {
+    refreshAllAPI,
+    ...apiState,
+  };
+};

--- a/clients/ui/frontend/src/app/hooks/skillCatalogSettings/useSkillCatalogSettingsAPIState.ts
+++ b/clients/ui/frontend/src/app/hooks/skillCatalogSettings/useSkillCatalogSettingsAPIState.ts
@@ -1,0 +1,38 @@
+import { APIState, useAPIState } from 'mod-arch-core';
+import React from 'react';
+import {
+  createSkillCatalogSourceConfig,
+  deleteSkillCatalogSourceConfig,
+  getSkillCatalogSourceConfig,
+  getSkillCatalogSourceConfigs,
+  updateSkillCatalogSourceConfig,
+  previewSkillCatalogSource,
+} from '~/app/api/skillCatalogSettings/service';
+import { SkillCatalogSettingsAPIs } from '~/app/skillCatalogTypes';
+
+export type SkillCatalogSettingsAPIState = APIState<SkillCatalogSettingsAPIs>;
+
+const useSkillCatalogSettingsAPIState = (
+  hostPath: string | null,
+  queryParameters?: Record<string, unknown>,
+  previewHostPath?: string | null,
+): [apiState: SkillCatalogSettingsAPIState, refreshAPIState: () => void] => {
+  const createAPI = React.useCallback(
+    (path: string) => ({
+      getSkillCatalogSourceConfigs: getSkillCatalogSourceConfigs(path, queryParameters),
+      createSkillCatalogSourceConfig: createSkillCatalogSourceConfig(path, queryParameters),
+      getSkillCatalogSourceConfig: getSkillCatalogSourceConfig(path, queryParameters),
+      updateSkillCatalogSourceConfig: updateSkillCatalogSourceConfig(path, queryParameters),
+      deleteSkillCatalogSourceConfig: deleteSkillCatalogSourceConfig(path, queryParameters),
+      previewSkillCatalogSource: previewSkillCatalogSource(
+        previewHostPath || path,
+        queryParameters,
+      ),
+    }),
+    [queryParameters, previewHostPath],
+  );
+
+  return useAPIState(hostPath, createAPI);
+};
+
+export default useSkillCatalogSettingsAPIState;

--- a/clients/ui/frontend/src/app/hooks/skillCatalogSettings/useSkillCatalogSourceConfigBySourceId.ts
+++ b/clients/ui/frontend/src/app/hooks/skillCatalogSettings/useSkillCatalogSourceConfigBySourceId.ts
@@ -1,0 +1,16 @@
+import { FetchState } from 'mod-arch-core';
+import * as React from 'react';
+import { SkillCatalogSourceConfig } from '~/app/skillCatalogTypes';
+import { SkillCatalogSettingsContext } from '~/app/context/skillCatalogSettings/SkillCatalogSettingsContext';
+import { useSourceConfigById } from '~/app/shared/catalogSettings/hooks/useSourceConfigById';
+
+export const useSkillCatalogSourceConfigBySourceId = (
+  sourceId: string,
+): FetchState<SkillCatalogSourceConfig | null> => {
+  const { apiState } = React.useContext(SkillCatalogSettingsContext);
+  return useSourceConfigById(
+    apiState.apiAvailable,
+    apiState.api.getSkillCatalogSourceConfig,
+    sourceId,
+  );
+};

--- a/clients/ui/frontend/src/app/hooks/skillCatalogSettings/useSkillCatalogSourceConfigs.ts
+++ b/clients/ui/frontend/src/app/hooks/skillCatalogSettings/useSkillCatalogSourceConfigs.ts
@@ -1,0 +1,11 @@
+import { FetchState } from 'mod-arch-core';
+import { SkillCatalogSourceConfigList } from '~/app/skillCatalogTypes';
+import { useSourceConfigs } from '~/app/shared/catalogSettings/hooks/useSourceConfigs';
+import { SkillCatalogSettingsAPIState } from './useSkillCatalogSettingsAPIState';
+
+export const useSkillCatalogSourceConfigs = (
+  apiState: SkillCatalogSettingsAPIState,
+): FetchState<SkillCatalogSourceConfigList> =>
+  useSourceConfigs(apiState.apiAvailable, apiState.api.getSkillCatalogSourceConfigs, {
+    catalogs: [],
+  });

--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -35,6 +35,7 @@ import {
   McpToolList,
 } from './mcpServerCatalogTypes';
 import type { AgentCatalogSpecificAPIs } from './agentsCatalogTypes';
+import type { SkillCatalogSpecificAPIs } from './skillCatalogTypes';
 
 export type HardwareConfiguration = {
   gpu_type: string;
@@ -304,7 +305,8 @@ export type McpCatalogSpecificAPIs = {
 export type ModelCatalogAPIs = CatalogBaseAPIs &
   ModelCatalogSpecificAPIs &
   McpCatalogSpecificAPIs &
-  AgentCatalogSpecificAPIs;
+  AgentCatalogSpecificAPIs &
+  SkillCatalogSpecificAPIs;
 
 export type CatalogModelDetailsParams = {
   sourceId?: string;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/SkillCatalogCoreLoader.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/SkillCatalogCoreLoader.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { Alert, Bullseye } from '@patternfly/react-core';
+import {
+  ApplicationsPage,
+  KubeflowDocs,
+  ProjectObjectType,
+  TitleWithIcon,
+  typedEmptyImage,
+  WhosMyAdministrator,
+} from 'mod-arch-shared';
+import { useThemeContext } from 'mod-arch-kubeflow';
+import { Outlet } from 'react-router-dom';
+import { SkillCatalogContext } from '~/app/context/skillCatalog/SkillCatalogContext';
+import { EmptyCatalogState, hasSourcesWithModels } from '~/app/shared/components/catalog';
+import { SKILL_CATALOG_TITLE, SKILL_CATALOG_DESCRIPTION } from '~/app/pages/skillCatalog/const';
+
+const SkillCatalogCoreLoader: React.FC = () => {
+  const { catalogSources, catalogSourcesLoaded, catalogSourcesLoadError } =
+    React.useContext(SkillCatalogContext);
+  const { isMUITheme } = useThemeContext();
+
+  if (catalogSourcesLoadError) {
+    return (
+      <ApplicationsPage
+        title={
+          <TitleWithIcon title={SKILL_CATALOG_TITLE} objectType={ProjectObjectType.mcpCatalog} />
+        }
+        description={SKILL_CATALOG_DESCRIPTION}
+        headerContent={null}
+        empty
+        emptyStatePage={
+          <Bullseye>
+            <Alert title="Skill catalog source load error" variant="danger" isInline>
+              {catalogSourcesLoadError.message}
+            </Alert>
+          </Bullseye>
+        }
+        loaded
+      />
+    );
+  }
+
+  if (!catalogSourcesLoaded) {
+    return (
+      <ApplicationsPage
+        title={
+          <TitleWithIcon title={SKILL_CATALOG_TITLE} objectType={ProjectObjectType.mcpCatalog} />
+        }
+        description={SKILL_CATALOG_DESCRIPTION}
+        headerContent={null}
+        empty
+        emptyStatePage={<Bullseye>Loading catalog sources...</Bullseye>}
+        loaded={false}
+      />
+    );
+  }
+
+  if (catalogSources?.items?.length === 0 || !hasSourcesWithModels(catalogSources)) {
+    return (
+      <ApplicationsPage
+        title={
+          <TitleWithIcon title={SKILL_CATALOG_TITLE} objectType={ProjectObjectType.mcpCatalog} />
+        }
+        description={SKILL_CATALOG_DESCRIPTION}
+        empty
+        emptyStatePage={
+          <EmptyCatalogState
+            testid="empty-skill-catalog-state"
+            title="Skill catalog configuration required"
+            description={
+              isMUITheme
+                ? 'To discover skills, follow the instructions in the docs below.'
+                : 'There are no skill sources to display. Request that your administrator configure skill sources for the catalog.'
+            }
+            headerIcon={() => (
+              <img src={typedEmptyImage(ProjectObjectType.modelRegistrySettings)} alt="" />
+            )}
+            primaryAction={isMUITheme ? <KubeflowDocs /> : <WhosMyAdministrator />}
+          />
+        }
+        headerContent={null}
+        loaded
+        provideChildrenPadding
+      />
+    );
+  }
+
+  return <Outlet />;
+};
+
+export default SkillCatalogCoreLoader;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/SkillCatalogRoutes.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/SkillCatalogRoutes.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { SkillCatalogContextProvider } from '~/app/context/skillCatalog/SkillCatalogContext';
+import SkillCatalogCoreLoader from './SkillCatalogCoreLoader';
+import SkillCatalog from './screens/SkillCatalog';
+import SkillDetailsPage from './screens/SkillDetailsPage';
+
+const SkillCatalogRoutes: React.FC = () => (
+  <SkillCatalogContextProvider>
+    <Routes>
+      <Route path="/*" element={<SkillCatalogCoreLoader />}>
+        <Route index element={<SkillCatalog />} />
+        <Route path=":skillId" element={<SkillDetailsPage />} />
+        <Route path="*" element={<Navigate to="." />} />
+      </Route>
+    </Routes>
+  </SkillCatalogContextProvider>
+);
+
+export default SkillCatalogRoutes;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillCatalogCard.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillCatalogCard.tsx
@@ -1,0 +1,173 @@
+import * as React from 'react';
+import {
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Flex,
+  FlexItem,
+  Label,
+  LabelGroup,
+} from '@patternfly/react-core';
+import { CubeIcon, PluggedIcon } from '@patternfly/react-icons';
+import { Link, type LinkProps } from 'react-router-dom';
+import type { Skill } from '~/app/skillCatalogTypes';
+import { skillDetailsUrl } from '~/app/routes/skillCatalog/skillCatalog';
+import { formatSkillVersion } from '~/app/pages/skillCatalog/utils/skillCatalogUtils';
+import { SKILL_TRUST_TIER_LABEL_MAPPING } from '~/app/pages/skillCatalog/const';
+import SkillInstallModal from '~/app/pages/skillCatalog/components/SkillInstallModal';
+
+type SkillCatalogCardProps = {
+  skill: Skill;
+};
+
+const SkillCatalogCard: React.FC<SkillCatalogCardProps> = React.memo(({ skill }) => {
+  const [isInstallModalOpen, setIsInstallModalOpen] = React.useState(false);
+  const skillName = skill.displayName || skill.name;
+
+  return (
+    <Card isFullHeight data-testid={`skill-catalog-card-${skill.id}`}>
+      <CardHeader>
+        <Flex
+          alignItems={{ default: 'alignItemsFlexStart' }}
+          justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          gap={{ default: 'gapXs' }}
+          className="pf-v6-u-mb-md"
+        >
+          <FlexItem>
+            <span
+              className="pf-v6-u-display-inline-block pf-v6-u-font-size-2xl pf-v6-u-color-200"
+              aria-hidden
+              data-testid={`skill-catalog-card-icon-${skill.id}`}
+            >
+              <CubeIcon />
+            </span>
+          </FlexItem>
+          <FlexItem>
+            <Label
+              color={skill.trustTier ? 'green' : 'grey'}
+              data-testid={`skill-catalog-card-trust-tier-${skill.id}`}
+            >
+              {skill.trustTier
+                ? (SKILL_TRUST_TIER_LABEL_MAPPING[skill.trustTier] ?? skill.trustTier)
+                : 'Unrated'}
+            </Label>
+          </FlexItem>
+        </Flex>
+        <CardTitle>
+          <Button
+            data-testid={`skill-catalog-card-detail-link-${skill.id}`}
+            variant="link"
+            isInline
+            component={(props: LinkProps) => <Link {...props} to={skillDetailsUrl(skill.id)} />}
+            style={{
+              fontSize: 'var(--pf-t--global--font--size--body--default)',
+              fontWeight: 'var(--pf-t--global--font--weight--body--bold)',
+            }}
+          >
+            <span
+              style={{
+                display: 'block',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+              data-testid={`skill-catalog-card-name-${skill.id}`}
+            >
+              {skillName}
+            </span>
+          </Button>
+        </CardTitle>
+        {(skill.provider || skill.version) && (
+          <div
+            className="pf-v6-u-mt-xs pf-v6-u-font-size-sm pf-v6-u-color-200"
+            style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {skill.provider && (
+              <span data-testid={`skill-catalog-card-provider-${skill.id}`}>{skill.provider}</span>
+            )}
+            {skill.provider && skill.version && <span aria-hidden> &middot; </span>}
+            {/* Each ref a repository lists becomes its own catalog entry, so several tiles
+                can share a name and description. The version is what tells them apart. */}
+            {skill.version && (
+              // title carries the full ref, so an abbreviated SHA stays recoverable.
+              <span title={skill.version} data-testid={`skill-catalog-card-version-${skill.id}`}>
+                {formatSkillVersion(skill.version)}
+              </span>
+            )}
+          </div>
+        )}
+      </CardHeader>
+      <CardBody>
+        <span
+          style={{
+            display: '-webkit-box',
+            WebkitBoxOrient: 'vertical',
+            WebkitLineClamp: 4,
+            overflow: 'hidden',
+            overflowWrap: 'anywhere',
+          }}
+          data-testid={`skill-catalog-card-description-${skill.id}`}
+        >
+          {skill.description ?? ''}
+        </span>
+        {skill.labels && skill.labels.length > 0 && (
+          <LabelGroup className="pf-v6-u-mt-md" numLabels={3}>
+            {skill.labels.map((label) => (
+              <Label key={label} variant="outline" data-testid={`skill-label-${label}`}>
+                {label}
+              </Label>
+            ))}
+          </LabelGroup>
+        )}
+      </CardBody>
+      <CardFooter>
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          flexWrap={{ default: 'nowrap' }}
+        >
+          <FlexItem style={{ minWidth: 0 }}>
+            <Label
+              color="blue"
+              data-testid={`skill-catalog-card-footer-name-${skill.id}`}
+              style={{ fontFamily: 'monospace', maxWidth: '100%' }}
+            >
+              <span
+                style={{
+                  display: 'block',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                /{skill.name}
+              </span>
+            </Label>
+          </FlexItem>
+          <FlexItem>
+            <Button
+              variant="plain"
+              aria-label={`Install ${skillName}`}
+              icon={<PluggedIcon />}
+              onClick={() => setIsInstallModalOpen(true)}
+              data-testid={`skill-catalog-card-install-button-${skill.id}`}
+            />
+          </FlexItem>
+        </Flex>
+      </CardFooter>
+      {isInstallModalOpen && (
+        <SkillInstallModal
+          skill={skill}
+          isOpen={isInstallModalOpen}
+          onClose={() => setIsInstallModalOpen(false)}
+        />
+      )}
+    </Card>
+  );
+});
+SkillCatalogCard.displayName = 'SkillCatalogCard';
+
+export default SkillCatalogCard;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillCatalogFilters.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillCatalogFilters.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { SkillCatalogContext } from '~/app/context/skillCatalog/SkillCatalogContext';
+import { CatalogFilterPanel, useCatalogFilterConfigs } from '~/app/shared/components/catalog';
+import {
+  SKILL_FILTER_KEYS,
+  SKILL_FILTER_CATEGORY_NAMES,
+  SKILL_LABEL_MAPPINGS,
+} from '~/app/pages/skillCatalog/const';
+
+const SkillCatalogFilters: React.FC = () => {
+  const { filters, setFilters, filterOptions, filterOptionsLoaded, filterOptionsLoadError } =
+    React.useContext(SkillCatalogContext);
+
+  const onFilterChange = React.useCallback(
+    (key: string, values: string[]) => {
+      setFilters((prev) => ({ ...prev, [key]: values }));
+    },
+    [setFilters],
+  );
+
+  const filterPanelItems = useCatalogFilterConfigs({
+    filterKeys: SKILL_FILTER_KEYS,
+    filterNames: SKILL_FILTER_CATEGORY_NAMES,
+    filterOptions: filterOptions?.filters,
+    selectedFilters: filters,
+    onFilterChange,
+    labelMappings: SKILL_LABEL_MAPPINGS,
+  });
+
+  return (
+    <CatalogFilterPanel
+      loaded={filterOptionsLoaded}
+      loadError={filterOptionsLoadError}
+      filters={filterPanelItems}
+      testIdPrefix="skill-filter"
+    />
+  );
+};
+
+export default SkillCatalogFilters;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillClaudeCodeInstallCommand.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillClaudeCodeInstallCommand.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { Alert, HelperText, HelperTextItem, Skeleton } from '@patternfly/react-core';
+import type { Skill } from '~/app/skillCatalogTypes';
+import { useSkillMarketplace } from '~/app/hooks/skillCatalog/useSkillMarketplace';
+import SkillInstallCodeBlock from '~/app/pages/skillCatalog/components/SkillInstallCodeBlock';
+
+type SkillClaudeCodeInstallCommandProps = {
+  skill: Skill;
+  idPrefix: string;
+};
+
+const SkillClaudeCodeInstallCommand: React.FC<SkillClaudeCodeInstallCommandProps> = ({
+  skill,
+  idPrefix,
+}) => {
+  const [marketplaceResult, marketplaceLoaded, marketplaceLoadError] = useSkillMarketplace();
+  const marketplace = marketplaceResult?.marketplace;
+
+  if (!marketplaceLoaded) {
+    return (
+      <Skeleton
+        width="100%"
+        height="80px"
+        data-testid={`${idPrefix}-claude-code-loading-${skill.id}`}
+      />
+    );
+  }
+
+  const plugin = marketplace?.plugins?.find(
+    (p) =>
+      p.source.url === skill.repository &&
+      p.source.path === skill.path &&
+      (!skill.version || p.source.ref === skill.version),
+  );
+
+  if (marketplaceLoadError || !marketplace || !plugin) {
+    return (
+      <Alert
+        variant="warning"
+        isInline
+        title="Install command unavailable"
+        data-testid={`${idPrefix}-claude-code-unavailable-${skill.id}`}
+      >
+        The catalog marketplace endpoint did not return this skill. Try the npx or Manual commands
+        instead.
+      </Alert>
+    );
+  }
+
+  const claudeCodeCommand = [
+    `/plugin marketplace add ${marketplaceResult.marketplaceUrl}`,
+    `/plugin install ${plugin.name}@${marketplace.name}`,
+  ].join('\n');
+
+  return (
+    <>
+      <SkillInstallCodeBlock
+        id={`${idPrefix}-claude-code-${skill.id}`}
+        content={claudeCodeCommand}
+      />
+      {!marketplaceResult.external && (
+        <HelperText className="pf-v6-u-mt-sm">
+          <HelperTextItem data-testid={`${idPrefix}-claude-code-in-cluster-note-${skill.id}`}>
+            This marketplace URL resolves inside the cluster, so it works for agents running there.
+            To use it from outside, expose the catalog through a Route or Ingress and set the
+            SKILL_CATALOG_MARKETPLACE_URL override on the UI backend.
+          </HelperTextItem>
+        </HelperText>
+      )}
+    </>
+  );
+};
+
+export default SkillClaudeCodeInstallCommand;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillFileTree.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillFileTree.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import {
+  AngleDownIcon,
+  AngleRightIcon,
+  FileIcon,
+  FolderIcon,
+  FolderOpenIcon,
+} from '@patternfly/react-icons';
+import type { FileTreeNode } from '~/app/pages/skillCatalog/utils/skillSupportingFilesTree';
+
+const ROW_HEIGHT = '22px';
+const INDENT_PER_DEPTH = 14;
+
+type SkillFileTreeRowProps = {
+  node: FileTreeNode;
+  depth: number;
+};
+
+const SkillFileTreeRow: React.FC<SkillFileTreeRowProps> = ({ node, depth }) => {
+  const [isExpanded, setIsExpanded] = React.useState(true);
+  const hasChildren = !!node.children && node.children.length > 0;
+  const isClickable = hasChildren || !!node.url;
+
+  return (
+    <>
+      <div
+        role={isClickable ? 'button' : undefined}
+        tabIndex={isClickable ? 0 : undefined}
+        data-testid={`skill-file-tree-row-${node.id}`}
+        onClick={() => {
+          if (hasChildren) {
+            setIsExpanded((prev) => !prev);
+          } else if (node.url) {
+            window.open(node.url, '_blank', 'noopener,noreferrer');
+          }
+        }}
+        onKeyDown={(event) => {
+          if (event.key !== 'Enter' && event.key !== ' ') {
+            return;
+          }
+          event.preventDefault();
+          if (hasChildren) {
+            setIsExpanded((prev) => !prev);
+          } else if (node.url) {
+            window.open(node.url, '_blank', 'noopener,noreferrer');
+          }
+        }}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          height: ROW_HEIGHT,
+          paddingLeft: `${depth * INDENT_PER_DEPTH}px`,
+          fontSize: '13px',
+          cursor: isClickable ? 'pointer' : 'default',
+        }}
+      >
+        <span
+          style={{
+            display: 'inline-flex',
+            width: '12px',
+            marginRight: '2px',
+            fontSize: '10px',
+            flexShrink: 0,
+          }}
+        >
+          {hasChildren && (isExpanded ? <AngleDownIcon /> : <AngleRightIcon />)}
+        </span>
+        <span
+          style={{ display: 'inline-flex', marginRight: '4px', fontSize: '12px', flexShrink: 0 }}
+        >
+          {hasChildren ? (
+            isExpanded ? (
+              <FolderOpenIcon color="var(--pf-t--global--icon--color--regular)" />
+            ) : (
+              <FolderIcon color="var(--pf-t--global--icon--color--regular)" />
+            )
+          ) : (
+            <FileIcon color="var(--pf-t--global--icon--color--subtle)" />
+          )}
+        </span>
+        <span
+          style={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            color: node.url ? 'var(--pf-t--global--text--color--link--default)' : undefined,
+          }}
+        >
+          {node.name}
+        </span>
+      </div>
+      {hasChildren &&
+        isExpanded &&
+        node.children?.map((child) => (
+          <SkillFileTreeRow key={child.id} node={child} depth={depth + 1} />
+        ))}
+    </>
+  );
+};
+
+type SkillFileTreeProps = {
+  root: FileTreeNode;
+};
+
+const SkillFileTree: React.FC<SkillFileTreeProps> = ({ root }) => (
+  <div data-testid="skill-file-tree">
+    <SkillFileTreeRow node={root} depth={0} />
+  </div>
+);
+
+export default SkillFileTree;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillInstallCodeBlock.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillInstallCodeBlock.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { ClipboardCopyButton, CodeBlock, CodeBlockCode } from '@patternfly/react-core';
+
+type SkillInstallCodeBlockProps = {
+  id: string;
+  content: string;
+};
+
+const SkillInstallCodeBlock: React.FC<SkillInstallCodeBlockProps> = ({ id, content }) => {
+  const [copied, setCopied] = React.useState(false);
+
+  return (
+    <div style={{ position: 'relative' }} data-testid={`${id}-code-block`}>
+      <CodeBlock>
+        <CodeBlockCode id={id} style={{ paddingRight: '2.5rem' }}>
+          {content}
+        </CodeBlockCode>
+      </CodeBlock>
+      <ClipboardCopyButton
+        id={`${id}-copy-button`}
+        textId={id}
+        aria-label="Copy to clipboard"
+        onClick={() => {
+          navigator.clipboard.writeText(content).catch(() => undefined);
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1200);
+        }}
+        exitDelay={600}
+        variant="plain"
+        style={{ position: 'absolute', top: '0.25rem', right: '0.25rem' }}
+        data-testid={`${id}-copy-button`}
+      >
+        {copied ? 'Copied' : 'Copy to clipboard'}
+      </ClipboardCopyButton>
+    </div>
+  );
+};
+
+export default SkillInstallCodeBlock;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillInstallModal.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillInstallModal.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import {
+  Flex,
+  FlexItem,
+  Label,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
+import type { Skill } from '~/app/skillCatalogTypes';
+import { SKILL_TRUST_TIER_LABEL_MAPPING } from '~/app/pages/skillCatalog/const';
+import SkillInstallTabs from '~/app/pages/skillCatalog/components/SkillInstallTabs';
+
+type SkillInstallModalProps = {
+  skill: Skill;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const SkillInstallModal: React.FC<SkillInstallModalProps> = ({ skill, isOpen, onClose }) => {
+  const skillName = skill.displayName || skill.name;
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      isOpen={isOpen}
+      onClose={onClose}
+      data-testid={`skill-install-modal-${skill.id}`}
+    >
+      <ModalHeader
+        title={`Install ${skillName}`}
+        data-testid={`skill-install-modal-title-${skill.id}`}
+      />
+      <ModalBody>
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          spaceItems={{ default: 'spaceItemsSm' }}
+          className="pf-v6-u-mb-sm"
+        >
+          {skill.version && (
+            <FlexItem>
+              <strong>Latest version:</strong> {skill.version}
+            </FlexItem>
+          )}
+          {skill.trustTier && (
+            <FlexItem>
+              <Label color="green" data-testid={`skill-install-modal-trust-tier-${skill.id}`}>
+                {SKILL_TRUST_TIER_LABEL_MAPPING[skill.trustTier] ?? skill.trustTier}
+              </Label>
+            </FlexItem>
+          )}
+        </Flex>
+        <SkillInstallTabs skill={skill} idPrefix="skill-install-modal" />
+      </ModalBody>
+    </Modal>
+  );
+};
+
+export default SkillInstallModal;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillInstallTabs.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/components/SkillInstallTabs.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
+import type { Skill } from '~/app/skillCatalogTypes';
+import {
+  buildManualCommand,
+  buildNpxCommand,
+} from '~/app/pages/skillCatalog/utils/skillInstallCommands';
+import SkillInstallCodeBlock from '~/app/pages/skillCatalog/components/SkillInstallCodeBlock';
+import SkillClaudeCodeInstallCommand from '~/app/pages/skillCatalog/components/SkillClaudeCodeInstallCommand';
+
+type SkillInstallTabsProps = {
+  skill: Skill;
+  /** Prefixes every DOM/test id so two instances (e.g. the tile modal and the
+   *  details page's inline card) can be mounted on the same page without collisions. */
+  idPrefix: string;
+};
+
+enum InstallTab {
+  NPX = 'npx',
+  CLAUDE_CODE = 'claude-code',
+  MANUAL = 'manual',
+}
+
+const SkillInstallTabs: React.FC<SkillInstallTabsProps> = ({ skill, idPrefix }) => {
+  const [activeTab, setActiveTab] = React.useState<InstallTab>(InstallTab.NPX);
+
+  return (
+    <Tabs
+      activeKey={activeTab}
+      onSelect={(_event, key) => {
+        const validTab = Object.values(InstallTab).find((t) => t === key);
+        if (validTab) {
+          setActiveTab(validTab);
+        }
+      }}
+      mountOnEnter
+      aria-label="Skill install options"
+      data-testid={`${idPrefix}-tabs-${skill.id}`}
+    >
+      <Tab
+        eventKey={InstallTab.NPX}
+        title={<TabTitleText>npx</TabTitleText>}
+        data-testid={`${idPrefix}-tab-npx`}
+      >
+        <SkillInstallCodeBlock
+          id={`${idPrefix}-npx-${skill.id}`}
+          content={buildNpxCommand(skill)}
+        />
+      </Tab>
+      <Tab
+        eventKey={InstallTab.CLAUDE_CODE}
+        title={<TabTitleText>Claude Code</TabTitleText>}
+        data-testid={`${idPrefix}-tab-claude-code`}
+      >
+        <SkillClaudeCodeInstallCommand skill={skill} idPrefix={idPrefix} />
+      </Tab>
+      <Tab
+        eventKey={InstallTab.MANUAL}
+        title={<TabTitleText>Manual</TabTitleText>}
+        data-testid={`${idPrefix}-tab-manual`}
+      >
+        <SkillInstallCodeBlock
+          id={`${idPrefix}-manual-${skill.id}`}
+          content={buildManualCommand(skill)}
+        />
+      </Tab>
+    </Tabs>
+  );
+};
+
+export default SkillInstallTabs;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/components/__tests__/SkillCatalogCard.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/components/__tests__/SkillCatalogCard.spec.tsx
@@ -1,0 +1,117 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SkillCatalogCard from '~/app/pages/skillCatalog/components/SkillCatalogCard';
+import type { Skill } from '~/app/skillCatalogTypes';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>{children}</MemoryRouter>
+);
+
+const mockSkill: Skill = {
+  id: '1',
+  name: 'diagnosing-bugs',
+  displayName: 'Diagnosing Bugs',
+  description: 'Test description for the skill.',
+  sourceId: 'matt-pocock-skills',
+  repository: 'https://github.com/mattpocock/skills.git',
+  path: 'skills/engineering/diagnosing-bugs',
+  version: 'v1.2.3',
+  labels: ['popular', 'debugging'],
+  trustTier: 'communityContributed',
+};
+
+describe('SkillCatalogCard', () => {
+  it('abbreviates a full commit SHA version but keeps the full ref in the title', () => {
+    const sha = '9f8c1a2b3d4e5f60718293a4b5c6d7e8f9012345';
+    render(<SkillCatalogCard skill={{ ...mockSkill, version: sha }} />, { wrapper });
+
+    const version = screen.getByTestId('skill-catalog-card-version-1');
+    expect(version).toHaveTextContent('9f8c1a2');
+    expect(version).toHaveAttribute('title', sha);
+  });
+
+  it('renders provider and version under the name', () => {
+    render(<SkillCatalogCard skill={{ ...mockSkill, provider: 'Matt Pocock' }} />, { wrapper });
+    expect(screen.getByTestId('skill-catalog-card-provider-1')).toHaveTextContent('Matt Pocock');
+    expect(screen.getByTestId('skill-catalog-card-version-1')).toHaveTextContent('v1.2.3');
+  });
+
+  it('renders version alone when the skill has no provider', () => {
+    render(<SkillCatalogCard skill={mockSkill} />, { wrapper });
+    expect(screen.queryByTestId('skill-catalog-card-provider-1')).not.toBeInTheDocument();
+    expect(screen.getByTestId('skill-catalog-card-version-1')).toHaveTextContent('v1.2.3');
+  });
+
+  it('omits the line entirely when neither provider nor version is set', () => {
+    render(<SkillCatalogCard skill={{ ...mockSkill, version: undefined }} />, { wrapper });
+    expect(screen.queryByTestId('skill-catalog-card-provider-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('skill-catalog-card-version-1')).not.toBeInTheDocument();
+  });
+
+  it('renders skill name and description', () => {
+    render(<SkillCatalogCard skill={mockSkill} />, { wrapper });
+    expect(screen.getByTestId('skill-catalog-card-name-1')).toHaveTextContent('Diagnosing Bugs');
+    expect(screen.getByTestId('skill-catalog-card-description-1')).toHaveTextContent(
+      'Test description for the skill.',
+    );
+  });
+
+  it('renders labels after the description', () => {
+    render(<SkillCatalogCard skill={mockSkill} />, { wrapper });
+    expect(screen.getByText('popular')).toBeInTheDocument();
+    expect(screen.getByText('debugging')).toBeInTheDocument();
+  });
+
+  it('does not render labels when none are present', () => {
+    render(<SkillCatalogCard skill={{ ...mockSkill, id: '2', labels: undefined }} />, {
+      wrapper,
+    });
+    expect(screen.queryByText('popular')).not.toBeInTheDocument();
+  });
+
+  it('renders an install button that opens the install modal on click', () => {
+    render(<SkillCatalogCard skill={mockSkill} />, { wrapper });
+    expect(screen.queryByTestId('skill-install-modal-1')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('skill-catalog-card-install-button-1'));
+
+    expect(screen.getByTestId('skill-install-modal-1')).toBeInTheDocument();
+    expect(screen.getByTestId('skill-install-modal-title-1')).toHaveTextContent(
+      'Install Diagnosing Bugs',
+    );
+  });
+
+  it('always renders the default cube icon', () => {
+    render(<SkillCatalogCard skill={mockSkill} />, { wrapper });
+    expect(screen.getByTestId('skill-catalog-card-icon-1')).toBeInTheDocument();
+  });
+
+  it('renders the trust tier as a green label', () => {
+    render(<SkillCatalogCard skill={mockSkill} />, { wrapper });
+    const trustTierLabel = screen.getByTestId('skill-catalog-card-trust-tier-1');
+    expect(trustTierLabel).toHaveTextContent('Community Contributed');
+  });
+
+  it('renders an "Unrated" grey label when trustTier is absent', () => {
+    render(<SkillCatalogCard skill={{ ...mockSkill, id: '3', trustTier: undefined }} />, {
+      wrapper,
+    });
+    expect(screen.getByTestId('skill-catalog-card-trust-tier-3')).toHaveTextContent('Unrated');
+  });
+
+  it('renders the slash-prefixed skill name in the footer next to the install button', () => {
+    render(<SkillCatalogCard skill={mockSkill} />, { wrapper });
+    expect(screen.getByTestId('skill-catalog-card-footer-name-1')).toHaveTextContent(
+      '/diagnosing-bugs',
+    );
+  });
+
+  it('renders clickable card name as link to details page', () => {
+    render(<SkillCatalogCard skill={mockSkill} />, { wrapper });
+    const link = screen.getByTestId('skill-catalog-card-detail-link-1');
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', '/skill-catalog/1');
+  });
+});

--- a/clients/ui/frontend/src/app/pages/skillCatalog/components/__tests__/SkillInstallModal.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/components/__tests__/SkillInstallModal.spec.tsx
@@ -1,0 +1,140 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { FetchState } from 'mod-arch-core';
+import SkillInstallModal from '~/app/pages/skillCatalog/components/SkillInstallModal';
+import { useSkillMarketplace } from '~/app/hooks/skillCatalog/useSkillMarketplace';
+import type { Skill, SkillMarketplace, SkillMarketplaceResult } from '~/app/skillCatalogTypes';
+
+jest.mock('~/app/hooks/skillCatalog/useSkillMarketplace', () => ({
+  useSkillMarketplace: jest.fn(),
+}));
+
+const mockUseSkillMarketplace = jest.mocked(useSkillMarketplace);
+
+const mockSkill: Skill = {
+  id: '1',
+  name: 'diagnosing-bugs',
+  displayName: 'Diagnosing Bugs',
+  sourceId: 'matt-pocock-skills',
+  repository: 'https://github.com/mattpocock/skills.git',
+  path: 'skills/engineering/diagnosing-bugs',
+  version: 'v1.2.3',
+  trustTier: 'communityContributed',
+};
+
+const marketplaceResult = (
+  marketplace: SkillMarketplace,
+  overrides: Partial<SkillMarketplaceResult> = {},
+): SkillMarketplaceResult => ({
+  marketplace,
+  marketplaceUrl:
+    'http://model-catalog.kubeflow.svc.cluster.local:8080/api/skill_catalog/v1/claude/marketplace.json',
+  external: false,
+  ...overrides,
+});
+
+const mockMarketplace: SkillMarketplace = {
+  name: 'kubeflow-skill-catalog',
+  plugins: [
+    {
+      name: 'diagnosing-bugs',
+      source: {
+        url: 'https://github.com/mattpocock/skills.git',
+        path: 'skills/engineering/diagnosing-bugs',
+        ref: 'v1.2.3',
+        sha: 'abc123',
+      },
+    },
+  ],
+};
+
+const buildFetchState = <T,>(data: T, loaded: boolean, error?: Error): FetchState<T> => [
+  data,
+  loaded,
+  error,
+  jest.fn(),
+];
+
+const originalClipboard = navigator.clipboard;
+
+beforeEach(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: jest.fn().mockResolvedValue(undefined) },
+    writable: true,
+    configurable: true,
+  });
+  mockUseSkillMarketplace.mockReturnValue(buildFetchState(null, false));
+});
+
+afterEach(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: originalClipboard,
+    writable: true,
+    configurable: true,
+  });
+  jest.clearAllMocks();
+});
+
+describe('SkillInstallModal', () => {
+  it('defaults to the npx tab with a command scoped to this skill via --skill', () => {
+    render(<SkillInstallModal skill={mockSkill} isOpen onClose={jest.fn()} />);
+    expect(screen.getByTestId('skill-install-modal-npx-1-code-block')).toHaveTextContent(
+      'npx skills add https://github.com/mattpocock/skills.git --skill diagnosing-bugs',
+    );
+  });
+
+  it('renders the manual git clone command on the Manual tab', () => {
+    render(<SkillInstallModal skill={mockSkill} isOpen onClose={jest.fn()} />);
+    fireEvent.click(screen.getByTestId('skill-install-modal-tab-manual'));
+    expect(screen.getByTestId('skill-install-modal-manual-1-code-block')).toHaveTextContent(
+      'git clone https://github.com/mattpocock/skills.git',
+    );
+  });
+
+  it('shows a loading state on the Claude Code tab while the marketplace is fetching', () => {
+    render(<SkillInstallModal skill={mockSkill} isOpen onClose={jest.fn()} />);
+    fireEvent.click(screen.getByTestId('skill-install-modal-tab-claude-code'));
+    expect(screen.getByTestId('skill-install-modal-claude-code-loading-1')).toBeInTheDocument();
+  });
+
+  it('builds the Claude Code install command from the real marketplace API response', () => {
+    mockUseSkillMarketplace.mockReturnValue(
+      buildFetchState(marketplaceResult(mockMarketplace), true),
+    );
+    render(<SkillInstallModal skill={mockSkill} isOpen onClose={jest.fn()} />);
+    fireEvent.click(screen.getByTestId('skill-install-modal-tab-claude-code'));
+
+    const codeBlock = screen.getByTestId('skill-install-modal-claude-code-1-code-block');
+    expect(codeBlock).toHaveTextContent('/plugin marketplace add');
+    expect(codeBlock).toHaveTextContent('/plugin install diagnosing-bugs@kubeflow-skill-catalog');
+  });
+
+  it('shows an unavailable message when the skill has no matching marketplace entry', () => {
+    mockUseSkillMarketplace.mockReturnValue(
+      buildFetchState(marketplaceResult({ name: 'kubeflow-skill-catalog', plugins: [] }), true),
+    );
+    render(<SkillInstallModal skill={mockSkill} isOpen onClose={jest.fn()} />);
+    fireEvent.click(screen.getByTestId('skill-install-modal-tab-claude-code'));
+
+    expect(screen.getByTestId('skill-install-modal-claude-code-unavailable-1')).toBeInTheDocument();
+  });
+
+  it('renders the trust tier as a green label', () => {
+    render(<SkillInstallModal skill={mockSkill} isOpen onClose={jest.fn()} />);
+    expect(screen.getByTestId('skill-install-modal-trust-tier-1')).toHaveTextContent(
+      'Community Contributed',
+    );
+  });
+
+  it('does not render a trust tier label when absent', () => {
+    render(
+      <SkillInstallModal
+        skill={{ ...mockSkill, trustTier: undefined }}
+        isOpen
+        onClose={jest.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('skill-install-modal-trust-tier-1')).not.toBeInTheDocument();
+  });
+});

--- a/clients/ui/frontend/src/app/pages/skillCatalog/const.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/const.ts
@@ -1,0 +1,76 @@
+import type { SkillFilterCategoryKey } from '~/app/pages/skillCatalog/types/skillCatalogFilterOptions';
+
+export const SKILL_CATALOG_TITLE = 'Skill Catalog';
+export const SKILL_CATALOG_DESCRIPTION = 'Browse and use skills provided by your organization.';
+
+export const OTHER_SKILLS_DISPLAY_NAME = 'Other skills';
+export const ALL_SKILLS_LABEL = 'All skills';
+
+export const SKILL_FILTER_KEYS: SkillFilterCategoryKey[] = ['provider', 'trustTier', 'category'];
+
+export const SKILL_FILTER_CATEGORY_NAMES: Record<SkillFilterCategoryKey, string> = {
+  provider: 'Provider',
+  trustTier: 'Trust tier',
+  category: 'Category',
+};
+
+// Keys must match the catalog backend's SkillTrustTier enum exactly
+// (catalog/pkg/openapi/model_skill_trust_tier.go) — it's a hard enum, so these are the
+// only values a skill's trustTier can ever have.
+export const SKILL_TRUST_TIER_LABEL_MAPPING: Record<string, string> = {
+  platformProvided: 'Platform Provided',
+  partnerVerified: 'Partner Verified',
+  organizationApproved: 'Organization Approved',
+  communityContributed: 'Community Contributed',
+};
+
+// Shape matches mod-arch-shared's SimpleSelectOption, so this can be passed to
+// <SimpleSelect options={...} /> directly.
+export const SKILL_TRUST_TIER_OPTIONS: { key: string; label: string }[] = [
+  { key: 'platformProvided', label: SKILL_TRUST_TIER_LABEL_MAPPING.platformProvided },
+  { key: 'partnerVerified', label: SKILL_TRUST_TIER_LABEL_MAPPING.partnerVerified },
+  { key: 'organizationApproved', label: SKILL_TRUST_TIER_LABEL_MAPPING.organizationApproved },
+  { key: 'communityContributed', label: SKILL_TRUST_TIER_LABEL_MAPPING.communityContributed },
+];
+
+export const SKILL_LABEL_MAPPINGS: Record<string, Record<string, string>> = {
+  trustTier: SKILL_TRUST_TIER_LABEL_MAPPING,
+};
+
+export const BACKEND_TO_FRONTEND_SKILL_FILTER_KEY: Record<string, SkillFilterCategoryKey> = {};
+
+export const SKILL_CATALOG_GALLERY = {
+  CARDS_PER_ROW: 4,
+  PAGE_SIZE: 10,
+  SECTION_TITLE: 'Skills',
+} as const;
+
+type GridSpan = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+
+const GRID_COLUMNS = 12;
+const GRID_SPAN_VALUES: GridSpan[] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+function toGridSpan(cols: number): GridSpan {
+  const index = Math.min(Math.max(0, cols - 1), GRID_SPAN_VALUES.length - 1);
+  return GRID_SPAN_VALUES[index];
+}
+
+export const SKILL_CATALOG_GRID_SPAN: {
+  sm: GridSpan;
+  md: GridSpan;
+  lg: GridSpan;
+  xl2: GridSpan;
+} = {
+  sm: toGridSpan(GRID_COLUMNS),
+  md: toGridSpan(GRID_COLUMNS / 2),
+  lg: toGridSpan(GRID_COLUMNS / SKILL_CATALOG_GALLERY.CARDS_PER_ROW),
+  xl2: toGridSpan(GRID_COLUMNS / SKILL_CATALOG_GALLERY.CARDS_PER_ROW),
+};
+
+// Mirrors maxSkillBodyLines in the catalog service's skill parser
+// (catalog/internal/catalog/skillcatalog/skillmd_parser.go), which warns when a
+// SKILL.md body exceeds it. The service does not expose the threshold, so it is
+// duplicated here; it comes from the Agent Skills specification rather than being
+// deployment-tunable. If skill validation rules later expose their thresholds through
+// the API, this constant should give way to that value.
+export const SKILL_RECOMMENDED_MAX_BODY_LINES = 500;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/hooks/useSkillUrlSync.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/hooks/useSkillUrlSync.ts
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { SKILL_FILTER_KEYS } from '~/app/pages/skillCatalog/const';
+import type { SkillCatalogFiltersState } from '~/app/pages/skillCatalog/types/skillCatalogFilterOptions';
+
+const SEARCH_PARAM = 'q';
+const SOURCE_PARAM = 'source';
+
+function filtersFromParams(params: URLSearchParams): SkillCatalogFiltersState {
+  const filters: SkillCatalogFiltersState = {};
+  for (const key of SKILL_FILTER_KEYS) {
+    const raw = params.get(key);
+    if (raw) {
+      filters[key] = raw.split(',');
+    }
+  }
+  return filters;
+}
+
+function filtersToParams(filters: SkillCatalogFiltersState, params: URLSearchParams): void {
+  for (const key of SKILL_FILTER_KEYS) {
+    const values = filters[key];
+    if (values && values.length > 0) {
+      params.set(key, values.join(','));
+    } else {
+      params.delete(key);
+    }
+  }
+}
+
+type UrlState = {
+  searchQuery: string;
+  filters: SkillCatalogFiltersState;
+  selectedSourceLabel: string | undefined;
+};
+
+type UseSkillUrlSyncReturn = {
+  initialState: UrlState;
+  syncToUrl: (state: UrlState) => void;
+};
+
+export function useSkillUrlSync(): UseSkillUrlSyncReturn {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const initialState = React.useMemo<UrlState>(
+    () => ({
+      searchQuery: searchParams.get(SEARCH_PARAM) || '',
+      filters: filtersFromParams(searchParams),
+      selectedSourceLabel: searchParams.get(SOURCE_PARAM) || undefined,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+
+  const syncToUrl = React.useCallback(
+    (state: UrlState) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (state.searchQuery) {
+            next.set(SEARCH_PARAM, state.searchQuery);
+          } else {
+            next.delete(SEARCH_PARAM);
+          }
+          if (state.selectedSourceLabel) {
+            next.set(SOURCE_PARAM, state.selectedSourceLabel);
+          } else {
+            next.delete(SOURCE_PARAM);
+          }
+          filtersToParams(state.filters, next);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return { initialState, syncToUrl };
+}

--- a/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillCatalog.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillCatalog.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { ApplicationsPage, ProjectObjectType, TitleWithIcon } from 'mod-arch-shared';
+import { SearchIcon } from '@patternfly/react-icons';
+import { SkillCatalogContext } from '~/app/context/skillCatalog/SkillCatalogContext';
+import { SKILL_CATALOG_TITLE, SKILL_CATALOG_DESCRIPTION } from '~/app/pages/skillCatalog/const';
+import { hasSkillFiltersApplied } from '~/app/pages/skillCatalog/utils/skillCatalogUtils';
+import SkillCatalogFilters from '~/app/pages/skillCatalog/components/SkillCatalogFilters';
+import { CatalogPageLayout, EmptyCatalogState } from '~/app/shared/components/catalog';
+import SkillCatalogSourceLabelSelector from './SkillCatalogSourceLabelSelector';
+import SkillCatalogAllSkillsView from './SkillCatalogAllSkillsView';
+import SkillCatalogGalleryView from './SkillCatalogGalleryView';
+
+const SkillCatalog: React.FC = () => {
+  const {
+    searchQuery,
+    setSearchQuery,
+    clearAllFilters,
+    selectedSourceLabel,
+    setSelectedSourceLabel,
+    filters,
+    catalogSources,
+    catalogLabels,
+    catalogSourcesLoaded,
+    emptyCategoryLabels,
+    setCategoryCount,
+  } = React.useContext(SkillCatalogContext);
+
+  const filtersApplied = hasSkillFiltersApplied(filters, searchQuery);
+  const isAllSkillsView = selectedSourceLabel === undefined && !filtersApplied;
+
+  const handleSearch = React.useCallback(
+    (term: string) => {
+      setSearchQuery(term);
+    },
+    [setSearchQuery],
+  );
+
+  const handleClearSearch = React.useCallback(() => {
+    setSearchQuery('');
+  }, [setSearchQuery]);
+
+  const handleResetAllFilters = React.useCallback(() => {
+    clearAllFilters();
+  }, [clearAllFilters]);
+
+  return (
+    <ApplicationsPage
+      title={
+        <TitleWithIcon title={SKILL_CATALOG_TITLE} objectType={ProjectObjectType.mcpCatalog} />
+      }
+      description={SKILL_CATALOG_DESCRIPTION}
+      empty={false}
+      loaded
+      provideChildrenPadding
+    >
+      <CatalogPageLayout
+        catalogSources={catalogSources}
+        catalogLabels={catalogLabels}
+        catalogSourcesLoaded={catalogSourcesLoaded}
+        selectedSourceLabel={selectedSourceLabel}
+        onSelectSourceLabel={setSelectedSourceLabel}
+        isAllItemsView={isAllSkillsView}
+        emptyCategoryLabels={emptyCategoryLabels}
+        setCategoryCount={setCategoryCount}
+        renderEmptyCategoriesState={() => (
+          <EmptyCatalogState
+            testid="empty-skill-catalog-no-categories"
+            title="No skills available"
+            headerIcon={SearchIcon}
+            description="There are no skill categories available. Configure sources in settings to get started."
+          />
+        )}
+        renderFilterSidebar={() => <SkillCatalogFilters />}
+        renderToolbar={() => (
+          <SkillCatalogSourceLabelSelector
+            searchTerm={searchQuery}
+            onSearch={handleSearch}
+            onClearSearch={handleClearSearch}
+          />
+        )}
+        renderAllItemsView={() => <SkillCatalogAllSkillsView searchTerm={searchQuery} />}
+        renderGalleryView={(isSingleCategory, singleCategoryLabel) => (
+          <SkillCatalogGalleryView
+            handleFilterReset={handleResetAllFilters}
+            isSingleCategory={isSingleCategory}
+            singleCategoryLabel={singleCategoryLabel}
+          />
+        )}
+      />
+    </ApplicationsPage>
+  );
+};
+
+export default SkillCatalog;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillCatalogAllSkillsView.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillCatalogAllSkillsView.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { SkillCatalogContext } from '~/app/context/skillCatalog/SkillCatalogContext';
+import { CatalogAllItemsView } from '~/app/shared/components/catalog';
+import { skillFiltersToFilterQuery } from '~/app/pages/skillCatalog/utils/skillCatalogUtils';
+import SkillCatalogCategorySection from './SkillCatalogCategorySection';
+
+type SkillCatalogAllSkillsViewProps = {
+  searchTerm: string;
+};
+
+const SkillCatalogAllSkillsView: React.FC<SkillCatalogAllSkillsViewProps> = ({ searchTerm }) => {
+  const { catalogSources, catalogLabels, setSelectedSourceLabel, filters } =
+    React.useContext(SkillCatalogContext);
+
+  const filterQuery = React.useMemo(() => skillFiltersToFilterQuery(filters), [filters]);
+
+  const handleShowMoreCategory = React.useCallback(
+    (categoryLabel: string) => {
+      setSelectedSourceLabel(categoryLabel);
+    },
+    [setSelectedSourceLabel],
+  );
+
+  return (
+    <CatalogAllItemsView
+      searchTerm={searchTerm}
+      catalogSources={catalogSources}
+      catalogLabels={catalogLabels}
+      pageSize={4}
+      otherSectionKey="other-skills"
+      onShowMore={handleShowMoreCategory}
+      renderCategorySection={(label, term, pageSize, onShowMore) => (
+        <SkillCatalogCategorySection
+          label={label}
+          searchTerm={term}
+          filterQuery={filterQuery || undefined}
+          pageSize={pageSize}
+          onShowMore={onShowMore}
+        />
+      )}
+    />
+  );
+};
+
+export default SkillCatalogAllSkillsView;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillCatalogCategorySection.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillCatalogCategorySection.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { useSkillsBySourceLabelWithAPI } from '~/app/hooks/skillCatalog/useSkillsBySourceLabel';
+import useReportCategoryEmpty from '~/app/hooks/useReportCategoryEmpty';
+import {
+  getLabelDescription,
+  getLabelDisplayName,
+  CatalogCategorySection,
+} from '~/app/shared/components/catalog';
+import { SourceLabel } from '~/app/shared/types/catalogTypes';
+import { SkillCatalogContext } from '~/app/context/skillCatalog/SkillCatalogContext';
+import { SKILL_CATALOG_GRID_SPAN, OTHER_SKILLS_DISPLAY_NAME } from '~/app/pages/skillCatalog/const';
+import SkillCatalogCard from '~/app/pages/skillCatalog/components/SkillCatalogCard';
+
+type SkillCatalogCategorySectionProps = {
+  label: string;
+  searchTerm: string;
+  filterQuery?: string;
+  pageSize: number;
+  onShowMore: (label: string) => void;
+};
+
+const SkillCatalogCategorySection: React.FC<SkillCatalogCategorySectionProps> = ({
+  label,
+  searchTerm,
+  filterQuery,
+  pageSize,
+  onShowMore,
+}) => {
+  const { skillApiState, catalogLabels, reportCategoryEmpty } =
+    React.useContext(SkillCatalogContext);
+  // Don't forward the sentinel "null" label (SourceLabel.other) to the API — pass undefined
+  // instead so the catalog service receives no sourceLabel filter.
+  const apiSourceLabel = label === SourceLabel.other ? undefined : label;
+
+  const {
+    skills: rawSkills,
+    skillsLoaded,
+    skillsLoadError,
+  } = useSkillsBySourceLabelWithAPI(skillApiState, {
+    sourceLabel: apiSourceLabel,
+    pageSize,
+    searchQuery: searchTerm,
+    filterQuery,
+  });
+
+  // Use skills directly from the catalog service — client-side source ID filtering is skipped
+  // because ConfigMap source IDs (admin UI) differ from the catalog service's internal source IDs.
+  const { items } = rawSkills;
+
+  const categoryTitle = getLabelDisplayName(
+    label,
+    catalogLabels,
+    OTHER_SKILLS_DISPLAY_NAME,
+    'skills',
+  );
+  const categoryDescription = getLabelDescription(label, catalogLabels);
+  const labelSlug = label.toLowerCase().replace(/\s+/g, '-');
+
+  useReportCategoryEmpty(
+    reportCategoryEmpty,
+    label,
+    skillsLoaded,
+    items.length,
+    searchTerm,
+    skillsLoadError,
+  );
+
+  if (skillsLoaded && items.length === 0 && !searchTerm) {
+    return null;
+  }
+
+  return (
+    <CatalogCategorySection
+      label={label}
+      categoryTitle={categoryTitle}
+      categoryDescription={categoryDescription}
+      items={items}
+      loaded={skillsLoaded}
+      loadError={skillsLoadError}
+      pageSize={pageSize}
+      onShowMore={onShowMore}
+      renderCard={(skill) => <SkillCatalogCard skill={skill} />}
+      getItemKey={(skill) => skill.id}
+      gridSpans={SKILL_CATALOG_GRID_SPAN}
+      loadingScreenReaderText={`Loading ${label} skills`}
+      testIds={{
+        title: `skills-category-title-${label}`,
+        showMore: `skills-show-all-${labelSlug}`,
+        error: `skills-error-state-${label}`,
+        skeleton: (index) => `skills-category-skeleton-${labelSlug}-${index}`,
+        empty: `empty-skill-catalog-state-${label}`,
+      }}
+    />
+  );
+};
+
+export default SkillCatalogCategorySection;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillCatalogGalleryView.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillCatalogGalleryView.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { Button } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import { SkillCatalogContext } from '~/app/context/skillCatalog/SkillCatalogContext';
+import { useSkillsBySourceLabelWithAPI } from '~/app/hooks/skillCatalog/useSkillsBySourceLabel';
+import { SKILL_CATALOG_GRID_SPAN, OTHER_SKILLS_DISPLAY_NAME } from '~/app/pages/skillCatalog/const';
+import { skillFiltersToFilterQuery } from '~/app/pages/skillCatalog/utils/skillCatalogUtils';
+import {
+  getLabelDisplayName,
+  getLabelDescription,
+  CatalogGalleryLayout,
+  EmptyCatalogState,
+} from '~/app/shared/components/catalog';
+import SkillCatalogCard from '~/app/pages/skillCatalog/components/SkillCatalogCard';
+
+const PAGE_SIZE = 10;
+
+type SkillCatalogGalleryViewProps = {
+  handleFilterReset: () => void;
+  isSingleCategory?: boolean;
+  singleCategoryLabel?: string;
+};
+
+const SkillCatalogGalleryView: React.FC<SkillCatalogGalleryViewProps> = ({
+  handleFilterReset,
+  isSingleCategory = false,
+  singleCategoryLabel,
+}) => {
+  const {
+    skillApiState,
+    selectedSourceLabel,
+    searchQuery,
+    filters,
+    catalogLabels,
+    catalogLabelsLoaded,
+  } = React.useContext(SkillCatalogContext);
+
+  const filterQuery = React.useMemo(() => skillFiltersToFilterQuery(filters), [filters]);
+
+  const { skills, skillsLoaded, skillsLoadError } = useSkillsBySourceLabelWithAPI(skillApiState, {
+    sourceLabel: selectedSourceLabel,
+    pageSize: PAGE_SIZE,
+    searchQuery,
+    filterQuery: filterQuery || undefined,
+  });
+
+  const loaded = skillsLoaded && catalogLabelsLoaded;
+
+  const effectiveCategoryLabel = singleCategoryLabel || selectedSourceLabel || '';
+  const categoryTitle = isSingleCategory
+    ? getLabelDisplayName(
+        effectiveCategoryLabel,
+        catalogLabels,
+        OTHER_SKILLS_DISPLAY_NAME,
+        'skills',
+      )
+    : undefined;
+  const categoryDescription = isSingleCategory
+    ? getLabelDescription(effectiveCategoryLabel, catalogLabels)
+    : undefined;
+
+  return (
+    <CatalogGalleryLayout
+      items={skills.items}
+      loaded={loaded}
+      loadError={skillsLoadError}
+      renderCard={(skill) => <SkillCatalogCard skill={skill} />}
+      getItemKey={(skill) => skill.id}
+      gridSpans={SKILL_CATALOG_GRID_SPAN}
+      hasMore={skills.hasMore && skills.items.length >= PAGE_SIZE}
+      isLoadingMore={skills.isLoadingMore}
+      onLoadMore={skills.loadMore}
+      loadMoreLabel="Load more skills"
+      loadingMoreLabel="Loading more skills..."
+      loadingLabel="Loading skills..."
+      errorTitle="Failed to load skills"
+      categoryTitle={categoryTitle}
+      categoryDescription={categoryDescription}
+      renderEmptyState={() => (
+        <EmptyCatalogState
+          testid="empty-skill-catalog-state"
+          title="No results found"
+          headerIcon={SearchIcon}
+          description="No skills match your filters. Adjust your filters and try again."
+          primaryAction={
+            <Button variant="link" onClick={handleFilterReset}>
+              Reset filters
+            </Button>
+          }
+        />
+      )}
+    />
+  );
+};
+
+export default SkillCatalogGalleryView;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillCatalogSourceLabelSelector.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillCatalogSourceLabelSelector.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import {
+  Flex,
+  Stack,
+  StackItem,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarToggleGroup,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons';
+import { ThemeAwareSearchInput } from 'mod-arch-shared';
+import { SkillCatalogContext } from '~/app/context/skillCatalog/SkillCatalogContext';
+import { CatalogSourceLabelToggle, getLabelDisplayName } from '~/app/shared/components/catalog';
+import { OTHER_SKILLS_DISPLAY_NAME, ALL_SKILLS_LABEL } from '~/app/pages/skillCatalog/const';
+
+type SkillCatalogSourceLabelSelectorProps = {
+  searchTerm: string;
+  onSearch: (term: string) => void;
+  onClearSearch: () => void;
+};
+
+const SkillCatalogSourceLabelSelector: React.FC<SkillCatalogSourceLabelSelectorProps> = ({
+  searchTerm,
+  onSearch,
+  onClearSearch,
+}) => {
+  const [inputValue, setInputValue] = React.useState(searchTerm || '');
+  const {
+    catalogSources,
+    catalogLabels,
+    catalogSourcesLoaded,
+    selectedSourceLabel,
+    setSelectedSourceLabel,
+    emptyCategoryLabels,
+  } = React.useContext(SkillCatalogContext);
+
+  React.useEffect(() => {
+    setInputValue(searchTerm || '');
+  }, [searchTerm]);
+
+  const handleSearchInputChange = React.useCallback((value: string) => {
+    setInputValue(value);
+  }, []);
+
+  const handleSearchInputSearch = React.useCallback(
+    (_: React.SyntheticEvent<HTMLButtonElement>, value: string) => {
+      onSearch(value.trim());
+    },
+    [onSearch],
+  );
+
+  const getLabelDisplayNameForSkill = React.useCallback(
+    (label: string) =>
+      getLabelDisplayName(label, catalogLabels, OTHER_SKILLS_DISPLAY_NAME, 'skills'),
+    [catalogLabels],
+  );
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Toolbar className="pf-v6-u-pb-0">
+          <ToolbarContent rowWrap={{ default: 'wrap' }}>
+            <Flex style={{ flex: 1 }}>
+              <ToolbarToggleGroup style={{ flex: 1 }} breakpoint="md" toggleIcon={<FilterIcon />}>
+                <ToolbarGroup
+                  style={{ flex: 1 }}
+                  variant="filter-group"
+                  gap={{ default: 'gapMd' }}
+                  alignItems="center"
+                >
+                  <ToolbarItem style={{ flex: 1 }}>
+                    <ThemeAwareSearchInput
+                      data-testid="skill-catalog-search-input"
+                      aria-label="Search skills"
+                      className="toolbar-fieldset-wrapper"
+                      placeholder="Search by name, keyword, or description"
+                      value={inputValue}
+                      onChange={handleSearchInputChange}
+                      onSearch={handleSearchInputSearch}
+                      onClear={onClearSearch}
+                    />
+                  </ToolbarItem>
+                </ToolbarGroup>
+              </ToolbarToggleGroup>
+            </Flex>
+          </ToolbarContent>
+        </Toolbar>
+      </StackItem>
+      {catalogSourcesLoaded && (
+        <StackItem>
+          <Flex
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+          >
+            <CatalogSourceLabelToggle
+              catalogSources={catalogSources}
+              catalogLabels={catalogLabels}
+              selectedSourceLabel={selectedSourceLabel}
+              onSelectSourceLabel={setSelectedSourceLabel}
+              allBlockDisplayName={ALL_SKILLS_LABEL}
+              getLabelDisplayNameOverride={getLabelDisplayNameForSkill}
+              emptyCategoryLabels={emptyCategoryLabels}
+            />
+          </Flex>
+        </StackItem>
+      )}
+    </Stack>
+  );
+};
+
+export default SkillCatalogSourceLabelSelector;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillDetailsPage.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillDetailsPage.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { useParams } from 'react-router';
+import { Link } from 'react-router-dom';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  Content,
+  ContentVariants,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  Flex,
+  FlexItem,
+  Label,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { CubeIcon, PluggedIcon, SearchIcon } from '@patternfly/react-icons';
+import { ApplicationsPage } from 'mod-arch-shared';
+import { useSkillWithAPI } from '~/app/hooks/skillCatalog/useSkill';
+import { SkillCatalogContext } from '~/app/context/skillCatalog/SkillCatalogContext';
+import { skillCatalogUrl } from '~/app/routes/skillCatalog/skillCatalog';
+import {
+  SKILL_CATALOG_TITLE,
+  SKILL_TRUST_TIER_LABEL_MAPPING,
+} from '~/app/pages/skillCatalog/const';
+import ScrollViewOnMount from '~/app/shared/components/ScrollViewOnMount';
+import SkillInstallModal from '~/app/pages/skillCatalog/components/SkillInstallModal';
+import SkillDetailsView from './SkillDetailsView';
+
+const SkillDetailsPage: React.FC = () => {
+  const { skillId = '' } = useParams<{ skillId: string }>();
+  const { skillApiState } = React.useContext(SkillCatalogContext);
+  const [skill, skillLoaded, skillLoadError] = useSkillWithAPI(skillApiState, skillId);
+  const [isInstallModalOpen, setIsInstallModalOpen] = React.useState(false);
+
+  const isNotFound = !skill && (skillLoaded || !!skillLoadError);
+  const skillName = skill?.displayName || skill?.name;
+
+  return (
+    <>
+      <ScrollViewOnMount shouldScroll scrollToTop />
+      <ApplicationsPage
+        breadcrumb={
+          <Breadcrumb>
+            <BreadcrumbItem>
+              <Link to={skillCatalogUrl()}>{SKILL_CATALOG_TITLE}</Link>
+            </BreadcrumbItem>
+            <BreadcrumbItem isActive data-testid="breadcrumb-skill-name">
+              {skillName || 'Details'}
+            </BreadcrumbItem>
+          </Breadcrumb>
+        }
+        title={
+          skill ? (
+            <Flex
+              spaceItems={{ default: 'spaceItemsMd' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+            >
+              <FlexItem
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  height: '48px',
+                  width: '48px',
+                  borderRadius: '50%',
+                  backgroundColor: 'var(--pf-t--global--background--color--secondary--default)',
+                }}
+              >
+                <CubeIcon style={{ fontSize: '24px' }} data-testid="skill-default-icon" />
+              </FlexItem>
+              <Stack>
+                <StackItem>{skillName}</StackItem>
+                <StackItem>
+                  <Flex
+                    gap={{ default: 'gapSm' }}
+                    alignItems={{ default: 'alignItemsCenter' }}
+                    flexWrap={{ default: 'wrap' }}
+                  >
+                    <FlexItem>
+                      <Label
+                        color={skill.trustTier ? 'green' : 'grey'}
+                        data-testid="skill-details-trust-tier"
+                      >
+                        {skill.trustTier
+                          ? (SKILL_TRUST_TIER_LABEL_MAPPING[skill.trustTier] ?? skill.trustTier)
+                          : 'Unrated'}
+                      </Label>
+                    </FlexItem>
+                    {skill.provider && (
+                      <FlexItem>
+                        <Content component={ContentVariants.small}>
+                          Provider: {skill.provider}
+                        </Content>
+                      </FlexItem>
+                    )}
+                  </Flex>
+                </StackItem>
+              </Stack>
+            </Flex>
+          ) : null
+        }
+        headerAction={
+          skill ? (
+            <Button
+              variant="primary"
+              icon={<PluggedIcon />}
+              onClick={() => setIsInstallModalOpen(true)}
+              data-testid="skill-details-install-button"
+            >
+              Install
+            </Button>
+          ) : undefined
+        }
+        empty={isNotFound}
+        emptyStatePage={
+          isNotFound ? (
+            <EmptyState icon={SearchIcon} titleText="Skill not found" data-testid="skill-not-found">
+              <EmptyStateBody>The requested skill could not be found.</EmptyStateBody>
+              <EmptyStateFooter>
+                <Button
+                  variant="primary"
+                  component={(props) => <Link {...props} to={skillCatalogUrl()} />}
+                >
+                  Return to {SKILL_CATALOG_TITLE}
+                </Button>
+              </EmptyStateFooter>
+            </EmptyState>
+          ) : undefined
+        }
+        loadError={isNotFound ? undefined : skillLoadError}
+        loaded={isNotFound || skillLoaded}
+        errorMessage="Unable to load skill details"
+        provideChildrenPadding
+      >
+        {skill && <SkillDetailsView skill={skill} />}
+      </ApplicationsPage>
+      {skill && isInstallModalOpen && (
+        <SkillInstallModal
+          skill={skill}
+          isOpen={isInstallModalOpen}
+          onClose={() => setIsInstallModalOpen(false)}
+        />
+      )}
+    </>
+  );
+};
+
+export default SkillDetailsPage;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillDetailsView.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/screens/SkillDetailsView.tsx
@@ -1,0 +1,312 @@
+import * as React from 'react';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Content,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Icon,
+  Label,
+  LabelGroup,
+  List,
+  ListItem,
+  PageSection,
+  Sidebar,
+  Tooltip,
+  SidebarContent,
+  SidebarPanel,
+  Stack,
+  StackItem,
+  Title,
+} from '@patternfly/react-core';
+import { CodeIcon, ExclamationTriangleIcon, GithubIcon } from '@patternfly/react-icons';
+import type { Skill } from '~/app/skillCatalogTypes';
+import ExternalLink from '~/app/shared/components/ExternalLink';
+import MarkdownComponent from '~/app/shared/markdown/MarkdownComponent';
+import SkillInstallTabs from '~/app/pages/skillCatalog/components/SkillInstallTabs';
+import SkillFileTree from '~/app/pages/skillCatalog/components/SkillFileTree';
+import {
+  SKILL_RECOMMENDED_MAX_BODY_LINES,
+  SKILL_TRUST_TIER_LABEL_MAPPING,
+} from '~/app/pages/skillCatalog/const';
+import { buildSupportingFilesTree } from '~/app/pages/skillCatalog/utils/skillSupportingFilesTree';
+import { parseAllowedTools } from '~/app/pages/skillCatalog/utils/skillCatalogUtils';
+
+type SkillDetailsViewProps = {
+  skill: Skill;
+};
+
+const VISIBLE_LABELS = 3;
+const MAX_BOX_HEIGHT = '200px';
+
+// Scrolls only once content exceeds MAX_BOX_HEIGHT — a short list sizes to its
+// content instead of leaving dead space inside a fixed-height box.
+const scrollBoxStyle: React.CSSProperties = {
+  maxHeight: MAX_BOX_HEIGHT,
+  overflowY: 'auto',
+  border: '1px solid var(--pf-t--global--border--color--default)',
+  borderRadius: 'var(--pf-t--global--border--radius--small)',
+  padding: '4px 8px',
+};
+
+// Shortens a repository URL to its "org/repo" form for the sidebar Source field,
+// while the full URL remains the link target.
+const getRepoShortLabel = (url?: string): string | undefined => {
+  if (!url) {
+    return undefined;
+  }
+  try {
+    const parts = new URL(url).pathname
+      .replace(/\.git$/, '')
+      .split('/')
+      .filter(Boolean);
+    return parts.length >= 2 ? `${parts[parts.length - 2]}/${parts[parts.length - 1]}` : url;
+  } catch {
+    return url;
+  }
+};
+
+const SkillDetailsView: React.FC<SkillDetailsViewProps> = ({ skill }) => {
+  const repositoryUrl = skill.repository || skill.repositoryUrl;
+  const repoShortLabel = getRepoShortLabel(repositoryUrl);
+  const supportingFilesTree = buildSupportingFilesTree(skill);
+  const allowedTools = parseAllowedTools(skill.allowedTools);
+
+  return (
+    <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'noPadding' }}>
+      <Sidebar hasGutter isPanelRight>
+        <SidebarContent style={{ minWidth: 0, overflow: 'hidden' }}>
+          <Stack hasGutter>
+            <StackItem>
+              <Card>
+                <CardHeader>
+                  <Title headingLevel="h2" size="lg">
+                    Description
+                  </Title>
+                </CardHeader>
+                <CardBody>
+                  <Content className="pf-v6-u-text-break-word">
+                    <p data-testid="skill-description">{skill.description || 'No description'}</p>
+                  </Content>
+                </CardBody>
+              </Card>
+            </StackItem>
+            <StackItem>
+              <Card data-testid="skill-install-card">
+                <CardHeader>
+                  <Title headingLevel="h2" size="lg">
+                    Install
+                  </Title>
+                </CardHeader>
+                <CardBody>
+                  <SkillInstallTabs skill={skill} idPrefix="skill-install-section" />
+                </CardBody>
+              </Card>
+            </StackItem>
+            <StackItem>
+              <Card>
+                <CardHeader>
+                  <Title headingLevel="h2" size="lg">
+                    <Icon isInline style={{ marginRight: '4px' }}>
+                      <GithubIcon />
+                    </Icon>
+                    README
+                  </Title>
+                </CardHeader>
+                <CardBody>
+                  {!skill.readme && (
+                    <Content component="p" data-testid="skill-no-readme">
+                      No README available
+                    </Content>
+                  )}
+                  {skill.readme && (
+                    <MarkdownComponent
+                      data={skill.readme}
+                      dataTestId={`skill-readme-${skill.id}`}
+                      maxHeading={3}
+                    />
+                  )}
+                </CardBody>
+              </Card>
+            </StackItem>
+          </Stack>
+        </SidebarContent>
+        <SidebarPanel width={{ default: 'width_33' }}>
+          <Card>
+            <CardHeader>
+              <Title headingLevel="h2" size="lg">
+                Skill details
+              </Title>
+            </CardHeader>
+            <CardBody>
+              <DescriptionList>
+                {skill.category && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Category</DescriptionListTerm>
+                    <DescriptionListDescription data-testid="skill-category">
+                      {skill.category}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Provider</DescriptionListTerm>
+                  <DescriptionListDescription data-testid="skill-provider">
+                    {skill.provider || 'N/A'}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Trust tier</DescriptionListTerm>
+                  <DescriptionListDescription>
+                    <Label
+                      color={skill.trustTier ? 'green' : 'grey'}
+                      data-testid="skill-detail-trust-tier"
+                    >
+                      {skill.trustTier
+                        ? (SKILL_TRUST_TIER_LABEL_MAPPING[skill.trustTier] ?? skill.trustTier)
+                        : 'Unrated'}
+                    </Label>
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Version</DescriptionListTerm>
+                  <DescriptionListDescription data-testid="skill-version">
+                    {skill.version || 'N/A'}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                {skill.bodyLineCount !== undefined && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Skill length</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      {/* An agent loads the whole SKILL.md body into its context, so length
+                          is a cost signal. Shown for every skill; the colour and tooltip
+                          only escalate past the recommended maximum. */}
+                      <Tooltip
+                        content={
+                          skill.bodyLineCount > SKILL_RECOMMENDED_MAX_BODY_LINES
+                            ? `This skill's body exceeds the recommended maximum of ${SKILL_RECOMMENDED_MAX_BODY_LINES} lines. An agent loads the whole body into its context, so longer skills leave less room for your own work.`
+                            : `Length of the skill's SKILL.md body. The recommended maximum is ${SKILL_RECOMMENDED_MAX_BODY_LINES} lines, because an agent loads the whole body into its context.`
+                        }
+                      >
+                        <Label
+                          color={
+                            skill.bodyLineCount > SKILL_RECOMMENDED_MAX_BODY_LINES
+                              ? 'orange'
+                              : 'green'
+                          }
+                          icon={
+                            skill.bodyLineCount > SKILL_RECOMMENDED_MAX_BODY_LINES ? (
+                              <ExclamationTriangleIcon />
+                            ) : undefined
+                          }
+                          data-testid="skill-body-line-count"
+                        >
+                          {skill.bodyLineCount} lines
+                        </Label>
+                      </Tooltip>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Invocation</DescriptionListTerm>
+                  <DescriptionListDescription data-testid="skill-invocation">
+                    /{skill.name}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                {skill.labels && skill.labels.length > 0 && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Labels</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <LabelGroup numLabels={VISIBLE_LABELS} isCompact>
+                        {skill.labels.map((label) => (
+                          <Label key={label} variant="outline" data-testid="skill-detail-label">
+                            {label}
+                          </Label>
+                        ))}
+                      </LabelGroup>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
+                <DescriptionListGroup>
+                  <DescriptionListTerm>License</DescriptionListTerm>
+                  <DescriptionListDescription data-testid="skill-license">
+                    {skill.license || 'N/A'}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                <DescriptionListGroup>
+                  <DescriptionListTerm>Author</DescriptionListTerm>
+                  <DescriptionListDescription data-testid="skill-author">
+                    {skill.author || 'N/A'}
+                  </DescriptionListDescription>
+                </DescriptionListGroup>
+                {skill.compatibility && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Compatibility</DescriptionListTerm>
+                    <DescriptionListDescription data-testid="skill-compatibility">
+                      {skill.compatibility}
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
+                {repositoryUrl && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Source</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <ExternalLink
+                        text={repoShortLabel || repositoryUrl}
+                        to={repositoryUrl}
+                        testId="skill-source-code-link"
+                      />
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
+                {supportingFilesTree && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Supporting files</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <div style={scrollBoxStyle} data-testid="skill-supporting-files-box">
+                        <SkillFileTree root={supportingFilesTree} />
+                      </div>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
+                {allowedTools.length > 0 && (
+                  <DescriptionListGroup>
+                    <DescriptionListTerm>Allowed tools</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <div style={scrollBoxStyle} data-testid="skill-allowed-tools-box">
+                        <List
+                          isPlain
+                          data-testid="skill-allowed-tools-list"
+                          style={{ fontSize: '13px' }}
+                        >
+                          {allowedTools.map((tool) => (
+                            <ListItem
+                              key={tool}
+                              icon={
+                                <Icon isInline style={{ fontSize: '12px' }}>
+                                  <CodeIcon />
+                                </Icon>
+                              }
+                              data-testid={`skill-allowed-tool-${tool}`}
+                              style={{ lineHeight: '22px' }}
+                            >
+                              {tool}
+                            </ListItem>
+                          ))}
+                        </List>
+                      </div>
+                    </DescriptionListDescription>
+                  </DescriptionListGroup>
+                )}
+              </DescriptionList>
+            </CardBody>
+          </Card>
+        </SidebarPanel>
+      </Sidebar>
+    </PageSection>
+  );
+};
+
+export default SkillDetailsView;

--- a/clients/ui/frontend/src/app/pages/skillCatalog/screens/__tests__/SkillDetailsView.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/screens/__tests__/SkillDetailsView.spec.tsx
@@ -1,0 +1,54 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SkillDetailsView from '~/app/pages/skillCatalog/screens/SkillDetailsView';
+import type { Skill } from '~/app/skillCatalogTypes';
+
+// react-markdown ships ESM that jest does not transform, so the renderer is stubbed.
+// Nothing here asserts on README content.
+jest.mock('~/app/shared/markdown/MarkdownComponent', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('~/app/hooks/skillCatalog/useSkillMarketplace', () => ({
+  useSkillMarketplace: () => [null, true, undefined],
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>{children}</MemoryRouter>
+);
+
+const baseSkill: Skill = {
+  id: '1',
+  name: 'diagnosing-bugs',
+  displayName: 'Diagnosing Bugs',
+  description: 'Test description.',
+  repository: 'https://github.com/mattpocock/skills.git',
+  path: 'skills/engineering/diagnosing-bugs',
+  version: 'v1.2.3',
+};
+
+describe('SkillDetailsView skill length', () => {
+  it('shows the line count in green for a body within the recommended maximum', () => {
+    render(<SkillDetailsView skill={{ ...baseSkill, bodyLineCount: 120 }} />, { wrapper });
+
+    const label = screen.getByTestId('skill-body-line-count');
+    expect(label).toHaveTextContent('120 lines');
+    expect(label).toHaveClass('pf-m-green');
+  });
+
+  it('shows the line count in orange once it exceeds the recommended maximum', () => {
+    render(<SkillDetailsView skill={{ ...baseSkill, bodyLineCount: 1240 }} />, { wrapper });
+
+    const label = screen.getByTestId('skill-body-line-count');
+    expect(label).toHaveTextContent('1240 lines');
+    expect(label).toHaveClass('pf-m-orange');
+  });
+
+  it('omits the row entirely when the catalog did not report a line count', () => {
+    render(<SkillDetailsView skill={baseSkill} />, { wrapper });
+    expect(screen.queryByTestId('skill-body-line-count')).not.toBeInTheDocument();
+  });
+});

--- a/clients/ui/frontend/src/app/pages/skillCatalog/types/skillCatalogFilterOptions.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/types/skillCatalogFilterOptions.ts
@@ -1,0 +1,15 @@
+import type { CatalogFilterStringOption } from '~/app/shared/components/catalog';
+
+export type SkillFilterCategoryKey = 'provider' | 'trustTier' | 'category';
+
+export type SkillCatalogFiltersState = {
+  [K in SkillFilterCategoryKey]?: string[];
+};
+
+export type SkillCatalogFilterOptions = {
+  [key in SkillFilterCategoryKey]?: CatalogFilterStringOption;
+};
+
+export type SkillCatalogFilterOptionsList = {
+  filters?: SkillCatalogFilterOptions;
+};

--- a/clients/ui/frontend/src/app/pages/skillCatalog/utils/__tests__/formatSkillVersion.spec.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/utils/__tests__/formatSkillVersion.spec.ts
@@ -1,0 +1,26 @@
+import { formatSkillVersion } from '~/app/pages/skillCatalog/utils/skillCatalogUtils';
+
+describe('formatSkillVersion', () => {
+  it('abbreviates a full 40-character commit SHA to 7 characters', () => {
+    expect(formatSkillVersion('9f8c1a2b3d4e5f60718293a4b5c6d7e8f9012345')).toBe('9f8c1a2');
+  });
+
+  it('abbreviates an uppercase SHA too', () => {
+    expect(formatSkillVersion('9F8C1A2B3D4E5F60718293A4B5C6D7E8F9012345')).toBe('9F8C1A2');
+  });
+
+  it('leaves a semver tag untouched', () => {
+    expect(formatSkillVersion('v1.2.3')).toBe('v1.2.3');
+  });
+
+  it('leaves a short hex-looking tag untouched', () => {
+    // A tag may legitimately be named like an abbreviated SHA; truncating it would
+    // misreport the version, so only exact 40-character hashes are shortened.
+    expect(formatSkillVersion('abc1234')).toBe('abc1234');
+  });
+
+  it('leaves a 40-character non-hex string untouched', () => {
+    const value = 'z'.repeat(40);
+    expect(formatSkillVersion(value)).toBe(value);
+  });
+});

--- a/clients/ui/frontend/src/app/pages/skillCatalog/utils/__tests__/parseAllowedTools.spec.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/utils/__tests__/parseAllowedTools.spec.ts
@@ -1,0 +1,38 @@
+import { parseAllowedTools } from '~/app/pages/skillCatalog/utils/skillCatalogUtils';
+
+describe('parseAllowedTools', () => {
+  it('returns an empty array when allowedTools is undefined or empty', () => {
+    expect(parseAllowedTools(undefined)).toEqual([]);
+    expect(parseAllowedTools([])).toEqual([]);
+  });
+
+  it('rejoins whitespace-split fragments and splits on comma into one entry per tool pattern', () => {
+    // Real shape returned by the catalog API: a single "Bash(aws logs tail:*)"
+    // pattern arrives split into three array entries by an upstream whitespace split.
+    const allowedTools = [
+      'Bash(aws',
+      'logs',
+      'describe-log-groups:*),Bash(aws',
+      'logs',
+      'tail:*),Bash(*/tools/*/install.sh:*)',
+    ];
+
+    expect(parseAllowedTools(allowedTools)).toEqual([
+      'Bash(aws logs describe-log-groups:*)',
+      'Bash(aws logs tail:*)',
+      'Bash(*/tools/*/install.sh:*)',
+    ]);
+  });
+
+  it('leaves a single, already-clean pattern unchanged', () => {
+    expect(parseAllowedTools(['Bash(git diff:*)'])).toEqual(['Bash(git diff:*)']);
+  });
+
+  it('splits a single array entry containing multiple comma-separated patterns', () => {
+    expect(
+      parseAllowedTools([
+        'Bash(*/gitlab-branch-manager/scripts/*.sh:*),Bash(*/tools/*/install.sh:*)',
+      ]),
+    ).toEqual(['Bash(*/gitlab-branch-manager/scripts/*.sh:*)', 'Bash(*/tools/*/install.sh:*)']);
+  });
+});

--- a/clients/ui/frontend/src/app/pages/skillCatalog/utils/__tests__/skillInstallCommands.spec.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/utils/__tests__/skillInstallCommands.spec.ts
@@ -1,0 +1,48 @@
+import {
+  buildManualCommand,
+  buildNpxCommand,
+} from '~/app/pages/skillCatalog/utils/skillInstallCommands';
+import type { Skill } from '~/app/skillCatalogTypes';
+
+const baseSkill: Skill = {
+  id: '1',
+  name: 'diagnosing-bugs',
+  repository: 'https://github.com/mattpocock/skills.git',
+  path: 'skills/engineering/diagnosing-bugs',
+};
+
+describe('buildNpxCommand', () => {
+  it('scopes the install to this skill via --skill, rather than the whole repository', () => {
+    expect(buildNpxCommand(baseSkill)).toBe(
+      'npx skills add https://github.com/mattpocock/skills.git --skill diagnosing-bugs',
+    );
+  });
+});
+
+describe('buildManualCommand', () => {
+  it('copies from the local clone directory git clone actually creates, not the remote URL', () => {
+    const command = buildManualCommand(baseSkill);
+    const [cloneLine, cpLine] = command.split('\n');
+
+    expect(cloneLine).toBe('git clone https://github.com/mattpocock/skills.git');
+    // `git clone <url>` creates a local dir named after the repo ("skills"), not the URL.
+    expect(cpLine).toBe(
+      'cp -r skills/skills/engineering/diagnosing-bugs ~/.claude/skills/diagnosing-bugs',
+    );
+  });
+
+  it('strips a trailing slash before deriving the clone directory name', () => {
+    const command = buildManualCommand({
+      ...baseSkill,
+      repository: 'https://github.com/mattpocock/skills.git/',
+    });
+    expect(command.split('\n')[1]).toContain('cp -r skills/');
+  });
+
+  it('falls back to the skill name when path is absent', () => {
+    const command = buildManualCommand({ ...baseSkill, path: undefined });
+    expect(command.split('\n')[1]).toBe(
+      'cp -r skills/diagnosing-bugs ~/.claude/skills/diagnosing-bugs',
+    );
+  });
+});

--- a/clients/ui/frontend/src/app/pages/skillCatalog/utils/skillCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/utils/skillCatalogUtils.ts
@@ -1,0 +1,44 @@
+import { hasFiltersApplied, stringFiltersToFilterQuery } from '~/app/shared/components/catalog';
+import { SKILL_FILTER_KEYS } from '~/app/pages/skillCatalog/const';
+import type { SkillCatalogFiltersState } from '~/app/pages/skillCatalog/types/skillCatalogFilterOptions';
+
+export const hasSkillFiltersApplied = (
+  filters: SkillCatalogFiltersState,
+  searchQuery: string,
+): boolean => hasFiltersApplied(filters, SKILL_FILTER_KEYS, searchQuery);
+
+export function skillFiltersToFilterQuery(filters: SkillCatalogFiltersState): string {
+  return stringFiltersToFilterQuery(filters, {});
+}
+
+/**
+ * The catalog API's allowedTools array is comma-delimited tool patterns
+ * (e.g. "Bash(git diff:*)") that have additionally been split on whitespace
+ * upstream, so a single pattern like "Bash(aws logs tail:*)" arrives as three
+ * separate array entries. Rejoining with spaces reconstructs the original
+ * comma-delimited string, which is then split on "," to recover one entry
+ * per tool pattern.
+ */
+export function parseAllowedTools(allowedTools?: string[]): string[] {
+  if (!allowedTools || allowedTools.length === 0) {
+    return [];
+  }
+  return allowedTools
+    .join(' ')
+    .split(',')
+    .map((tool) => tool.trim())
+    .filter(Boolean);
+}
+
+/**
+ * A skill's version is the ref it was indexed at — a tag, a release, or a commit SHA.
+ * A full SHA is 40 characters and would dominate a gallery card, so it is abbreviated
+ * to the 7 characters git itself uses for short hashes.
+ *
+ * Only an exact 40-character hex string is abbreviated. Shorter hex-looking values are
+ * left alone: a tag may legitimately be named something like "abc1234", and truncating
+ * it would misreport the version.
+ */
+export function formatSkillVersion(version: string): string {
+  return /^[0-9a-f]{40}$/i.test(version) ? version.slice(0, 7) : version;
+}

--- a/clients/ui/frontend/src/app/pages/skillCatalog/utils/skillInstallCommands.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/utils/skillInstallCommands.ts
@@ -1,0 +1,30 @@
+import type { Skill } from '~/app/skillCatalogTypes';
+
+// The bare `npx skills add <repo-url>` form installs every skill the repository
+// carries. `--skill <name>` scopes the install to the one skill the user picked in
+// the catalog, matching the per-skill install offered by the Claude Code and Manual
+// tabs. skill.name is the leaf identifier the CLI expects (e.g. "find-skills"), not
+// the full in-repo path.
+export const buildNpxCommand = (skill: Skill): string => {
+  const repository = skill.repository ?? skill.repositoryUrl ?? '';
+  return `npx skills add ${repository} --skill ${skill.name}`;
+};
+
+// `git clone <repository>` creates a local directory named after the repository, not the
+// URL itself — this recovers that local directory name (last path segment, minus ".git")
+// so the cp source in buildManualCommand refers to a real local path.
+const getCloneDirName = (repository: string): string => {
+  const withoutTrailingSlash = repository.replace(/\/+$/, '');
+  const lastSegment = withoutTrailingSlash.split('/').pop() ?? withoutTrailingSlash;
+  return lastSegment.replace(/\.git$/, '');
+};
+
+export const buildManualCommand = (skill: Skill): string => {
+  const repository = skill.repository ?? skill.repositoryUrl ?? '';
+  const cloneDir = getCloneDirName(repository);
+  const installDir = `~/.claude/skills/${skill.name}`;
+  return [
+    `git clone ${repository}`,
+    `cp -r ${cloneDir}/${skill.path ?? skill.name} ${installDir}`,
+  ].join('\n');
+};

--- a/clients/ui/frontend/src/app/pages/skillCatalog/utils/skillSupportingFilesTree.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalog/utils/skillSupportingFilesTree.tsx
@@ -1,0 +1,76 @@
+import type { Skill } from '~/app/skillCatalogTypes';
+
+export type FileTreeNode = {
+  id: string;
+  name: string;
+  /** Present on leaf (file) nodes — clicking the row opens this URL. */
+  url?: string;
+  children?: FileTreeNode[];
+};
+
+const stripGitSuffix = (url: string): string => url.replace(/\.git$/, '');
+
+export const getSupportingFileUrl = (skill: Skill, filePath: string): string | undefined => {
+  if (!skill.repository) {
+    return undefined;
+  }
+  const ref = skill.resolvedCommit || skill.version;
+  if (!ref) {
+    return undefined;
+  }
+  return `${stripGitSuffix(skill.repository)}/blob/${ref}/${filePath}`;
+};
+
+type MutableNode = {
+  name: string;
+  relativePath: string;
+  url?: string;
+  children: Map<string, MutableNode>;
+};
+
+const toFileTreeNodes = (node: MutableNode): FileTreeNode[] =>
+  Array.from(node.children.values()).map((child) => {
+    const hasChildren = child.children.size > 0;
+    return {
+      id: child.relativePath,
+      name: child.name,
+      url: hasChildren ? undefined : child.url,
+      children: hasChildren ? toFileTreeNodes(child) : undefined,
+    };
+  });
+
+// Builds a compact file-browser tree from a skill's flat supportingFiles paths, rooted at
+// the skill's own directory.
+export const buildSupportingFilesTree = (skill: Skill): FileTreeNode | undefined => {
+  if (!skill.supportingFiles || skill.supportingFiles.length === 0) {
+    return undefined;
+  }
+
+  const rootPrefix = skill.path ? `${skill.path}/` : '';
+  const root: MutableNode = { name: '', relativePath: '', children: new Map() };
+
+  skill.supportingFiles.forEach((filePath) => {
+    const relative = filePath.startsWith(rootPrefix) ? filePath.slice(rootPrefix.length) : filePath;
+    const segments = relative.split('/').filter(Boolean);
+
+    let node = root;
+    let cumulativePath = '';
+    segments.forEach((segment) => {
+      cumulativePath = cumulativePath ? `${cumulativePath}/${segment}` : segment;
+      let child = node.children.get(segment);
+      if (!child) {
+        child = { name: segment, relativePath: cumulativePath, children: new Map() };
+        node.children.set(segment, child);
+      }
+      node = child;
+    });
+
+    node.url = getSupportingFileUrl(skill, filePath);
+  });
+
+  return {
+    id: 'root',
+    name: skill.path || skill.name,
+    children: toFileTreeNodes(root),
+  };
+};

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/SkillCatalogSettingsRoutes.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/SkillCatalogSettingsRoutes.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import CatalogSettingsRoutes from '~/app/shared/catalogSettings/CatalogSettingsRoutes';
+import { skillCatalogSettingsDefinition } from './definition';
+
+const SkillCatalogSettingsRoutes: React.FC = () => (
+  <CatalogSettingsRoutes definition={skillCatalogSettingsDefinition} />
+);
+
+export default SkillCatalogSettingsRoutes;

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillCatalogSourceStatus.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillCatalogSourceStatus.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import {
+  Button,
+  Label,
+  Spinner,
+  Stack,
+  StackItem,
+  Tooltip,
+  Truncate,
+} from '@patternfly/react-core';
+import { InProgressIcon } from '@patternfly/react-icons';
+import type { SkillCatalogSourceConfig } from '~/app/skillCatalogTypes';
+import { SkillCatalogSettingsContext } from '~/app/context/skillCatalogSettings/SkillCatalogSettingsContext';
+import { CatalogSourceStatus } from '~/app/shared/types/catalogTypes';
+import CatalogSourceStatusErrorModal from '~/app/pages/modelCatalogSettings/components/CatalogSourceStatusErrorModal';
+
+type SkillCatalogSourceStatusProps = {
+  skillCatalogSourceConfig: SkillCatalogSourceConfig;
+};
+
+const SkillCatalogSourceStatus: React.FC<SkillCatalogSourceStatusProps> = ({
+  skillCatalogSourceConfig,
+}) => {
+  const {
+    skillCatalogSources,
+    skillCatalogSourcesLoaded,
+    skillCatalogSourcesLoadError,
+    isSkillSourceSyncPending,
+  } = React.useContext(SkillCatalogSettingsContext);
+  const [isErrorModalOpen, setIsErrorModalOpen] = React.useState(false);
+
+  if (!skillCatalogSourceConfig.enabled || skillCatalogSourceConfig.isDefault) {
+    return <>-</>;
+  }
+
+  // Takes precedence over the reported status: until the catalog confirms the
+  // reload, the status it returns describes the previous sync, so showing "Ready"
+  // here would claim the edit had already been applied.
+  if (isSkillSourceSyncPending(skillCatalogSourceConfig.id)) {
+    return (
+      <Tooltip content="Changes saved. The catalog is re-reading its configuration and re-indexing the repositories; skills can take a few minutes to update.">
+        <Label
+          color="blue"
+          variant="outline"
+          icon={<Spinner size="sm" />}
+          data-testid={`skill-source-status-syncing-${skillCatalogSourceConfig.id}`}
+        >
+          Syncing
+        </Label>
+      </Tooltip>
+    );
+  }
+
+  if (!skillCatalogSourcesLoaded) {
+    return (
+      <Spinner
+        size="md"
+        data-testid={`skill-source-status-loading-${skillCatalogSourceConfig.id}`}
+      />
+    );
+  }
+
+  const matchingSource = skillCatalogSources?.items?.find(
+    (source) => source.id === skillCatalogSourceConfig.id,
+  );
+
+  const startingOrUnknownLabel = (
+    <Label
+      color="grey"
+      variant="outline"
+      icon={<InProgressIcon />}
+      data-testid={`skill-source-status-${skillCatalogSourcesLoadError ? 'unknown' : 'starting'}-${skillCatalogSourceConfig.id}`}
+    >
+      {skillCatalogSourcesLoadError ? 'Unknown' : 'Starting'}
+    </Label>
+  );
+
+  if (!matchingSource || !matchingSource.status) {
+    return startingOrUnknownLabel;
+  }
+
+  switch (matchingSource.status) {
+    case CatalogSourceStatus.AVAILABLE:
+      return (
+        <Label
+          status="success"
+          variant="outline"
+          data-testid={`skill-source-status-connected-${skillCatalogSourceConfig.id}`}
+        >
+          Ready
+        </Label>
+      );
+
+    case CatalogSourceStatus.ERROR: {
+      const errorMessage = matchingSource.error || 'Unknown error occurred';
+
+      return (
+        <>
+          <Stack hasGutter>
+            <StackItem>
+              <Label
+                status="danger"
+                variant="outline"
+                data-testid={`skill-source-status-failed-${skillCatalogSourceConfig.id}`}
+              >
+                Failed
+              </Label>
+            </StackItem>
+            <StackItem>
+              <Button
+                variant="link"
+                isInline
+                isDanger
+                onClick={() => setIsErrorModalOpen(true)}
+                data-testid={`skill-source-status-error-link-${skillCatalogSourceConfig.id}`}
+              >
+                <Truncate content={errorMessage} tooltipProps={{ hidden: true }} />
+              </Button>
+            </StackItem>
+          </Stack>
+          <CatalogSourceStatusErrorModal
+            isOpen={isErrorModalOpen}
+            onClose={() => setIsErrorModalOpen(false)}
+            errorMessage={errorMessage}
+          />
+        </>
+      );
+    }
+
+    case CatalogSourceStatus.DISABLED:
+      return startingOrUnknownLabel;
+    default:
+      return startingOrUnknownLabel;
+  }
+};
+
+export default SkillCatalogSourceStatus;

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillManageSourceForm.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillManageSourceForm.tsx
@@ -1,0 +1,332 @@
+import * as React from 'react';
+import {
+  Button,
+  Checkbox,
+  Form,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Label,
+  LabelGroup,
+  Stack,
+  StackItem,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+import { useNavigate } from 'react-router-dom';
+import FormSection from '~/app/pages/modelRegistry/components/pf-overrides/FormSection';
+import {
+  validateSourceName,
+  SOURCE_NAME_CHARACTER_LIMIT,
+  generateSourceIdFromName,
+} from '~/app/shared/catalogSettings';
+import { skillCatalogSettingsUrl } from '~/app/routes/skillCatalogSettings/skillCatalogSettings';
+import { SkillCatalogSettingsContext } from '~/app/context/skillCatalogSettings/SkillCatalogSettingsContext';
+import type { SkillCatalogSourceConfig } from '~/app/skillCatalogTypes';
+import { SkillCatalogSourceType } from '~/app/skillCatalogTypes';
+import { useManageSkillSourceData } from '~/app/pages/skillCatalogSettings/useManageSkillSourceData';
+import type { ManageSkillSourceFormData } from '~/app/pages/skillCatalogSettings/useManageSkillSourceData';
+import { useSkillSourcePreview } from '~/app/pages/skillCatalogSettings/useSkillSourcePreview';
+import { findConflictingSource } from '~/app/pages/skillCatalogSettings/utils/duplicateSourceName';
+import SkillSourceDetailsSection from './SkillSourceDetailsSection';
+import SkillRepositoriesSection from './SkillRepositoriesSection';
+import SkillPreviewPanel from './SkillPreviewPanel';
+import SkillManageSourceFormFooter from './SkillManageSourceFormFooter';
+
+const sourceConfigToFormData = (config: SkillCatalogSourceConfig): ManageSkillSourceFormData => {
+  const firstRepo = config.repositories?.[0] ?? { url: '' };
+  const remainingRepos = config.repositories?.slice(1) ?? [];
+  return {
+    id: config.id,
+    name: config.name,
+    enabled: config.enabled ?? true,
+    repositories: [
+      {
+        ...firstRepo,
+        provider: firstRepo.provider ?? config.provider,
+        category: firstRepo.category ?? config.category,
+        trustTier: firstRepo.trustTier ?? config.trustTier,
+      },
+      ...remainingRepos,
+    ],
+    labels: config.labels ?? [],
+  };
+};
+
+const isFormValid = (formData: ManageSkillSourceFormData): boolean =>
+  validateSourceName(formData.name, SOURCE_NAME_CHARACTER_LIMIT) &&
+  // A source managed through this form carries exactly one repository, which is what
+  // the BFF and the catalog service's inline form accept. A source that already lists
+  // several was written outside the UI; saving it here would be rejected, so the form
+  // blocks instead of offering a save that cannot succeed.
+  formData.repositories.length === 1 &&
+  formData.repositories.every((r) => r.url.trim().length > 0) &&
+  // The catalog service skips a repository that lists no refs ("no refs configured;
+  // skills must be pinned to a tag or commit SHA"), so a source saved without one can
+  // only ever sync to Failed. The refs field's own helper text already says at least
+  // one is required — enforce it here rather than offering a save that cannot work.
+  formData.repositories.every((r) => (r.refs?.length ?? 0) > 0);
+
+type SkillManageSourceFormProps = {
+  existingSourceConfig?: SkillCatalogSourceConfig;
+  isEditMode: boolean;
+};
+
+const SkillManageSourceForm: React.FC<SkillManageSourceFormProps> = ({
+  existingSourceConfig,
+  isEditMode,
+}) => {
+  const navigate = useNavigate();
+  const existingData = existingSourceConfig
+    ? sourceConfigToFormData(existingSourceConfig)
+    : undefined;
+  const [formData, setData] = useManageSkillSourceData(existingData);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const [submitError, setSubmitError] = React.useState<Error | undefined>(undefined);
+  const [labelInputValue, setLabelInputValue] = React.useState('');
+  const {
+    apiState,
+    skillCatalogSourceConfigs,
+    refreshSkillCatalogSourceConfigs,
+    refreshSkillCatalogSources,
+    markSkillSourceSyncPending,
+  } = React.useContext(SkillCatalogSettingsContext);
+
+  // The source id is derived from the name and is not editable, so two sources named
+  // alike collide on id. The BFF rejects that with "already exists" — but only after
+  // submit, and on create it is the same key the colliding source's git token is stored
+  // under. Surfacing it on the name field keeps the admin from getting that far.
+  const duplicateNameError = React.useMemo(() => {
+    if (isEditMode) {
+      return undefined;
+    }
+    const clash = findConflictingSource(formData.name, skillCatalogSourceConfigs);
+    return clash
+      ? `The source "${clash.name}" already uses the identifier "${generateSourceIdFromName(formData.name)}". Choose a different name.`
+      : undefined;
+  }, [isEditMode, formData.name, skillCatalogSourceConfigs]);
+
+  const isComplete = isFormValid(formData) && !duplicateNameError;
+
+  const preview = useSkillSourcePreview({
+    formData,
+    existingSourceConfig,
+    apiState,
+    isEditMode,
+  });
+
+  const addLabel = () => {
+    const trimmed = labelInputValue.trim();
+    if (trimmed && !formData.labels.includes(trimmed)) {
+      setData('labels', [...formData.labels, trimmed]);
+    }
+    setLabelInputValue('');
+  };
+
+  const removeLabel = (label: string) => {
+    setData(
+      'labels',
+      formData.labels.filter((l) => l !== label),
+    );
+  };
+
+  const handleSubmit = async () => {
+    if (!apiState.apiAvailable) {
+      setSubmitError(new Error('API is not available'));
+      return;
+    }
+    setIsSubmitting(true);
+    setSubmitError(undefined);
+
+    try {
+      // Commit whatever is still sitting in the label box. Requiring Enter before
+      // Save silently dropped the label the admin had just typed.
+      const pendingLabel = labelInputValue.trim();
+      const labels =
+        pendingLabel && !formData.labels.includes(pendingLabel)
+          ? [...formData.labels, pendingLabel]
+          : formData.labels;
+
+      const filledRepos = formData.repositories.filter((r) => r.url.trim().length > 0);
+      const firstRepo = filledRepos[0] ?? {};
+      // Strip repo-form-only fields before sending; they travel as source-level API fields
+      // so the BFF writes them into each repository entry in the YAML.
+      const repositories = filledRepos.map((r) => {
+        const repo = { ...r };
+        delete repo.provider;
+        delete repo.category;
+        delete repo.trustTier;
+        return repo;
+      });
+
+      const optionalFields = {
+        ...(firstRepo.trustTier ? { trustTier: firstRepo.trustTier } : {}),
+        ...(firstRepo.provider ? { provider: firstRepo.provider } : {}),
+        ...(firstRepo.category ? { category: firstRepo.category } : {}),
+      };
+
+      // generateSourceIdFromName strips characters a Kubernetes object name/Secret data
+      // key can't contain (e.g. apostrophes); a plain slugify (lowercase + hyphenate
+      // whitespace) lets them through and creating the source fails opaquely once a git
+      // token is added, because the id is also used as the credential Secret's data key.
+      const savedSourceId = isEditMode ? formData.id : generateSourceIdFromName(formData.name);
+
+      if (isEditMode && existingSourceConfig) {
+        await apiState.api.updateSkillCatalogSourceConfig({}, formData.id, {
+          enabled: formData.enabled,
+          repositories,
+          // Always sent on edit, empty array included: the BFF treats an omitted
+          // labels field as "leave as-is", so skipping it would make removing the
+          // last label a silent no-op.
+          labels,
+          ...optionalFields,
+        });
+      } else {
+        await apiState.api.createSkillCatalogSourceConfig(
+          {},
+          {
+            id: savedSourceId,
+            name: formData.name,
+            type: SkillCatalogSourceType.GIT_SKILLS,
+            enabled: formData.enabled,
+            repositories,
+            ...(labels.length > 0 ? { labels } : {}),
+            ...optionalFields,
+          },
+        );
+      }
+
+      // The write only lands in a ConfigMap; the catalog reloads asynchronously.
+      // Flag the source so the list shows "Syncing" rather than the stale status,
+      // and pull the source list now instead of waiting out the poll interval.
+      markSkillSourceSyncPending(savedSourceId);
+      refreshSkillCatalogSourceConfigs();
+      refreshSkillCatalogSources();
+      navigate(skillCatalogSettingsUrl());
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error : new Error('Failed to save source'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCancel = () => {
+    navigate(skillCatalogSettingsUrl());
+  };
+
+  return (
+    <>
+      <Sidebar hasBorder isPanelRight hasGutter>
+        <SidebarContent>
+          <Form isWidthLimited>
+            <Stack hasGutter>
+              <StackItem>
+                <SkillSourceDetailsSection
+                  duplicateNameError={duplicateNameError}
+                  formData={formData}
+                  setData={setData}
+                  isEditMode={isEditMode}
+                />
+              </StackItem>
+
+              <StackItem>
+                <SkillRepositoriesSection
+                  repositories={formData.repositories}
+                  onChange={(repos) => setData('repositories', repos)}
+                />
+              </StackItem>
+
+              <StackItem>
+                <FormSection title="Source metadata">
+                  <FormGroup label="Source labels" fieldId="skill-source-labels">
+                    {formData.labels.length > 0 && (
+                      <LabelGroup style={{ marginBottom: 'var(--pf-t--global--spacer--sm)' }}>
+                        {formData.labels.map((label) => (
+                          <Label key={label} onClose={() => removeLabel(label)}>
+                            {label}
+                          </Label>
+                        ))}
+                      </LabelGroup>
+                    )}
+                    <TextInputGroup>
+                      <TextInputGroupMain
+                        id="skill-source-labels-input"
+                        data-testid="skill-source-labels-input"
+                        value={labelInputValue}
+                        onChange={(_event, value) => setLabelInputValue(value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            addLabel();
+                          }
+                        }}
+                        placeholder="Type a label and press Enter"
+                      />
+                      {labelInputValue && (
+                        <TextInputGroupUtilities>
+                          <Button
+                            variant="plain"
+                            onClick={() => setLabelInputValue('')}
+                            aria-label="Clear label input"
+                          >
+                            <TimesIcon />
+                          </Button>
+                        </TextInputGroupUtilities>
+                      )}
+                    </TextInputGroup>
+                    <FormHelperText>
+                      <HelperText>
+                        <HelperTextItem>
+                          Group this source in the skill catalog&apos;s source selector. To label
+                          the skills themselves, use <b>Skill labels</b> on the repository above.
+                        </HelperTextItem>
+                      </HelperText>
+                    </FormHelperText>
+                  </FormGroup>
+                </FormSection>
+              </StackItem>
+
+              <StackItem>
+                <FormSection>
+                  <FormGroup fieldId="skill-enable-source">
+                    <Checkbox
+                      label={<span className="pf-v6-c-form__label-text">Enable source</span>}
+                      id="skill-enable-source"
+                      name="skill-enable-source"
+                      data-testid="skill-enable-source-checkbox"
+                      description="Enable users in your organization to view skills from this source in the skill catalog."
+                      isChecked={formData.enabled}
+                      onChange={(_event, checked) => setData('enabled', checked)}
+                    />
+                  </FormGroup>
+                </FormSection>
+              </StackItem>
+            </Stack>
+          </Form>
+        </SidebarContent>
+        <SidebarPanel width={{ default: 'width_50' }}>
+          <SkillPreviewPanel preview={preview} />
+        </SidebarPanel>
+      </Sidebar>
+      <SkillManageSourceFormFooter
+        submitLabel={isEditMode ? 'Save' : 'Add'}
+        submitError={submitError}
+        isSubmitDisabled={!isComplete || isSubmitting}
+        isSubmitting={isSubmitting}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+        isPreviewDisabled={!preview.canPreview}
+        isPreviewLoading={preview.previewState.isLoadingInitial}
+        onPreview={preview.handlePreview}
+      />
+    </>
+  );
+};
+
+export default SkillManageSourceForm;

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillManageSourceFormFooter.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillManageSourceFormFooter.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import {
+  PageSection,
+  Stack,
+  StackItem,
+  Button,
+  ActionList,
+  ActionListItem,
+  ActionListGroup,
+  Alert,
+} from '@patternfly/react-core';
+
+type SkillManageSourceFormFooterProps = {
+  submitLabel: string;
+  submitError?: Error;
+  isSubmitDisabled: boolean;
+  isSubmitting: boolean;
+  onSubmit: () => void;
+  onCancel: () => void;
+  isPreviewDisabled: boolean;
+  isPreviewLoading: boolean;
+  onPreview: () => void;
+};
+
+const SkillManageSourceFormFooter: React.FC<SkillManageSourceFormFooterProps> = ({
+  submitLabel,
+  submitError,
+  isSubmitDisabled,
+  isSubmitting,
+  onSubmit,
+  onCancel,
+  isPreviewDisabled,
+  isPreviewLoading,
+  onPreview,
+}) => (
+  <PageSection hasBodyWrapper={false} stickyOnBreakpoint={{ default: 'bottom' }}>
+    <Stack hasGutter>
+      {submitError && (
+        <StackItem>
+          <Alert variant="danger" isInline title="Failed to save source">
+            {submitError.message}
+          </Alert>
+        </StackItem>
+      )}
+      <StackItem>
+        <ActionList>
+          <ActionListGroup>
+            <ActionListItem>
+              <Button
+                isDisabled={isSubmitDisabled || isPreviewLoading}
+                variant="primary"
+                id="skill-submit-button"
+                data-testid="skill-submit-button"
+                isLoading={isSubmitting}
+                onClick={onSubmit}
+              >
+                {submitLabel}
+              </Button>
+            </ActionListItem>
+            <ActionListItem>
+              <Button
+                variant="secondary"
+                onClick={onPreview}
+                isDisabled={isPreviewDisabled}
+                isLoading={isPreviewLoading}
+                data-testid="skill-preview-button"
+              >
+                Preview
+              </Button>
+            </ActionListItem>
+            <ActionListItem>
+              <Button
+                isDisabled={isSubmitting || isPreviewLoading}
+                variant="link"
+                id="skill-cancel-button"
+                data-testid="skill-cancel-button"
+                onClick={onCancel}
+              >
+                Cancel
+              </Button>
+            </ActionListItem>
+          </ActionListGroup>
+        </ActionList>
+      </StackItem>
+    </Stack>
+  </PageSection>
+);
+
+export default SkillManageSourceFormFooter;

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillPreviewPanel.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillPreviewPanel.tsx
@@ -1,0 +1,239 @@
+import * as React from 'react';
+import {
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateActions,
+  ExpandableSection,
+  Flex,
+  FlexItem,
+  Title,
+  Tabs,
+  Tab,
+  TabTitleText,
+  Alert,
+  List,
+  ListItem,
+  Spinner,
+  Button,
+  AlertActionLink,
+} from '@patternfly/react-core';
+import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
+import { UseSkillSourcePreviewResult } from '~/app/pages/skillCatalogSettings/useSkillSourcePreview';
+import { CatalogSettingsPreviewTab } from '~/app/shared/catalogSettings/hooks/previewTypes';
+
+type SkillPreviewPanelProps = {
+  preview: UseSkillSourcePreviewResult;
+};
+
+const SkillPreviewPanel: React.FC<SkillPreviewPanelProps> = ({ preview }) => {
+  const {
+    previewState,
+    handlePreview: onPreview,
+    handleTabChange,
+    handleLoadMore: onLoadMore,
+    hasFormChanged,
+    canPreview,
+  } = preview;
+  const { isLoadingInitial, isLoadingMore, activeTab, summary, tabStates, error } = previewState;
+  const { items, hasMore } = tabStates[activeTab];
+
+  const handleTabSelect = (_event: React.MouseEvent, tabIndex: string | number) => {
+    handleTabChange(
+      tabIndex === 0 ? CatalogSettingsPreviewTab.INCLUDED : CatalogSettingsPreviewTab.EXCLUDED,
+    );
+  };
+
+  const renderEmptyState = () => {
+    if (error) {
+      return (
+        <EmptyState
+          icon={TimesCircleIcon}
+          titleText="Preview failed"
+          variant={EmptyStateVariant.sm}
+        >
+          <EmptyStateBody>
+            {/* Preview runs without the Auth token field: buildPreviewRequest strips it,
+                and the catalog service resolves credentials only through a stored
+                credentialRef. So a private repository can only be previewed once the
+                source has been saved — telling the admin to fill in the token here would
+                send them down a dead end. */}
+            <p>
+              We couldn&apos;t load skills from this repository. Double-check that the repository
+              URL above is correct and reachable from the cluster. Previewing a private repository
+              requires its token to be stored first — save the source, then preview it from the edit
+              form.
+            </p>
+            <ExpandableSection
+              toggleText="Show error details"
+              className="pf-v6-u-mt-sm pf-v6-u-text-align-left"
+              data-testid="skill-preview-error-details"
+            >
+              <p className="pf-v6-u-color-200 pf-v6-u-font-size-sm">{error.message}</p>
+            </ExpandableSection>
+          </EmptyStateBody>
+          <EmptyStateFooter>
+            <EmptyStateActions>
+              <Button
+                variant="link"
+                onClick={onPreview}
+                isDisabled={!canPreview}
+                isLoading={isLoadingInitial}
+                data-testid="skill-preview-button-panel-retry"
+              >
+                Preview
+              </Button>
+            </EmptyStateActions>
+          </EmptyStateFooter>
+        </EmptyState>
+      );
+    }
+
+    return (
+      <EmptyState titleText="Preview skills" variant={EmptyStateVariant.sm}>
+        <EmptyStateBody>
+          Complete all required fields, then click <strong>Preview</strong> to see which skills will
+          appear in the catalog.
+        </EmptyStateBody>
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <Button
+              variant="link"
+              onClick={onPreview}
+              isDisabled={!canPreview}
+              isLoading={isLoadingInitial}
+              data-testid="skill-preview-button-panel"
+            >
+              Preview
+            </Button>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      </EmptyState>
+    );
+  };
+
+  const renderContent = () => {
+    if (isLoadingInitial) {
+      return (
+        <div className="pf-v6-u-text-align-center pf-v6-u-py-xl">
+          <Spinner size="xl" aria-label="Loading preview" />
+        </div>
+      );
+    }
+
+    if ((!items.length && !summary) || error) {
+      return renderEmptyState();
+    }
+
+    return (
+      <>
+        <Tabs
+          activeKey={activeTab === CatalogSettingsPreviewTab.INCLUDED ? 0 : 1}
+          onSelect={handleTabSelect}
+          aria-label="Skill preview tabs"
+        >
+          <Tab eventKey={0} title={<TabTitleText>Skills included</TabTitleText>} />
+          <Tab eventKey={1} title={<TabTitleText>Skills excluded</TabTitleText>} />
+        </Tabs>
+        <div className="pf-v6-u-mt-md">
+          {hasFormChanged && (
+            <Alert
+              variant="info"
+              isInline
+              title="Source configuration changed. Refresh the preview."
+              className="pf-v6-u-mb-md"
+              actionLinks={
+                <AlertActionLink onClick={onPreview} data-testid="skill-refresh-preview-link">
+                  Refresh preview
+                </AlertActionLink>
+              }
+            />
+          )}
+          {items.length > 0 ? (
+            <>
+              <strong>
+                {activeTab === CatalogSettingsPreviewTab.INCLUDED
+                  ? `${summary?.includedAssets ?? 0} of ${summary?.totalAssets ?? 0} skills included:`
+                  : `${summary?.excludedAssets ?? 0} of ${summary?.totalAssets ?? 0} skills excluded:`}
+              </strong>
+              <List isPlain className="pf-v6-u-mt-md">
+                {items.map((skill) => (
+                  <ListItem
+                    key={skill.name}
+                    icon={
+                      skill.included ? (
+                        <CheckCircleIcon color="green" />
+                      ) : (
+                        <TimesCircleIcon color="red" />
+                      )
+                    }
+                  >
+                    {skill.name}
+                  </ListItem>
+                ))}
+              </List>
+              {hasMore && (
+                <div className="pf-v6-u-mt-md pf-v6-u-text-align-center">
+                  <Button
+                    variant="link"
+                    onClick={onLoadMore}
+                    isLoading={isLoadingMore}
+                    isDisabled={isLoadingMore}
+                  >
+                    {isLoadingMore ? 'Loading...' : 'Load more'}
+                  </Button>
+                </div>
+              )}
+            </>
+          ) : (
+            <EmptyState
+              variant={EmptyStateVariant.sm}
+              titleText={
+                activeTab === CatalogSettingsPreviewTab.INCLUDED
+                  ? 'No skills included'
+                  : 'No skills excluded'
+              }
+            >
+              <EmptyStateBody>
+                {activeTab === CatalogSettingsPreviewTab.INCLUDED
+                  ? 'No skills match the current filter settings.'
+                  : 'All skills from this repository are included.'}
+              </EmptyStateBody>
+            </EmptyState>
+          )}
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <div data-testid="skill-preview-panel" className="pf-v6-u-h-100">
+      <Flex
+        justifyContent={{ default: 'justifyContentSpaceBetween' }}
+        alignItems={{ default: 'alignItemsCenter' }}
+        className="pf-v6-u-mb-md"
+      >
+        <FlexItem>
+          <Title headingLevel="h2" size="lg">
+            Skill catalog preview
+          </Title>
+        </FlexItem>
+        <FlexItem>
+          <Button
+            variant="secondary"
+            onClick={onPreview}
+            isDisabled={!canPreview}
+            isLoading={isLoadingInitial}
+            data-testid="skill-preview-button-header"
+          >
+            Preview
+          </Button>
+        </FlexItem>
+      </Flex>
+      {renderContent()}
+    </div>
+  );
+};
+
+export default SkillPreviewPanel;

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillRepositoriesSection.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillRepositoriesSection.tsx
@@ -1,0 +1,288 @@
+import * as React from 'react';
+import {
+  Alert,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { SimpleSelect } from 'mod-arch-shared';
+import FormSection from '~/app/pages/modelRegistry/components/pf-overrides/FormSection';
+import type { SkillRepository } from '~/app/skillCatalogTypes';
+import { SKILL_TRUST_TIER_OPTIONS } from '~/app/pages/skillCatalog/const';
+
+const arrToComma = (arr?: string[]): string => arr?.join(', ') ?? '';
+
+const commaToArr = (s: string): string[] | undefined => {
+  const items = s
+    .split(',')
+    .map((v) => v.trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : undefined;
+};
+
+type SkillRepositoriesSectionProps = {
+  repositories: SkillRepository[];
+  onChange: (repositories: SkillRepository[]) => void;
+};
+
+const SkillRepositoriesSection: React.FC<SkillRepositoriesSectionProps> = ({
+  repositories,
+  onChange,
+}) => {
+  const repo = repositories[0] ?? { url: '' };
+  // A source written through this form carries a single repository (the loader rejects
+  // an inline list of more than one). A source authored by GitOps before that rule, or
+  // hand-edited since, can still arrive with several: keep the ones this form cannot
+  // show instead of dropping them, so editing the first repository is not destructive.
+  const extraRepositories = repositories.slice(1);
+
+  const handleChange = (patch: Partial<SkillRepository>) => {
+    onChange([{ ...repo, ...patch }, ...extraRepositories]);
+  };
+
+  // Comma-separated fields keep their own raw text as local state, seeded once from the
+  // loaded repo. Deriving the displayed text from the parsed array on every keystroke (via
+  // arrToComma(commaToArr(value))) drops a trailing ", " the moment it's typed — split on
+  // comma trims a still-being-typed empty segment away, so the next character the user types
+  // lands right after the previous label instead of starting a new one.
+  const [refsText, setRefsText] = React.useState(() => arrToComma(repo.refs));
+  const [scanPathsText, setScanPathsText] = React.useState(() => arrToComma(repo.scanPaths));
+  const [includedSkillsText, setIncludedSkillsText] = React.useState(() =>
+    arrToComma(repo.includedSkills),
+  );
+  const [excludedSkillsText, setExcludedSkillsText] = React.useState(() =>
+    arrToComma(repo.excludedSkills),
+  );
+  const [labelsText, setLabelsText] = React.useState(() => arrToComma(repo.labels));
+
+  return (
+    <FormSection title="Git repository">
+      <Stack hasGutter>
+        {extraRepositories.length > 0 && (
+          <StackItem>
+            <Alert
+              isInline
+              variant="danger"
+              title={`This source lists ${repositories.length} repositories and cannot be saved here`}
+              data-testid="skill-multi-repo-warning"
+            >
+              A source managed through this form carries a single repository. This one was
+              configured outside the UI. To edit it, reduce it to one repository in the source
+              ConfigMap, register each repository as its own source, or manage it through
+              yamlCatalogPath.
+            </Alert>
+          </StackItem>
+        )}
+        <StackItem>
+          <FormGroup label="Repository URL" fieldId="skill-repo-url-0" isRequired>
+            <TextInput
+              isRequired
+              type="url"
+              id="skill-repo-url-0"
+              data-testid="skill-repo-url-0"
+              value={repo.url}
+              placeholder="https://github.com/org/repo"
+              onChange={(_event, value) => handleChange({ url: value })}
+            />
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem>URL of a Git repository containing skill files.</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
+        </StackItem>
+
+        <StackItem>
+          <FormGroup label="Auth token" fieldId="skill-repo-auth-token-0">
+            <TextInput
+              type="password"
+              id="skill-repo-auth-token-0"
+              data-testid="skill-repo-auth-token-0"
+              value={repo.authToken ?? ''}
+              placeholder={repo.credentialRef ? '••••••••  (unchanged)' : 'ghp_xxxxxxxxxxxx'}
+              onChange={(_event, value) => handleChange({ authToken: value || undefined })}
+            />
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem>
+                  {repo.credentialRef
+                    ? 'A token is already stored for this source. Leave blank to keep it, or enter a new one to replace it.'
+                    : 'Personal access token for private repositories. Stored in a Kubernetes secret, never in the catalog config.'}
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
+        </StackItem>
+
+        <StackItem>
+          <FormGroup label="Refs" fieldId="skill-repo-refs-0">
+            <TextInput
+              id="skill-repo-refs-0"
+              data-testid="skill-repo-refs-0"
+              value={refsText}
+              placeholder="v1.2.3, 9f8c1a2"
+              onChange={(_event, value) => {
+                setRefsText(value);
+                handleChange({ refs: commaToArr(value) });
+              }}
+            />
+            <FormHelperText>
+              <HelperText>
+                {/* Both rules are enforced by the catalog service, not here: a ref cannot be
+                    told apart from a branch by name, so the resolver asks the remote at sync
+                    time. Stating them here keeps an admin from saving a source that will only
+                    fail later. Running a preview applies the same check before saving. */}
+                <HelperTextItem>
+                  Comma-separated Git tags or commit SHAs to scan, one entry per version. Each ref
+                  becomes its own set of catalog entries.
+                </HelperTextItem>
+                <HelperTextItem>
+                  Branches and HEAD are not accepted — skills must be pinned to an immutable ref so
+                  installs are reproducible. At least one ref is required; a repository with none is
+                  skipped at sync.
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
+        </StackItem>
+
+        <StackItem>
+          <FormGroup label="Scan paths" fieldId="skill-repo-scanpaths-0">
+            <TextInput
+              id="skill-repo-scanpaths-0"
+              data-testid="skill-repo-scanpaths-0"
+              value={scanPathsText}
+              placeholder="skills/"
+              onChange={(_event, value) => {
+                setScanPathsText(value);
+                handleChange({ scanPaths: commaToArr(value) });
+              }}
+            />
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem>
+                  Comma-separated directory paths within the repository to scan for skills. Leave
+                  empty to scan the entire repository.
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
+        </StackItem>
+
+        <StackItem>
+          <FormGroup label="Included skills" fieldId="skill-repo-included-0">
+            <TextInput
+              id="skill-repo-included-0"
+              data-testid="skill-repo-included-0"
+              value={includedSkillsText}
+              placeholder="*"
+              onChange={(_event, value) => {
+                setIncludedSkillsText(value);
+                handleChange({ includedSkills: commaToArr(value) });
+              }}
+            />
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem>
+                  Comma-separated skill name patterns to include. Use <code>*</code> to include all
+                  skills.
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
+        </StackItem>
+
+        <StackItem>
+          <FormGroup label="Excluded skills" fieldId="skill-repo-excluded-0">
+            <TextInput
+              id="skill-repo-excluded-0"
+              data-testid="skill-repo-excluded-0"
+              value={excludedSkillsText}
+              placeholder="internal-*"
+              onChange={(_event, value) => {
+                setExcludedSkillsText(value);
+                handleChange({ excludedSkills: commaToArr(value) });
+              }}
+            />
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem>Comma-separated skill name patterns to exclude.</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
+        </StackItem>
+
+        <StackItem>
+          <FormGroup label="Skill labels" fieldId="skill-repo-labels-0">
+            <TextInput
+              id="skill-repo-labels-0"
+              data-testid="skill-repo-labels-0"
+              value={labelsText}
+              placeholder="typescript, testing"
+              onChange={(_event, value) => {
+                setLabelsText(value);
+                handleChange({ labels: commaToArr(value) });
+              }}
+            />
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem>
+                  Comma-separated labels applied to every skill from this repository. They appear on
+                  skill cards and can be filtered on in the skill catalog.
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          </FormGroup>
+        </StackItem>
+
+        <StackItem>
+          <FormGroup label="Provider" fieldId="skill-repo-provider-0">
+            <TextInput
+              type="text"
+              id="skill-repo-provider-0"
+              data-testid="skill-repo-provider-0"
+              value={repo.provider ?? ''}
+              onChange={(_event, value) => handleChange({ provider: value || undefined })}
+              placeholder="e.g. Red Hat"
+            />
+          </FormGroup>
+        </StackItem>
+
+        <StackItem>
+          <FormGroup label="Category" fieldId="skill-repo-category-0">
+            <TextInput
+              type="text"
+              id="skill-repo-category-0"
+              data-testid="skill-repo-category-0"
+              value={repo.category ?? ''}
+              onChange={(_event, value) => handleChange({ category: value || undefined })}
+              placeholder="e.g. productivity"
+            />
+          </FormGroup>
+        </StackItem>
+
+        <StackItem>
+          <FormGroup label="Trust tier" fieldId="skill-repo-trust-tier-0">
+            <SimpleSelect
+              options={SKILL_TRUST_TIER_OPTIONS}
+              value={repo.trustTier}
+              onChange={(key) => handleChange({ trustTier: key })}
+              placeholder="Select a trust tier"
+              isFullWidth
+              dataTestId="skill-repo-trust-tier-0"
+              previewDescription={false}
+              popperProps={{ direction: 'down' }}
+              toggleProps={{ id: 'skill-repo-trust-tier-0-toggle' }}
+            />
+          </FormGroup>
+        </StackItem>
+      </Stack>
+    </FormSection>
+  );
+};
+
+export default SkillRepositoriesSection;

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillSourceDetailsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/SkillSourceDetailsSection.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import {
+  FormGroup,
+  TextInput,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+} from '@patternfly/react-core';
+import { UpdateObjectAtPropAndValue, ThemeAwareFormGroupWrapper } from 'mod-arch-shared';
+import FormSection from '~/app/pages/modelRegistry/components/pf-overrides/FormSection';
+import {
+  validateSourceName,
+  isSourceNameEmpty,
+  SOURCE_NAME_CHARACTER_LIMIT,
+} from '~/app/shared/catalogSettings';
+import type { ManageSkillSourceFormData } from '~/app/pages/skillCatalogSettings/useManageSkillSourceData';
+
+type SkillSourceDetailsSectionProps = {
+  formData: ManageSkillSourceFormData;
+  setData: UpdateObjectAtPropAndValue<ManageSkillSourceFormData>;
+  isEditMode: boolean;
+  /**
+   * Set when the name would derive a source id that an existing source already uses.
+   * Surfaced on the name field because the id is derived from the name and is not
+   * editable: without this the collision only appears as a "already exists" error
+   * after submitting.
+   */
+  duplicateNameError?: string;
+};
+
+const SkillSourceDetailsSection: React.FC<SkillSourceDetailsSectionProps> = ({
+  formData,
+  setData,
+  isEditMode,
+  duplicateNameError,
+}) => {
+  const [isNameTouched, setIsNameTouched] = React.useState(false);
+  const isNameValid = validateSourceName(formData.name, SOURCE_NAME_CHARACTER_LIMIT);
+  const hasNameError = isNameTouched && !isNameValid;
+  // A duplicate shows as soon as it is known, without waiting for a blur: the admin has
+  // typed a complete name that cannot be saved, and the sooner that is visible the less
+  // of the rest of the form they fill in first.
+  const showDuplicate = Boolean(duplicateNameError) && !hasNameError;
+
+  const nameInput = (
+    <TextInput
+      isRequired
+      readOnlyVariant={isEditMode ? 'plain' : undefined}
+      type="text"
+      id="skill-source-name"
+      name="skill-source-name"
+      data-testid="skill-source-name-input"
+      value={formData.name}
+      onChange={(_event, value) => setData('name', value)}
+      onBlur={() => setIsNameTouched(true)}
+      validated={hasNameError || showDuplicate ? 'error' : 'default'}
+    />
+  );
+
+  const nameHelperTextNode = showDuplicate ? (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem variant="error" data-testid="skill-source-name-duplicate">
+          {duplicateNameError}
+        </HelperTextItem>
+      </HelperText>
+    </FormHelperText>
+  ) : hasNameError ? (
+    <FormHelperText>
+      <HelperText>
+        <HelperTextItem variant="error" data-testid="skill-source-name-error">
+          {isSourceNameEmpty(formData.name)
+            ? 'Name is required'
+            : `Cannot exceed ${SOURCE_NAME_CHARACTER_LIMIT} characters`}
+        </HelperTextItem>
+      </HelperText>
+    </FormHelperText>
+  ) : undefined;
+
+  return (
+    <FormSection>
+      <ThemeAwareFormGroupWrapper
+        label="Name"
+        fieldId="skill-source-name"
+        isRequired
+        hasError={hasNameError}
+        helperTextNode={nameHelperTextNode}
+      >
+        {nameInput}
+      </ThemeAwareFormGroupWrapper>
+
+      <FormGroup label="Source type" fieldId="skill-source-type">
+        <TextInput
+          readOnlyVariant="plain"
+          type="text"
+          id="skill-source-type"
+          data-testid="skill-source-type"
+          value="Git repository"
+        />
+      </FormGroup>
+    </FormSection>
+  );
+};
+
+export default SkillSourceDetailsSection;

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/__tests__/SkillPreviewPanel.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/__tests__/SkillPreviewPanel.spec.tsx
@@ -1,0 +1,73 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SkillPreviewPanel from '~/app/pages/skillCatalogSettings/components/SkillPreviewPanel';
+import { CatalogSettingsPreviewTab } from '~/app/shared/catalogSettings/hooks/previewTypes';
+import type {
+  UseSkillSourcePreviewResult,
+  SkillPreviewState,
+} from '~/app/pages/skillCatalogSettings/useSkillSourcePreview';
+
+const emptyTabState = { items: [], hasMore: false };
+
+const buildPreviewState = (overrides: Partial<SkillPreviewState> = {}): SkillPreviewState => ({
+  isLoadingInitial: false,
+  isLoadingMore: false,
+  activeTab: CatalogSettingsPreviewTab.INCLUDED,
+  tabStates: {
+    [CatalogSettingsPreviewTab.INCLUDED]: emptyTabState,
+    [CatalogSettingsPreviewTab.EXCLUDED]: emptyTabState,
+  },
+  ...overrides,
+});
+
+const buildPreview = (
+  overrides: Partial<UseSkillSourcePreviewResult> = {},
+): UseSkillSourcePreviewResult => ({
+  previewState: buildPreviewState(),
+  handlePreview: jest.fn(),
+  handleTabChange: jest.fn(),
+  handleLoadMore: jest.fn(),
+  hasFormChanged: false,
+  canPreview: true,
+  ...overrides,
+});
+
+describe('SkillPreviewPanel', () => {
+  it('shows friendly guidance — check the URL and provide a token — when preview fails', () => {
+    const rawError = new Error(
+      "failed to resolve any repository: https://github.com/x/y.git@main: fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+    );
+    render(
+      <SkillPreviewPanel
+        preview={buildPreview({
+          previewState: buildPreviewState({ error: rawError }),
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/Double-check that the repository URL/)).toBeInTheDocument();
+    // Preview strips authToken and the catalog resolves credentials only via a stored
+    // credentialRef, so the copy must not send the admin to the Auth token field.
+    expect(
+      screen.getByText(/save the source, then preview it from the edit form/),
+    ).toBeInTheDocument();
+    // The raw technical error is available but tucked behind the collapsed expandable
+    // section, not shown as the primary message.
+    expect(screen.getByText(rawError.message)).not.toBeVisible();
+  });
+
+  it('reveals the raw technical error when "Show error details" is expanded', () => {
+    const rawError = new Error('fatal: repository not found');
+    render(
+      <SkillPreviewPanel
+        preview={buildPreview({
+          previewState: buildPreviewState({ error: rawError }),
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Show error details'));
+    expect(screen.getByText(rawError.message)).toBeInTheDocument();
+  });
+});

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/__tests__/SkillRepositoriesSection.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/__tests__/SkillRepositoriesSection.spec.tsx
@@ -1,0 +1,118 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SkillRepositoriesSection from '~/app/pages/skillCatalogSettings/components/SkillRepositoriesSection';
+import type { SkillRepository } from '~/app/skillCatalogTypes';
+
+// Mirrors how the real form holds `repositories` as controlled state fed back in via
+// onChange, since that round-trip is what originally broke typing a comma.
+const ControlledWrapper: React.FC<{
+  onLabelsCommitted: (labels: string[] | undefined) => void;
+}> = ({ onLabelsCommitted }) => {
+  const [repositories, setRepositories] = React.useState<SkillRepository[]>([{ url: '' }]);
+  return (
+    <SkillRepositoriesSection
+      repositories={repositories}
+      onChange={(next) => {
+        setRepositories(next);
+        onLabelsCommitted(next[0]?.labels);
+      }}
+    />
+  );
+};
+
+describe('SkillRepositoriesSection', () => {
+  it('preserves repositories it cannot show when the first one is edited', () => {
+    // A GitOps-authored source can still carry several repositories. Editing the first
+    // used to replace the whole list with one entry, silently deleting the rest.
+    const onChange = jest.fn();
+    const repositories: SkillRepository[] = [
+      { url: 'https://github.com/example/one' },
+      { url: 'https://github.com/example/two', credentialRef: 'two' },
+      { url: 'https://github.com/example/three' },
+    ];
+    render(<SkillRepositoriesSection repositories={repositories} onChange={onChange} />);
+
+    fireEvent.change(screen.getByTestId('skill-repo-url-0'), {
+      target: { value: 'https://github.com/example/renamed' },
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      { url: 'https://github.com/example/renamed' },
+      { url: 'https://github.com/example/two', credentialRef: 'two' },
+      { url: 'https://github.com/example/three' },
+    ]);
+  });
+
+  it('tells the admin refs must be immutable and non-empty', () => {
+    // The previous copy advertised branches and "leave empty to scan the default
+    // branch"; both produce a source the catalog service rejects at sync.
+    render(
+      <SkillRepositoriesSection
+        repositories={[{ url: 'https://github.com/example/one' }]}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('skill-repo-refs-0')).toHaveAttribute(
+      'placeholder',
+      'v1.2.3, 9f8c1a2',
+    );
+    expect(screen.getByText(/Branches and HEAD are not accepted/)).toBeInTheDocument();
+    expect(screen.getByText(/At least one ref is required/)).toBeInTheDocument();
+  });
+
+  it('blocks editing when the source lists more repositories than the form supports', () => {
+    render(
+      <SkillRepositoriesSection
+        repositories={[
+          { url: 'https://github.com/example/one' },
+          { url: 'https://github.com/example/two' },
+        ]}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('skill-multi-repo-warning')).toHaveTextContent(
+      'This source lists 2 repositories and cannot be saved here',
+    );
+  });
+
+  it('shows no multi-repository alert for a single-repository source', () => {
+    render(
+      <SkillRepositoriesSection
+        repositories={[{ url: 'https://github.com/example/one' }]}
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('skill-multi-repo-warning')).not.toBeInTheDocument();
+  });
+
+  it('lets a user type a comma to start a second label without it being erased', () => {
+    const onLabelsCommitted = jest.fn();
+    render(<ControlledWrapper onLabelsCommitted={onLabelsCommitted} />);
+
+    const input = screen.getByTestId('skill-repo-labels-0');
+
+    // Simulate typing character-by-character, including the comma+space that used to get
+    // silently stripped by re-deriving the field's text from the parsed array each keystroke.
+    fireEvent.change(input, { target: { value: 'typescript' } });
+    fireEvent.change(input, { target: { value: 'typescript,' } });
+    fireEvent.change(input, { target: { value: 'typescript, ' } });
+    fireEvent.change(input, { target: { value: 'typescript, testing' } });
+
+    expect(input).toHaveValue('typescript, testing');
+    expect(onLabelsCommitted).toHaveBeenLastCalledWith(['typescript', 'testing']);
+  });
+
+  it('parses a fully-typed comma-separated list into a trimmed array on commit', () => {
+    const onLabelsCommitted = jest.fn();
+    render(<ControlledWrapper onLabelsCommitted={onLabelsCommitted} />);
+
+    const input = screen.getByTestId('skill-repo-labels-0');
+    fireEvent.change(input, { target: { value: 'typescript,  testing ,e2e' } });
+
+    expect(onLabelsCommitted).toHaveBeenLastCalledWith(['typescript', 'testing', 'e2e']);
+  });
+});

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/__tests__/SkillSourceDetailsSection.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/components/__tests__/SkillSourceDetailsSection.spec.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import SkillSourceDetailsSection from '~/app/pages/skillCatalogSettings/components/SkillSourceDetailsSection';
+import type { ManageSkillSourceFormData } from '~/app/pages/skillCatalogSettings/useManageSkillSourceData';
+
+const formData: ManageSkillSourceFormData = {
+  id: '',
+  name: 'Acme Skills',
+  enabled: true,
+  repositories: [{ url: 'https://github.com/acme/skills' }],
+  labels: [],
+};
+
+const renderSection = (duplicateNameError?: string) =>
+  render(
+    <SkillSourceDetailsSection
+      formData={formData}
+      setData={jest.fn()}
+      isEditMode={false}
+      duplicateNameError={duplicateNameError}
+    />,
+  );
+
+describe('SkillSourceDetailsSection duplicate name', () => {
+  it('shows the collision on the name field without waiting for a blur', () => {
+    // The id is derived from the name and is not editable, so the admin cannot resolve
+    // a collision except by renaming — surfacing it late means re-doing the form.
+    renderSection('The source "Acme Skills" already uses the identifier "acme_skills".');
+
+    expect(screen.getByTestId('skill-source-name-duplicate')).toHaveTextContent(
+      'already uses the identifier "acme_skills"',
+    );
+  });
+
+  it('shows no duplicate error when the name is free', () => {
+    renderSection(undefined);
+    expect(screen.queryByTestId('skill-source-name-duplicate')).not.toBeInTheDocument();
+  });
+});

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/definition.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/definition.ts
@@ -1,0 +1,11 @@
+import { SkillCatalogSettingsContextProvider } from '~/app/context/skillCatalogSettings/SkillCatalogSettingsContext';
+import type { CatalogSettingsDefinition } from '~/app/shared/catalogSettings/types';
+import SkillCatalogSettings from './screens/SkillCatalogSettings';
+import SkillManageSourcePage from './screens/SkillManageSourcePage';
+
+export const skillCatalogSettingsDefinition: CatalogSettingsDefinition = {
+  id: 'skill_catalog',
+  ContextProvider: SkillCatalogSettingsContextProvider,
+  ListPage: SkillCatalogSettings,
+  ManagePage: SkillManageSourcePage,
+};

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/screens/SkillCatalogSettings.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/screens/SkillCatalogSettings.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { Button, EmptyState, EmptyStateBody, EmptyStateVariant } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { useNavigate } from 'react-router-dom';
+import { ApplicationsPage, ProjectObjectType, TitleWithIcon } from 'mod-arch-shared';
+import {
+  SKILL_CATALOG_SETTINGS_PAGE_TITLE,
+  SKILL_CATALOG_SETTINGS_DESCRIPTION,
+  skillAddSourceUrl,
+  SKILL_ADD_SOURCE_TITLE,
+} from '~/app/routes/skillCatalogSettings/skillCatalogSettings';
+import { SkillCatalogSettingsContext } from '~/app/context/skillCatalogSettings/SkillCatalogSettingsContext';
+import SkillCatalogSourceConfigsTable from './SkillCatalogSourceConfigsTable';
+
+const SkillCatalogSettings: React.FC = () => {
+  const navigate = useNavigate();
+  const {
+    skillCatalogSourceConfigs,
+    skillCatalogSourceConfigsLoaded,
+    skillCatalogSourceConfigsLoadError,
+    apiState,
+    refreshSkillCatalogSourceConfigs,
+  } = React.useContext(SkillCatalogSettingsContext);
+
+  const configs = skillCatalogSourceConfigs?.catalogs || [];
+  const isEmpty = skillCatalogSourceConfigsLoaded && configs.length === 0;
+
+  const handleDeleteSource = React.useCallback(
+    async (sourceId: string): Promise<void> => {
+      if (!apiState.apiAvailable) {
+        throw new Error('API not available');
+      }
+      await apiState.api.deleteSkillCatalogSourceConfig({}, sourceId);
+      refreshSkillCatalogSourceConfigs();
+    },
+    [apiState.api, apiState.apiAvailable, refreshSkillCatalogSourceConfigs],
+  );
+
+  return (
+    <ApplicationsPage
+      title={
+        <TitleWithIcon
+          title={SKILL_CATALOG_SETTINGS_PAGE_TITLE}
+          objectType={ProjectObjectType.mcpCatalog}
+        />
+      }
+      description={SKILL_CATALOG_SETTINGS_DESCRIPTION}
+      empty={isEmpty}
+      emptyStatePage={
+        <EmptyState
+          headingLevel="h5"
+          icon={PlusCircleIcon}
+          titleText="No skill sources"
+          variant={EmptyStateVariant.lg}
+          data-testid="skill-catalog-settings-empty-state"
+        >
+          <EmptyStateBody>
+            No skill sources have been configured. Add a source to get started.
+          </EmptyStateBody>
+          <Button
+            variant="primary"
+            onClick={() => navigate(skillAddSourceUrl())}
+            data-testid="skill-add-source-button-empty"
+          >
+            {SKILL_ADD_SOURCE_TITLE}
+          </Button>
+        </EmptyState>
+      }
+      loaded={skillCatalogSourceConfigsLoaded}
+      loadError={skillCatalogSourceConfigsLoadError}
+      errorMessage="Unable to load skill catalog source configurations."
+      provideChildrenPadding
+    >
+      <SkillCatalogSourceConfigsTable
+        skillCatalogSourceConfigs={configs}
+        onAddSource={() => navigate(skillAddSourceUrl())}
+        onDeleteSource={handleDeleteSource}
+      />
+    </ApplicationsPage>
+  );
+};
+
+export default SkillCatalogSettings;

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/screens/SkillCatalogSourceConfigsTable.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/screens/SkillCatalogSourceConfigsTable.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react';
+import {
+  Alert,
+  AlertActionCloseButton,
+  Button,
+  Flex,
+  FlexItem,
+  Stack,
+  StackItem,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { Table } from 'mod-arch-shared';
+import type { SkillCatalogSourceConfig } from '~/app/skillCatalogTypes';
+import { SkillCatalogSettingsContext } from '~/app/context/skillCatalogSettings/SkillCatalogSettingsContext';
+import { SKILL_ADD_SOURCE_TITLE } from '~/app/routes/skillCatalogSettings/skillCatalogSettings';
+import { skillCatalogSourceConfigsColumns } from './SkillCatalogSourceConfigsTableColumns';
+import SkillCatalogSourceConfigsTableRow from './SkillCatalogSourceConfigsTableRow';
+
+type SkillCatalogSourceConfigsTableProps = {
+  skillCatalogSourceConfigs: SkillCatalogSourceConfig[];
+  onAddSource: () => void;
+  onDeleteSource: (sourceId: string) => Promise<void>;
+};
+
+const SkillCatalogSourceConfigsTable: React.FC<SkillCatalogSourceConfigsTableProps> = ({
+  skillCatalogSourceConfigs,
+  onAddSource,
+  onDeleteSource,
+}) => {
+  const [toggleError, setToggleError] = React.useState<Error | undefined>(undefined);
+  const [updatingToggleId, setUpdatingToggleId] = React.useState<string | null>(null);
+  const {
+    apiState,
+    refreshSkillCatalogSourceConfigs,
+    refreshSkillCatalogSources,
+    markSkillSourceSyncPending,
+  } = React.useContext(SkillCatalogSettingsContext);
+
+  const handleEnableToggle = async (
+    checked: boolean,
+    catalogSourceConfig: SkillCatalogSourceConfig,
+  ) => {
+    if (!apiState.apiAvailable) {
+      setToggleError(new Error('API is not available'));
+      return;
+    }
+    setUpdatingToggleId(catalogSourceConfig.id);
+    setToggleError(undefined);
+
+    try {
+      await apiState.api.updateSkillCatalogSourceConfig({}, catalogSourceConfig.id, {
+        enabled: checked,
+      });
+      markSkillSourceSyncPending(catalogSourceConfig.id);
+      refreshSkillCatalogSourceConfigs();
+      refreshSkillCatalogSources();
+    } catch (e) {
+      if (e instanceof Error) {
+        setToggleError(new Error(`Error enabling/disabling source ${catalogSourceConfig.name}`));
+      }
+    } finally {
+      setUpdatingToggleId(null);
+    }
+  };
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Table
+          data-testid="skill-catalog-source-configs-table"
+          data={skillCatalogSourceConfigs}
+          columns={skillCatalogSourceConfigsColumns}
+          toolbarContent={
+            <Flex direction={{ default: 'column' }}>
+              <FlexItem>
+                <Toolbar>
+                  <ToolbarContent>
+                    <ToolbarItem>
+                      <Button
+                        variant="primary"
+                        onClick={onAddSource}
+                        data-testid="skill-add-source-button"
+                      >
+                        {SKILL_ADD_SOURCE_TITLE}
+                      </Button>
+                    </ToolbarItem>
+                  </ToolbarContent>
+                </Toolbar>
+              </FlexItem>
+              {toggleError && (
+                <FlexItem>
+                  <Alert
+                    variant="danger"
+                    data-testid="skill-toggle-alert"
+                    title={toggleError.message}
+                    actionClose={
+                      <AlertActionCloseButton onClose={() => setToggleError(undefined)} />
+                    }
+                  />
+                </FlexItem>
+              )}
+            </Flex>
+          }
+          rowRenderer={(config) => (
+            <SkillCatalogSourceConfigsTableRow
+              key={config.id}
+              skillCatalogSourceConfig={config}
+              isUpdatingToggle={updatingToggleId === config.id}
+              onToggleUpdate={handleEnableToggle}
+              onDeleteSource={onDeleteSource}
+            />
+          )}
+          variant="compact"
+        />
+      </StackItem>
+    </Stack>
+  );
+};
+
+export default SkillCatalogSourceConfigsTable;

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/screens/SkillCatalogSourceConfigsTableColumns.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/screens/SkillCatalogSourceConfigsTableColumns.tsx
@@ -1,0 +1,40 @@
+import { kebabTableColumn, SortableData } from 'mod-arch-shared';
+import type { SkillCatalogSourceConfig } from '~/app/skillCatalogTypes';
+
+export const skillCatalogSourceConfigsColumns: SortableData<SkillCatalogSourceConfig>[] = [
+  {
+    field: 'name',
+    label: 'Name',
+    sortable: (a, b) => a.name.localeCompare(b.name),
+    width: 25,
+  },
+  {
+    field: 'type',
+    label: 'Source type',
+    sortable: false,
+    width: 20,
+  },
+  {
+    field: 'enabled',
+    label: 'Enable',
+    sortable: false,
+    info: {
+      popover:
+        'Enable a source to make its skills available to users in your organization from the skill catalog.',
+    },
+    width: 15,
+  },
+  {
+    field: 'status',
+    label: 'Validation status',
+    sortable: false,
+    width: 15,
+  },
+  {
+    field: 'actions',
+    label: '',
+    sortable: false,
+    width: 20,
+  },
+  kebabTableColumn(),
+];

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/screens/SkillCatalogSourceConfigsTableRow.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/screens/SkillCatalogSourceConfigsTableRow.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import { ActionsColumn, Td, Tr } from '@patternfly/react-table';
+import { Button, Switch } from '@patternfly/react-core';
+import { useNavigate } from 'react-router-dom';
+import type { SkillCatalogSourceConfig } from '~/app/skillCatalogTypes';
+import { skillManageSourceUrl } from '~/app/routes/skillCatalogSettings/skillCatalogSettings';
+import DeleteModal from '~/app/shared/components/DeleteModal';
+import { useNotification } from '~/app/hooks/useNotification';
+import SkillCatalogSourceStatus from '~/app/pages/skillCatalogSettings/components/SkillCatalogSourceStatus';
+
+const SKILL_SOURCE_TYPE_LABELS: Record<string, string> = {
+  'git-skills-plugin': 'Git repository',
+};
+
+type SkillCatalogSourceConfigsTableRowProps = {
+  skillCatalogSourceConfig: SkillCatalogSourceConfig;
+  onDeleteSource: (sourceId: string) => Promise<void>;
+  isUpdatingToggle: boolean;
+  onToggleUpdate: (checked: boolean, sourceConfig: SkillCatalogSourceConfig) => void;
+};
+
+const SkillCatalogSourceConfigsTableRow: React.FC<SkillCatalogSourceConfigsTableRowProps> = ({
+  skillCatalogSourceConfig,
+  onDeleteSource,
+  isUpdatingToggle,
+  onToggleUpdate,
+}) => {
+  const navigate = useNavigate();
+  const notification = useNotification();
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
+  const [isDeleting, setIsDeleting] = React.useState(false);
+  const [deleteError, setDeleteError] = React.useState<Error | undefined>();
+
+  const isDefault = skillCatalogSourceConfig.isDefault ?? false;
+  const isEnabled = skillCatalogSourceConfig.enabled ?? true;
+
+  const handleEnableToggle = (checked: boolean) => {
+    onToggleUpdate(checked, skillCatalogSourceConfig);
+  };
+
+  const handleManageSource = () => {
+    navigate(skillManageSourceUrl(skillCatalogSourceConfig.id));
+  };
+
+  const handleDeleteClick = () => {
+    setDeleteError(undefined);
+    setIsDeleteModalOpen(true);
+  };
+
+  const handleDeleteConfirm = async () => {
+    setIsDeleting(true);
+    setDeleteError(undefined);
+
+    try {
+      await onDeleteSource(skillCatalogSourceConfig.id);
+      setIsDeleteModalOpen(false);
+      notification.success(`${skillCatalogSourceConfig.name} deleted successfully`);
+    } catch (error) {
+      setDeleteError(error instanceof Error ? error : new Error('Failed to delete source'));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleCloseDeleteModal = () => {
+    if (!isDeleting) {
+      setIsDeleteModalOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <Tr>
+        <Td dataLabel="Name" style={{ verticalAlign: 'middle' }}>
+          <span data-testid={`skill-source-name-${skillCatalogSourceConfig.id}`}>
+            {skillCatalogSourceConfig.name}
+          </span>
+        </Td>
+        <Td dataLabel="Source type" style={{ verticalAlign: 'middle' }}>
+          <span data-testid={`skill-source-type-${skillCatalogSourceConfig.id}`}>
+            {SKILL_SOURCE_TYPE_LABELS[skillCatalogSourceConfig.type] ??
+              skillCatalogSourceConfig.type}
+          </span>
+        </Td>
+        <Td dataLabel="Enable" style={{ verticalAlign: 'middle' }}>
+          <Switch
+            data-testid={`skill-enable-toggle-${skillCatalogSourceConfig.id}`}
+            id={`skill-enable-toggle-${skillCatalogSourceConfig.id}`}
+            aria-label={`Enable ${skillCatalogSourceConfig.name}`}
+            isChecked={isEnabled}
+            isDisabled={isUpdatingToggle}
+            onChange={(_event, checked) => handleEnableToggle(checked)}
+          />
+        </Td>
+        <Td dataLabel="Validation status" style={{ verticalAlign: 'middle' }}>
+          <SkillCatalogSourceStatus skillCatalogSourceConfig={skillCatalogSourceConfig} />
+        </Td>
+        <Td style={{ verticalAlign: 'middle' }}>
+          {/* Shipped defaults are read-only: they expose no edit or delete controls. */}
+          {!isDefault && (
+            <Button
+              variant="link"
+              onClick={handleManageSource}
+              data-testid={`skill-manage-source-button-${skillCatalogSourceConfig.id}`}
+            >
+              Manage source
+            </Button>
+          )}
+        </Td>
+        <Td isActionCell style={{ verticalAlign: 'middle' }}>
+          {!isDefault && (
+            <ActionsColumn
+              items={[{ title: 'Delete source', onClick: handleDeleteClick }]}
+              data-testid={`skill-source-actions-${skillCatalogSourceConfig.id}`}
+            />
+          )}
+        </Td>
+      </Tr>
+      {isDeleteModalOpen && (
+        <DeleteModal
+          title="Delete a source"
+          testId="skill-delete-source-modal"
+          onClose={handleCloseDeleteModal}
+          deleting={isDeleting}
+          onDelete={handleDeleteConfirm}
+          deleteName={skillCatalogSourceConfig.name}
+          error={deleteError}
+        >
+          The <strong>{skillCatalogSourceConfig.name}</strong> source will be deleted, and its
+          skills will be removed from the skill catalog.
+        </DeleteModal>
+      )}
+    </>
+  );
+};
+
+export default SkillCatalogSourceConfigsTableRow;

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/screens/SkillManageSourcePage.tsx
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/screens/SkillManageSourcePage.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import { ApplicationsPage } from 'mod-arch-shared';
+import {
+  SKILL_ADD_SOURCE_TITLE,
+  SKILL_ADD_SOURCE_DESCRIPTION,
+  SKILL_MANAGE_SOURCE_TITLE,
+  SKILL_MANAGE_SOURCE_DESCRIPTION,
+  skillCatalogSettingsUrl,
+} from '~/app/routes/skillCatalogSettings/skillCatalogSettings';
+import { useSkillCatalogSourceConfigBySourceId } from '~/app/hooks/skillCatalogSettings/useSkillCatalogSourceConfigBySourceId';
+import SkillManageSourceForm from '~/app/pages/skillCatalogSettings/components/SkillManageSourceForm';
+
+const SKILL_CATALOG_SOURCES_BREADCRUMB = 'Skill catalog sources';
+
+const SkillManageSourcePage: React.FC = () => {
+  const { catalogSourceId } = useParams<{ catalogSourceId?: string }>();
+  const isAddMode = !catalogSourceId;
+  const pageTitle = isAddMode ? SKILL_ADD_SOURCE_TITLE : SKILL_MANAGE_SOURCE_TITLE;
+  const description = isAddMode ? SKILL_ADD_SOURCE_DESCRIPTION : SKILL_MANAGE_SOURCE_DESCRIPTION;
+
+  const [existingSourceConfig, existingSourceConfigLoaded, existingSourceConfigLoadError] =
+    useSkillCatalogSourceConfigBySourceId(catalogSourceId || '');
+
+  return (
+    <ApplicationsPage
+      breadcrumb={
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to={skillCatalogSettingsUrl()}>{SKILL_CATALOG_SOURCES_BREADCRUMB}</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem data-testid="skill-breadcrumb-source-action" isActive>
+            {pageTitle}
+          </BreadcrumbItem>
+        </Breadcrumb>
+      }
+      title={pageTitle}
+      description={description}
+      errorMessage={catalogSourceId ? existingSourceConfigLoadError?.message : undefined}
+      empty={catalogSourceId ? !existingSourceConfig : false}
+      loaded={catalogSourceId ? existingSourceConfigLoaded : true}
+      provideChildrenPadding
+    >
+      <SkillManageSourceForm
+        existingSourceConfig={existingSourceConfig || undefined}
+        isEditMode={!isAddMode}
+      />
+    </ApplicationsPage>
+  );
+};
+
+export default SkillManageSourcePage;

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/useManageSkillSourceData.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/useManageSkillSourceData.ts
@@ -1,0 +1,27 @@
+import { GenericObjectState } from 'mod-arch-core';
+import useGenericObjectState from 'mod-arch-core/dist/utilities/useGenericObjectState';
+import type { SkillRepository } from '~/app/skillCatalogTypes';
+
+export type ManageSkillSourceFormData = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  repositories: SkillRepository[];
+  labels: string[];
+};
+
+const defaultFormData: ManageSkillSourceFormData = {
+  id: '',
+  name: '',
+  enabled: true,
+  repositories: [{ url: '' }],
+  labels: [],
+};
+
+export const useManageSkillSourceData = (
+  existingData?: Partial<ManageSkillSourceFormData>,
+): GenericObjectState<ManageSkillSourceFormData> =>
+  useGenericObjectState<ManageSkillSourceFormData>({
+    ...defaultFormData,
+    ...existingData,
+  });

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/useSkillSourcePreview.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/useSkillSourcePreview.ts
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import {
+  SkillCatalogSourceConfig,
+  SkillCatalogSourcePreviewRequest,
+  SkillCatalogSourcePreviewAsset,
+  SkillCatalogSourcePreviewSummary,
+  SkillCatalogSourceType,
+} from '~/app/skillCatalogTypes';
+import { SkillCatalogSettingsAPIState } from '~/app/hooks/skillCatalogSettings/useSkillCatalogSettingsAPIState';
+import { CatalogSettingsPreviewTab } from '~/app/shared/catalogSettings/hooks/previewTypes';
+import { useCatalogSourcePreviewCore } from '~/app/shared/catalogSettings/hooks/useCatalogSourcePreviewCore';
+import { ManageSkillSourceFormData } from './useManageSkillSourceData';
+
+export type SkillPreviewTabState = {
+  items: SkillCatalogSourcePreviewAsset[];
+  nextPageToken?: string;
+  hasMore: boolean;
+};
+
+export type SkillPreviewState = {
+  isLoadingInitial: boolean;
+  isLoadingMore: boolean;
+  summary?: SkillCatalogSourcePreviewSummary;
+  tabStates: Record<CatalogSettingsPreviewTab, SkillPreviewTabState>;
+  error?: Error;
+  lastPreviewedData?: SkillCatalogSourcePreviewRequest;
+  activeTab: CatalogSettingsPreviewTab;
+};
+
+export interface UseSkillSourcePreviewOptions {
+  formData: ManageSkillSourceFormData;
+  existingSourceConfig?: SkillCatalogSourceConfig;
+  apiState: SkillCatalogSettingsAPIState;
+  isEditMode: boolean;
+}
+
+export interface UseSkillSourcePreviewResult {
+  previewState: SkillPreviewState;
+  handlePreview: () => Promise<void>;
+  handleTabChange: (tab: CatalogSettingsPreviewTab) => void;
+  handleLoadMore: () => void;
+  hasFormChanged: boolean;
+  canPreview: boolean;
+}
+
+export const useSkillSourcePreview = ({
+  formData,
+  apiState,
+  isEditMode,
+}: UseSkillSourcePreviewOptions): UseSkillSourcePreviewResult => {
+  const canPreview =
+    formData.repositories.length > 0 && formData.repositories[0].url.trim().length > 0;
+
+  const buildPreviewRequest = React.useCallback((): SkillCatalogSourcePreviewRequest => {
+    const repositories = formData.repositories
+      .filter((r) => r.url.trim().length > 0)
+      .map((r) => {
+        const repo = { ...r };
+        delete repo.authToken;
+        delete repo.provider;
+        delete repo.category;
+        delete repo.trustTier;
+        return repo;
+      });
+
+    return {
+      type: SkillCatalogSourceType.GIT_SKILLS,
+      properties: {
+        repositories,
+      },
+    };
+  }, [formData]);
+
+  const previewApi = React.useCallback(
+    (
+      opts: Parameters<SkillCatalogSettingsAPIState['api']['previewSkillCatalogSource']>[0],
+      data: SkillCatalogSourcePreviewRequest,
+      queryParams?: Parameters<SkillCatalogSettingsAPIState['api']['previewSkillCatalogSource']>[2],
+    ) => apiState.api.previewSkillCatalogSource(opts, data, queryParams),
+    [apiState.api],
+  );
+
+  const { previewState, handlePreviewInternal, handleTabChange, handleLoadMore, hasFormChanged } =
+    useCatalogSourcePreviewCore<
+      SkillCatalogSourcePreviewAsset,
+      SkillCatalogSourcePreviewSummary,
+      SkillCatalogSourcePreviewRequest
+    >({
+      canPreview,
+      isEditMode,
+      apiAvailable: apiState.apiAvailable,
+      buildPreviewRequest,
+      previewApi,
+    });
+
+  const handlePreview = React.useCallback(async () => {
+    await handlePreviewInternal();
+  }, [handlePreviewInternal]);
+
+  return {
+    previewState,
+    handlePreview,
+    handleTabChange,
+    handleLoadMore,
+    hasFormChanged,
+    canPreview,
+  };
+};

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/utils/__tests__/duplicateSourceName.spec.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/utils/__tests__/duplicateSourceName.spec.ts
@@ -1,0 +1,43 @@
+import { findConflictingSource } from '~/app/pages/skillCatalogSettings/utils/duplicateSourceName';
+import type { SkillCatalogSourceConfigList } from '~/app/skillCatalogTypes';
+import { SkillCatalogSourceType } from '~/app/skillCatalogTypes';
+
+const configs: SkillCatalogSourceConfigList = {
+  catalogs: [
+    { id: 'acme_skills', name: 'Acme Skills', type: SkillCatalogSourceType.GIT_SKILLS },
+    { id: 'community_skills', name: 'Community Skills', type: SkillCatalogSourceType.GIT_SKILLS },
+  ],
+};
+
+describe('findConflictingSource', () => {
+  it('finds the source a same-named new source would collide with', () => {
+    expect(findConflictingSource('Acme Skills', configs)?.id).toBe('acme_skills');
+  });
+
+  it('matches on the derived id, not the raw name', () => {
+    // generateSourceIdFromName lowercases and folds spaces/hyphens to underscores, so
+    // these all derive acme_skills and collide even though the names differ.
+    expect(findConflictingSource('acme skills', configs)?.id).toBe('acme_skills');
+    expect(findConflictingSource('Acme-Skills', configs)?.id).toBe('acme_skills');
+  });
+
+  it('does not treat a name as colliding when punctuation changes the derived id', () => {
+    // Punctuation is stripped rather than folded, so "Acme's Skills" derives
+    // acmes_skills and is a genuinely different source from acme_skills.
+    expect(findConflictingSource("Acme's Skills", configs)).toBeUndefined();
+  });
+
+  it('returns undefined for a name that derives a free id', () => {
+    expect(findConflictingSource('Nvidia Skills', configs)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty or punctuation-only name', () => {
+    expect(findConflictingSource('', configs)).toBeUndefined();
+    expect(findConflictingSource('   ', configs)).toBeUndefined();
+    expect(findConflictingSource('!!!', configs)).toBeUndefined();
+  });
+
+  it('returns undefined before the source list has loaded', () => {
+    expect(findConflictingSource('Acme Skills', null)).toBeUndefined();
+  });
+});

--- a/clients/ui/frontend/src/app/pages/skillCatalogSettings/utils/duplicateSourceName.ts
+++ b/clients/ui/frontend/src/app/pages/skillCatalogSettings/utils/duplicateSourceName.ts
@@ -1,0 +1,31 @@
+import { generateSourceIdFromName } from '~/app/shared/catalogSettings';
+import type {
+  SkillCatalogSourceConfig,
+  SkillCatalogSourceConfigList,
+} from '~/app/skillCatalogTypes';
+
+/**
+ * Returns the existing source whose id a new source of this name would collide with,
+ * or undefined when there is no clash.
+ *
+ * A source id is derived from its name and is not editable, so two sources named alike
+ * resolve to the same id. The BFF rejects that on create, but only after submit — and
+ * that id is also the key the source's git token is stored under in the shared
+ * git-credentials Secret. Detecting it while the admin is still typing avoids both the
+ * wasted round trip and the confusion of a failure that looks like it changed nothing.
+ *
+ * Only meaningful when creating: an edit keeps the id the source already has.
+ */
+export const findConflictingSource = (
+  name: string,
+  sourceConfigs: SkillCatalogSourceConfigList | null,
+): SkillCatalogSourceConfig | undefined => {
+  if (!name.trim()) {
+    return undefined;
+  }
+  const candidateId = generateSourceIdFromName(name);
+  if (!candidateId) {
+    return undefined;
+  }
+  return sourceConfigs?.catalogs.find((c) => c.id === candidateId);
+};

--- a/clients/ui/frontend/src/app/routes/skillCatalog/skillCatalog.ts
+++ b/clients/ui/frontend/src/app/routes/skillCatalog/skillCatalog.ts
@@ -1,0 +1,6 @@
+export const SKILL_CATALOG_TITLE = 'Skill Catalog';
+
+export const skillCatalogUrl = (): string => '/skill-catalog';
+
+export const skillDetailsUrl = (skillId: string | number): string =>
+  `${skillCatalogUrl()}/${encodeURIComponent(String(skillId))}`;

--- a/clients/ui/frontend/src/app/routes/skillCatalogSettings/skillCatalogSettings.ts
+++ b/clients/ui/frontend/src/app/routes/skillCatalogSettings/skillCatalogSettings.ts
@@ -1,0 +1,15 @@
+export const SKILL_CATALOG_SETTINGS_PAGE_TITLE = 'Skill catalog sources';
+export const SKILL_CATALOG_SETTINGS_DESCRIPTION =
+  'Add and manage Git repositories that populate the skill catalog for users in your organization.';
+
+export const SKILL_ADD_SOURCE_TITLE = 'Add source';
+export const SKILL_ADD_SOURCE_DESCRIPTION = 'Add a new skill catalog Git repository source.';
+export const SKILL_MANAGE_SOURCE_TITLE = 'Manage source';
+export const SKILL_MANAGE_SOURCE_DESCRIPTION = 'Configure this skill catalog source.';
+
+export const skillCatalogSettingsUrl = (): string => '/skill-catalog-settings';
+
+export const skillAddSourceUrl = (): string => `${skillCatalogSettingsUrl()}/add-source`;
+
+export const skillManageSourceUrl = (catalogSourceId: string): string =>
+  `${skillCatalogSettingsUrl()}/manage-source/${encodeURIComponent(catalogSourceId)}`;

--- a/clients/ui/frontend/src/app/shared/catalogSettings/createCatalogSettingsContext.tsx
+++ b/clients/ui/frontend/src/app/shared/catalogSettings/createCatalogSettingsContext.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
-import { useQueryParamNamespaces } from 'mod-arch-core';
+import { useQueryParamNamespaces, POLL_INTERVAL } from 'mod-arch-core';
 import useModelCatalogAPIState from '~/app/hooks/modelCatalog/useModelCatalogAPIState';
 import { useCatalogSourcesWithPolling } from './hooks/useCatalogSourcesWithPolling';
+import {
+  useCatalogSourceSyncTracker,
+  SYNC_PENDING_POLL_INTERVAL,
+} from './hooks/useCatalogSourceSyncTracker';
 import type { CatalogSettingsContextDefinition, CatalogSettingsContextValue } from './types';
 
 /**
@@ -45,8 +49,20 @@ export const createCatalogSettingsContext = <TAPIState, TConfigList>(
     const [sourceConfigs, sourceConfigsLoaded, sourceConfigsLoadError, refreshSourceConfigs] =
       contextDef.useSourceConfigsList(apiState);
 
+    const { isSyncPending, markSyncPending, reconcileSyncPending, hasPendingSyncs } =
+      useCatalogSourceSyncTracker();
+
     const [catalogSources, catalogSourcesLoaded, catalogSourcesLoadError, refreshCatalogSources] =
-      useCatalogSourcesWithPolling(catalogAPIState);
+      useCatalogSourcesWithPolling(
+        catalogAPIState,
+        hasPendingSyncs ? SYNC_PENDING_POLL_INTERVAL : POLL_INTERVAL,
+      );
+
+    // Every poll gets handed back to the tracker so a pending mark clears as soon
+    // as the catalog reports something different for that source.
+    React.useEffect(() => {
+      reconcileSyncPending(catalogSources);
+    }, [catalogSources, reconcileSyncPending]);
 
     return React.useMemo(
       () => ({
@@ -60,6 +76,8 @@ export const createCatalogSettingsContext = <TAPIState, TConfigList>(
         catalogSourcesLoaded,
         catalogSourcesLoadError,
         refreshCatalogSources,
+        isSyncPending,
+        markSyncPending,
       }),
       [
         apiState,
@@ -72,6 +90,8 @@ export const createCatalogSettingsContext = <TAPIState, TConfigList>(
         catalogSourcesLoaded,
         catalogSourcesLoadError,
         refreshCatalogSources,
+        isSyncPending,
+        markSyncPending,
       ],
     );
   };

--- a/clients/ui/frontend/src/app/shared/catalogSettings/hooks/__tests__/useCatalogSourceSyncTracker.spec.ts
+++ b/clients/ui/frontend/src/app/shared/catalogSettings/hooks/__tests__/useCatalogSourceSyncTracker.spec.ts
@@ -1,0 +1,173 @@
+import '@testing-library/jest-dom';
+import { renderHook, act } from '@testing-library/react';
+import {
+  useCatalogSourceSyncTracker,
+  SYNC_PENDING_TIMEOUT,
+} from '~/app/shared/catalogSettings/hooks/useCatalogSourceSyncTracker';
+import { CatalogSourceStatus } from '~/app/shared/types/catalogTypes';
+import type { CatalogSource, CatalogSourceList } from '~/app/shared/types/catalogTypes';
+
+const sourceList = (...items: CatalogSource[]): CatalogSourceList => ({
+  items,
+  size: items.length,
+  pageSize: 10,
+  nextPageToken: '',
+});
+
+const availableSource = (id: string, overrides: Partial<CatalogSource> = {}): CatalogSource => ({
+  id,
+  name: id,
+  labels: [],
+  enabled: true,
+  status: CatalogSourceStatus.AVAILABLE,
+  ...overrides,
+});
+
+describe('useCatalogSourceSyncTracker', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('reports nothing pending before any write', () => {
+    const { result } = renderHook(() => useCatalogSourceSyncTracker());
+
+    expect(result.current.hasPendingSyncs).toBe(false);
+    expect(result.current.isSyncPending('skills')).toBe(false);
+  });
+
+  it('marks a source pending and raises hasPendingSyncs', () => {
+    const { result } = renderHook(() => useCatalogSourceSyncTracker());
+
+    act(() => {
+      result.current.reconcileSyncPending(sourceList(availableSource('skills')));
+    });
+    act(() => {
+      result.current.markSyncPending('skills');
+    });
+
+    expect(result.current.isSyncPending('skills')).toBe(true);
+    expect(result.current.hasPendingSyncs).toBe(true);
+  });
+
+  it('leaves a source pending while the catalog keeps reporting the same thing', () => {
+    const { result } = renderHook(() => useCatalogSourceSyncTracker());
+
+    act(() => {
+      result.current.reconcileSyncPending(sourceList(availableSource('skills')));
+    });
+    act(() => {
+      result.current.markSyncPending('skills');
+    });
+    // An include/exclude filter edit is invisible in the source list: the catalog
+    // reports "available" throughout, so the pending mark must survive the poll.
+    act(() => {
+      result.current.reconcileSyncPending(sourceList(availableSource('skills')));
+    });
+
+    expect(result.current.isSyncPending('skills')).toBe(true);
+  });
+
+  it('clears the pending mark when the reported status changes', () => {
+    const { result } = renderHook(() => useCatalogSourceSyncTracker());
+
+    act(() => {
+      result.current.reconcileSyncPending(sourceList(availableSource('skills')));
+    });
+    act(() => {
+      result.current.markSyncPending('skills');
+    });
+    act(() => {
+      result.current.reconcileSyncPending(
+        sourceList(
+          availableSource('skills', { status: CatalogSourceStatus.ERROR, error: 'clone failed' }),
+        ),
+      );
+    });
+
+    expect(result.current.isSyncPending('skills')).toBe(false);
+    expect(result.current.hasPendingSyncs).toBe(false);
+  });
+
+  it('clears the pending mark when the reported labels change', () => {
+    const { result } = renderHook(() => useCatalogSourceSyncTracker());
+
+    act(() => {
+      result.current.reconcileSyncPending(sourceList(availableSource('skills')));
+    });
+    act(() => {
+      result.current.markSyncPending('skills');
+    });
+    act(() => {
+      result.current.reconcileSyncPending(
+        sourceList(availableSource('skills', { labels: ['community'] })),
+      );
+    });
+
+    expect(result.current.isSyncPending('skills')).toBe(false);
+  });
+
+  it('clears the pending mark for a newly created source once the catalog lists it', () => {
+    const { result } = renderHook(() => useCatalogSourceSyncTracker());
+
+    act(() => {
+      result.current.reconcileSyncPending(sourceList());
+    });
+    act(() => {
+      result.current.markSyncPending('new-skills');
+    });
+    expect(result.current.isSyncPending('new-skills')).toBe(true);
+
+    act(() => {
+      result.current.reconcileSyncPending(sourceList(availableSource('new-skills')));
+    });
+
+    expect(result.current.isSyncPending('new-skills')).toBe(false);
+  });
+
+  it('expires the pending mark after the timeout when the catalog never signals', () => {
+    const { result } = renderHook(() => useCatalogSourceSyncTracker());
+
+    act(() => {
+      result.current.reconcileSyncPending(sourceList(availableSource('skills')));
+    });
+    act(() => {
+      result.current.markSyncPending('skills');
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(SYNC_PENDING_TIMEOUT - 1000);
+    });
+    expect(result.current.isSyncPending('skills')).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(result.current.isSyncPending('skills')).toBe(false);
+    expect(result.current.hasPendingSyncs).toBe(false);
+  });
+
+  it('tracks several sources independently', () => {
+    const { result } = renderHook(() => useCatalogSourceSyncTracker());
+
+    act(() => {
+      result.current.reconcileSyncPending(sourceList(availableSource('a'), availableSource('b')));
+    });
+    act(() => {
+      result.current.markSyncPending('a');
+      result.current.markSyncPending('b');
+    });
+    act(() => {
+      result.current.reconcileSyncPending(
+        sourceList(availableSource('a', { labels: ['x'] }), availableSource('b')),
+      );
+    });
+
+    expect(result.current.isSyncPending('a')).toBe(false);
+    expect(result.current.isSyncPending('b')).toBe(true);
+    expect(result.current.hasPendingSyncs).toBe(true);
+  });
+});

--- a/clients/ui/frontend/src/app/shared/catalogSettings/hooks/useCatalogSourceSyncTracker.ts
+++ b/clients/ui/frontend/src/app/shared/catalogSettings/hooks/useCatalogSourceSyncTracker.ts
@@ -1,0 +1,112 @@
+import * as React from 'react';
+import type { CatalogSource, CatalogSourceList } from '~/app/shared/types/catalogTypes';
+
+/**
+ * Poll rate for the catalog source list while at least one source is waiting for
+ * the catalog to pick up an edit. Only in effect while something is pending; the
+ * list falls back to POLL_INTERVAL once everything has settled.
+ */
+export const SYNC_PENDING_POLL_INTERVAL = 5000;
+
+/**
+ * How long a source keeps reporting "syncing" when the catalog never tells us
+ * anything changed.
+ *
+ * Saving a source writes a ConfigMap; the catalog then re-reads it and re-indexes
+ * its repositories in the background, which can take minutes. `CatalogSource`
+ * carries no sync timestamp — only id, name, enabled, labels, status and error —
+ * so a status flip or a label edit is observable from here, but an
+ * include/exclude filter edit is not: the source reports "available" throughout
+ * and the new content simply appears. For those the only honest end to the
+ * pending state is a timeout.
+ */
+export const SYNC_PENDING_TIMEOUT = 3 * 60 * 1000;
+
+type PendingSync = { since: number; fingerprint: string };
+
+/**
+ * Everything the catalog tells us about a source. Any difference means the
+ * catalog has re-read the source since it was marked pending.
+ */
+const fingerprintSource = (source: CatalogSource | undefined): string =>
+  source
+    ? JSON.stringify([
+        source.status ?? '',
+        source.error ?? '',
+        source.enabled ?? true,
+        source.labels,
+      ])
+    : '';
+
+export type CatalogSourceSyncTracker = {
+  /** True while `sourceId` has been edited and the catalog has not confirmed a reload. */
+  isSyncPending: (sourceId: string) => boolean;
+  /** Call after a successful create/update/toggle to start showing "syncing". */
+  markSyncPending: (sourceId: string) => void;
+  /** Feed each polled source list back in so pending marks can be cleared. */
+  reconcileSyncPending: (catalogSources: CatalogSourceList | null) => void;
+  /** True while any source is pending; used to raise the poll rate. */
+  hasPendingSyncs: boolean;
+};
+
+export const useCatalogSourceSyncTracker = (): CatalogSourceSyncTracker => {
+  const [pending, setPending] = React.useState<Record<string, PendingSync>>({});
+  const latestSourcesRef = React.useRef<CatalogSourceList | null>(null);
+
+  const markSyncPending = React.useCallback((sourceId: string) => {
+    const source = latestSourcesRef.current?.items?.find((s) => s.id === sourceId);
+    setPending((prev) => ({
+      ...prev,
+      [sourceId]: { since: Date.now(), fingerprint: fingerprintSource(source) },
+    }));
+  }, []);
+
+  const reconcileSyncPending = React.useCallback((catalogSources: CatalogSourceList | null) => {
+    latestSourcesRef.current = catalogSources;
+    setPending((prev) => {
+      const entries = Object.entries(prev);
+      if (entries.length === 0) {
+        return prev;
+      }
+      const kept = entries.filter(([sourceId, entry]) => {
+        const source = catalogSources?.items?.find((s) => s.id === sourceId);
+        return fingerprintSource(source) === entry.fingerprint;
+      });
+      // Returning `prev` unchanged when nothing resolved keeps this out of a
+      // render loop with the effect that reconciles on every poll.
+      return kept.length === entries.length ? prev : Object.fromEntries(kept);
+    });
+  }, []);
+
+  // Expire pending marks the catalog never gave us a signal for.
+  React.useEffect(() => {
+    const entries = Object.values(pending);
+    if (entries.length === 0) {
+      return undefined;
+    }
+    const earliest = Math.min(...entries.map((entry) => entry.since));
+    const timer = window.setTimeout(
+      () => {
+        const cutoff = Date.now() - SYNC_PENDING_TIMEOUT;
+        setPending((prev) => {
+          const kept = Object.entries(prev).filter(([, entry]) => entry.since > cutoff);
+          return kept.length === Object.keys(prev).length ? prev : Object.fromEntries(kept);
+        });
+      },
+      Math.max(0, earliest + SYNC_PENDING_TIMEOUT - Date.now()),
+    );
+    return () => window.clearTimeout(timer);
+  }, [pending]);
+
+  const hasPendingSyncs = Object.keys(pending).length > 0;
+
+  return React.useMemo(
+    () => ({
+      isSyncPending: (sourceId: string) => sourceId in pending,
+      markSyncPending,
+      reconcileSyncPending,
+      hasPendingSyncs,
+    }),
+    [pending, markSyncPending, reconcileSyncPending, hasPendingSyncs],
+  );
+};

--- a/clients/ui/frontend/src/app/shared/catalogSettings/hooks/useCatalogSourcesWithPolling.ts
+++ b/clients/ui/frontend/src/app/shared/catalogSettings/hooks/useCatalogSourcesWithPolling.ts
@@ -5,6 +5,8 @@ import type { CatalogSourcesPollingAPIState } from '~/app/shared/catalogSettings
 
 export const useCatalogSourcesWithPolling = (
   apiState: CatalogSourcesPollingAPIState,
+  /** Override the poll rate — used to speed the list up while an edit is settling. */
+  refreshRate: number = POLL_INTERVAL,
 ): FetchState<CatalogSourceList> => {
   const call = React.useCallback<FetchStateCallbackPromise<CatalogSourceList>>(
     (opts) => {
@@ -19,6 +21,6 @@ export const useCatalogSourcesWithPolling = (
   return useFetchState(
     call,
     { items: [], size: 0, pageSize: 0, nextPageToken: '' },
-    { initialPromisePurity: true, refreshRate: POLL_INTERVAL },
+    { initialPromisePurity: true, refreshRate },
   );
 };

--- a/clients/ui/frontend/src/app/shared/catalogSettings/index.ts
+++ b/clients/ui/frontend/src/app/shared/catalogSettings/index.ts
@@ -25,6 +25,12 @@ export type {
   UseCatalogSourcePreviewCoreResult,
 } from './hooks/useCatalogSourcePreviewCore';
 export { useCatalogSourcesWithPolling } from './hooks/useCatalogSourcesWithPolling';
+export {
+  useCatalogSourceSyncTracker,
+  SYNC_PENDING_POLL_INTERVAL,
+  SYNC_PENDING_TIMEOUT,
+} from './hooks/useCatalogSourceSyncTracker';
+export type { CatalogSourceSyncTracker } from './hooks/useCatalogSourceSyncTracker';
 export { useSourceConfigById } from './hooks/useSourceConfigById';
 export { useSourceConfigs } from './hooks/useSourceConfigs';
 export { generateSourceIdFromName } from './utils/generateSourceIdFromName';

--- a/clients/ui/frontend/src/app/shared/catalogSettings/types.ts
+++ b/clients/ui/frontend/src/app/shared/catalogSettings/types.ts
@@ -22,6 +22,10 @@ export type CatalogSettingsContextValue<TAPIState, TConfigList> = {
   catalogSourcesLoaded: boolean;
   catalogSourcesLoadError?: Error;
   refreshCatalogSources: () => void;
+  /** True while a source has been edited and the catalog has not confirmed the reload. */
+  isSyncPending: (sourceId: string) => boolean;
+  /** Mark a source as awaiting a catalog reload after a successful write. */
+  markSyncPending: (sourceId: string) => void;
 };
 
 /**

--- a/clients/ui/frontend/src/app/shared/types/catalogTypes.ts
+++ b/clients/ui/frontend/src/app/shared/types/catalogTypes.ts
@@ -28,7 +28,7 @@ export type PaginationParams = {
 
 export type CatalogSourceList = PaginationParams & { items?: CatalogSource[] };
 
-export type CatalogAssetType = 'models' | 'mcp_servers' | 'agents';
+export type CatalogAssetType = 'models' | 'mcp_servers' | 'agents' | 'skills';
 
 export type CatalogSourceListParams = {
   assetType?: CatalogAssetType;

--- a/clients/ui/frontend/src/app/skillCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/skillCatalogTypes.ts
@@ -1,0 +1,221 @@
+import { APIOptions } from 'mod-arch-core';
+import type {
+  CatalogFilterOptionsList,
+  PreviewCatalogSourceQueryParams,
+} from '~/app/modelCatalogTypes';
+import { PaginationParams } from '~/app/shared/types/catalogTypes';
+
+export type Skill = {
+  id: string;
+  name: string;
+  sourceId?: string;
+  displayName?: string;
+  description?: string;
+  readme?: string;
+  tags?: string[];
+  repositoryUrl?: string;
+  labels?: string[];
+  provider?: string;
+  category?: string;
+  trustTier?: string;
+  repository?: string;
+  path?: string;
+  version?: string;
+  resolvedCommit?: string;
+  license?: string;
+  /**
+   * SKILL.md body length. Surfaced as a quality signal: an agent loads the whole body
+   * into its context, so an over-long skill costs context budget. Not filterable.
+   */
+  bodyLineCount?: number;
+  author?: string;
+  compatibility?: string;
+  allowedTools?: string[];
+  supportingFiles?: string[];
+};
+
+export type SkillList = PaginationParams & { items?: Skill[] };
+
+export type SkillListParams = {
+  sourceLabel?: string;
+  pageSize?: number | string;
+  nextPageToken?: string;
+  q?: string;
+  filterQuery?: string;
+};
+
+export enum SkillCatalogSourceType {
+  GIT_SKILLS = 'git-skills-plugin',
+}
+
+/**
+ * A per-skill exception to a repository's custom metadata. The repository's own
+ * category/labels apply to every skill it yields; an override replaces them for the
+ * one skill it names.
+ *
+ * There is no form control for these — the settings UI edits repository-level
+ * metadata only. They are carried through so that saving a source authored by
+ * GitOps does not delete them, since the BFF rebuilds the repository entry from
+ * whatever the UI sends.
+ */
+export type SkillOverride = {
+  name: string;
+  category?: string;
+  labels?: string[];
+};
+
+export type SkillRepository = {
+  url: string;
+  canonicalUrl?: string;
+  refs?: string[];
+  scanPaths?: string[];
+  includedSkills?: string[];
+  excludedSkills?: string[];
+  /** Read-only in the UI; round-tripped verbatim so a UI save preserves them. */
+  skillOverrides?: SkillOverride[];
+  /**
+   * Write-only. The git token entered in the admin form. The BFF stores it in the
+   * shared git-credentials Secret and never echoes it back, so this is always
+   * undefined on reads.
+   */
+  authToken?: string;
+  /**
+   * Read-only. Key in the git-credentials Secret mounted into the catalog pod,
+   * set by the BFF when a token is supplied. Round-tripped on edit so that saving
+   * a source without re-entering the token keeps its existing credential.
+   */
+  credentialRef?: string;
+  provider?: string;
+  category?: string;
+  trustTier?: string;
+  /**
+   * Stamped onto every skill this repository yields, so they appear on skill cards
+   * and in the catalog filter options. Distinct from
+   * SkillCatalogSourceConfig.labels, which only group the source itself.
+   */
+  labels?: string[];
+};
+
+export type SkillCatalogSourceConfig = {
+  id: string;
+  name: string;
+  type: SkillCatalogSourceType;
+  enabled?: boolean;
+  isDefault?: boolean;
+  repositories?: SkillRepository[];
+  trustTier?: string;
+  provider?: string;
+  category?: string;
+  labels?: string[];
+};
+
+export type SkillCatalogSourceConfigPayload =
+  | SkillCatalogSourceConfig
+  | Pick<SkillCatalogSourceConfig, 'enabled' | 'repositories'>;
+
+export type SkillCatalogSourceConfigList = {
+  catalogs: SkillCatalogSourceConfig[];
+};
+
+export type GetSkillCatalogSourceConfigs = (
+  opts: APIOptions,
+) => Promise<SkillCatalogSourceConfigList>;
+export type CreateSkillCatalogSourceConfig = (
+  opts: APIOptions,
+  data: SkillCatalogSourceConfigPayload,
+) => Promise<SkillCatalogSourceConfig>;
+export type GetSkillCatalogSourceConfig = (
+  opts: APIOptions,
+  sourceId: string,
+) => Promise<SkillCatalogSourceConfig>;
+export type UpdateSkillCatalogSourceConfig = (
+  opts: APIOptions,
+  sourceId: string,
+  data: Partial<SkillCatalogSourceConfigPayload>,
+) => Promise<SkillCatalogSourceConfig>;
+export type DeleteSkillCatalogSourceConfig = (opts: APIOptions, sourceId: string) => Promise<void>;
+
+export type SkillCatalogSourcePreviewRequest = {
+  type: SkillCatalogSourceType;
+  properties?: Record<string, unknown>;
+};
+
+export type SkillCatalogSourcePreviewAsset = {
+  name: string;
+  included: boolean;
+};
+
+export type SkillCatalogSourcePreviewSummary = {
+  totalAssets: number;
+  includedAssets: number;
+  excludedAssets: number;
+};
+
+export type SkillCatalogSourcePreviewResult = {
+  items: SkillCatalogSourcePreviewAsset[];
+  summary: SkillCatalogSourcePreviewSummary;
+  nextPageToken: string;
+  pageSize: number;
+  size: number;
+};
+
+export type PreviewSkillCatalogSource = (
+  opts: APIOptions,
+  data: SkillCatalogSourcePreviewRequest,
+  queryParams?: PreviewCatalogSourceQueryParams,
+) => Promise<SkillCatalogSourcePreviewResult>;
+
+export type SkillCatalogSettingsAPIs = {
+  getSkillCatalogSourceConfigs: GetSkillCatalogSourceConfigs;
+  createSkillCatalogSourceConfig: CreateSkillCatalogSourceConfig;
+  getSkillCatalogSourceConfig: GetSkillCatalogSourceConfig;
+  updateSkillCatalogSourceConfig: UpdateSkillCatalogSourceConfig;
+  deleteSkillCatalogSourceConfig: DeleteSkillCatalogSourceConfig;
+  previewSkillCatalogSource: PreviewSkillCatalogSource;
+};
+
+export type GetSkillList = (opts: APIOptions, listParams?: SkillListParams) => Promise<SkillList>;
+
+export type GetSkillFilterOptionList = (opts: APIOptions) => Promise<CatalogFilterOptionsList>;
+
+export type GetSkill = (opts: APIOptions, skillId: string) => Promise<Skill>;
+
+export type SkillMarketplacePluginSource = {
+  url: string;
+  path: string;
+  ref?: string;
+  sha?: string;
+};
+
+export type SkillMarketplacePlugin = {
+  name: string;
+  source: SkillMarketplacePluginSource;
+};
+
+export type SkillMarketplace = {
+  name: string;
+  plugins?: SkillMarketplacePlugin[];
+};
+
+/**
+ * The marketplace manifest plus the URL to hand to `/plugin marketplace add`.
+ *
+ * The URL is not this BFF endpoint's: that route is namespace-scoped and
+ * authenticated, which an agent cannot satisfy. By default it is the catalog
+ * service's in-cluster address, reachable by agents running in the cluster;
+ * `external` is true only when an operator has configured a routable URL.
+ */
+export type SkillMarketplaceResult = {
+  marketplace: SkillMarketplace;
+  marketplaceUrl: string;
+  external: boolean;
+};
+
+export type GetSkillMarketplace = (opts: APIOptions) => Promise<SkillMarketplaceResult>;
+
+export type SkillCatalogSpecificAPIs = {
+  getSkillList: GetSkillList;
+  getSkillFilterOptionList: GetSkillFilterOptionList;
+  getSkill: GetSkill;
+  getSkillMarketplace: GetSkillMarketplace;
+};

--- a/docker-compose-local.yaml
+++ b/docker-compose-local.yaml
@@ -17,11 +17,13 @@ networks:
 services:
   model-registry-ui:
     build:
-      context: ./clients/ui
-      dockerfile: Dockerfile.standalone
+      context: .
+      dockerfile: clients/ui/Dockerfile.standalone
       args:
         DEPLOYMENT_MODE: standalone
         STYLE_THEME: mui-theme
+        UI_SOURCE_CODE: ./clients/ui/frontend
+        BFF_SOURCE_CODE: ./clients/ui/bff
     command:
       - --port=9000
       - --mock-k8s-client=true


### PR DESCRIPTION
The PR implements the KEP-0005, Skills Catalog

## Description
This PR includes UI for Skill catalog
- Admin UI, where user can create update delete source for enlisting or delisting Skills. Similar to any other catalogs
- Main Skills catalog gallery page with tiles showing the available skills in the catalog
- Skill Details Page

## How Has This Been Tested?
Yes, there are unit tests and manually has been tested.

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.

### Gallery Page
<img width="1819" height="1343" alt="image" src="https://github.com/user-attachments/assets/6c483733-f7e1-4c74-9f9f-c85afcad039d" />

### Skill Details Page
<img width="1819" height="1343" alt="image" src="https://github.com/user-attachments/assets/2adfa8c4-105a-4611-a3d7-44d7d4752f66" />

### Admin Page
<img width="1819" height="1343" alt="image" src="https://github.com/user-attachments/assets/cc9115ee-c9d5-4885-917e-c71688f18a04" />

Assisted-by: Claude Opus 5