### PR TITLE
chore: update manifests for release v0.3.15

### DIFF
--- a/manifests/kustomize/base/kustomization.yaml
+++ b/manifests/kustomize/base/kustomization.yaml
@@ -5,3 +5,7 @@ resources:
 - model-registry-deployment.yaml
 - model-registry-service.yaml
 - model-registry-sa.yaml
+images:
+- name: ghcr.io/kubeflow/hub/server
+  newName: ghcr.io/kubeflow/hub/server
+  newTag: v0.3.15

--- a/manifests/kustomize/options/catalog/base/kustomization.yaml
+++ b/manifests/kustomize/options/catalog/base/kustomization.yaml
@@ -28,13 +28,17 @@ configMapGenerator:
     disableNameSuffixHash: true
 
 secretGenerator:
-- name: model-catalog-postgres
-  envs:
+- envs:
   - postgres.env
+  name: model-catalog-postgres
   options:
     disableNameSuffixHash: true
-- name: model-catalog-hf-api-key
-  envs:
+- envs:
   - hf-api-key.env
+  name: model-catalog-hf-api-key
   options:
     disableNameSuffixHash: true
+images:
+- name: ghcr.io/kubeflow/hub/server
+  newName: ghcr.io/kubeflow/hub/server
+  newTag: v0.3.15

--- a/manifests/kustomize/options/csi/kustomization.yaml
+++ b/manifests/kustomize/options/csi/kustomization.yaml
@@ -4,3 +4,7 @@ namespace: kubeflow
 
 resources:
 - clusterstoragecontainer.yaml
+images:
+- name: ghcr.io/kubeflow/hub/storage-initializer
+  newName: ghcr.io/kubeflow/hub/storage-initializer
+  newTag: v0.3.15

--- a/manifests/kustomize/options/ui/base/kustomization.yaml
+++ b/manifests/kustomize/options/ui/base/kustomization.yaml
@@ -25,4 +25,4 @@ resources:
 images:
 - name: model-registry-ui
   newName: ghcr.io/kubeflow/hub/ui
-  newTag: latest
+  newTag: v0.3.15


### PR DESCRIPTION
## Summary
- Pin kustomize image tags to `v0.3.15` for the server, CSI storage-initializer, UI, and catalog.

## Test plan
- [ ] Confirm kustomize image tags match `v0.3.15`
- [ ] Confirm this targets `release/v0.3.15` on kubeflow/hub


Made with [Cursor](https://cursor.com)