### PR TITLE
update private/gated hf model inputs

### DIFF
--- a/api/openapi/catalog-v1.yaml
+++ b/api/openapi/catalog-v1.yaml
@@ -605,8 +605,11 @@ paths:
               huggingfaceSource:
                 summary: HuggingFace catalog source
                 description: |-
-                  Upload configuration for HuggingFace source with API credentials.
-                  The API key is passed per-request and not persisted anywhere.
+                  Upload configuration for a HuggingFace source.
+                  The API key is read from an environment variable (HF_API_KEY
+                  by default). Optionally set apiKeyEnvVar to HF_API_KEY or a
+                  name starting with HF_API_KEY_ to select a per-source key.
+                  Do not put the API key value in this configuration.
                 value: |
                   type: hf
                   includedModels:
@@ -615,8 +618,8 @@ paths:
                   excludedModels:
                     - "*-gguf"
                   properties:
-                    apiKey: "your-huggingface-api-key-here" # notsecret
-                    modelLimit: 100
+                    apiKeyEnvVar: "HF_API_KEY"
+                    maxModels: 100
               mcpStatelessPreview:
                 summary: Stateless MCP server preview
                 description: |-
@@ -1407,6 +1410,19 @@ components:
             This field is null or empty when the source is functioning normally.
           type: string
           nullable: true
+        hasApiKey:
+          description: |-
+            Whether an API token is stored for this source. The token value is never
+            returned. False for sources that have no stored token.
+          type: boolean
+          readOnly: true
+        authenticated:
+          description: |-
+            Whether the stored API token validated successfully.
+            Null when no token exists (`hasApiKey` is false).
+          type: boolean
+          nullable: true
+          readOnly: true
         includedModels:
           description: |-
             Optional list of glob patterns for models to include. If specified, only models matching

--- a/api/openapi/catalog.yaml
+++ b/api/openapi/catalog.yaml
@@ -691,8 +691,11 @@ paths:
               huggingfaceSource:
                 summary: HuggingFace catalog source
                 description: |-
-                  Upload configuration for HuggingFace source with API credentials.
-                  The API key is passed per-request and not persisted anywhere.
+                  Upload configuration for a HuggingFace source.
+                  The API key is read from an environment variable (HF_API_KEY
+                  by default). Optionally set apiKeyEnvVar to HF_API_KEY or a
+                  name starting with HF_API_KEY_ to select a per-source key.
+                  Do not put the API key value in this configuration.
                 value: |
                   type: hf
                   includedModels:
@@ -701,8 +704,8 @@ paths:
                   excludedModels:
                     - "*-gguf"
                   properties:
-                    apiKey: "your-huggingface-api-key-here" # notsecret
-                    modelLimit: 100
+                    apiKeyEnvVar: "HF_API_KEY"
+                    maxModels: 100
               mcpStatelessPreview:
                 summary: Stateless MCP server preview
                 description: |-
@@ -1412,6 +1415,19 @@ components:
             This field is null or empty when the source is functioning normally.
           type: string
           nullable: true
+        hasApiKey:
+          description: |-
+            Whether an API token is stored for this source. The token value is never
+            returned. False for sources that have no stored token.
+          type: boolean
+          readOnly: true
+        authenticated:
+          description: |-
+            Whether the stored API token validated successfully.
+            Null when no token exists (`hasApiKey` is false).
+          type: boolean
+          nullable: true
+          readOnly: true
         includedModels:
           description: |-
             Optional list of glob patterns for models to include. If specified, only models matching

--- a/api/openapi/src/catalog-v1.yaml
+++ b/api/openapi/src/catalog-v1.yaml
@@ -190,8 +190,11 @@ paths:
               huggingfaceSource:
                 summary: HuggingFace catalog source
                 description: |-
-                  Upload configuration for HuggingFace source with API credentials.
-                  The API key is passed per-request and not persisted anywhere.
+                  Upload configuration for a HuggingFace source.
+                  The API key is read from an environment variable (HF_API_KEY
+                  by default). Optionally set apiKeyEnvVar to HF_API_KEY or a
+                  name starting with HF_API_KEY_ to select a per-source key.
+                  Do not put the API key value in this configuration.
                 value: |
                   type: hf
                   includedModels:
@@ -200,8 +203,8 @@ paths:
                   excludedModels:
                     - "*-gguf"
                   properties:
-                    apiKey: "your-huggingface-api-key-here" # notsecret
-                    modelLimit: 100
+                    apiKeyEnvVar: "HF_API_KEY"
+                    maxModels: 100
               mcpStatelessPreview:
                 summary: Stateless MCP server preview
                 description: |-
@@ -321,6 +324,19 @@ components:
             This field is null or empty when the source is functioning normally.
           type: string
           nullable: true
+        hasApiKey:
+          description: |-
+            Whether an API token is stored for this source. The token value is never
+            returned. False for sources that have no stored token.
+          type: boolean
+          readOnly: true
+        authenticated:
+          description: |-
+            Whether the stored API token validated successfully.
+            Null when no token exists (`hasApiKey` is false).
+          type: boolean
+          nullable: true
+          readOnly: true
         includedModels:
           description: |-
             Optional list of glob patterns for models to include. If specified, only models matching

--- a/api/openapi/src/catalog.yaml
+++ b/api/openapi/src/catalog.yaml
@@ -198,8 +198,11 @@ paths:
               huggingfaceSource:
                 summary: HuggingFace catalog source
                 description: |-
-                  Upload configuration for HuggingFace source with API credentials.
-                  The API key is passed per-request and not persisted anywhere.
+                  Upload configuration for a HuggingFace source.
+                  The API key is read from an environment variable (HF_API_KEY
+                  by default). Optionally set apiKeyEnvVar to HF_API_KEY or a
+                  name starting with HF_API_KEY_ to select a per-source key.
+                  Do not put the API key value in this configuration.
                 value: |
                   type: hf
                   includedModels:
@@ -208,8 +211,8 @@ paths:
                   excludedModels:
                     - "*-gguf"
                   properties:
-                    apiKey: "your-huggingface-api-key-here" # notsecret
-                    modelLimit: 100
+                    apiKeyEnvVar: "HF_API_KEY"
+                    maxModels: 100
               mcpStatelessPreview:
                 summary: Stateless MCP server preview
                 description: |-
@@ -346,6 +349,19 @@ components:
             This field is null or empty when the source is functioning normally.
           type: string
           nullable: true
+        hasApiKey:
+          description: |-
+            Whether an API token is stored for this source. The token value is never
+            returned. False for sources that have no stored token.
+          type: boolean
+          readOnly: true
+        authenticated:
+          description: |-
+            Whether the stored API token validated successfully.
+            Null when no token exists (`hasApiKey` is false).
+          type: boolean
+          nullable: true
+          readOnly: true
         includedModels:
           description: |-
             Optional list of glob patterns for models to include. If specified, only models matching

--- a/catalog/README.md
+++ b/catalog/README.md
@@ -205,6 +205,73 @@ The following Hugging Face task types are mapped to model types:
 
 **Note:** The classification is performed automatically when models are fetched from Hugging Face. Models that don't match any known tasks will be classified as `"unknown"` and can be manually updated via the YAML catalog or API if needed.
 
+### Hugging Face Access Properties
+
+The Hugging Face catalog provider sets `hf_access_type` on every HF-sourced model. Presence of this property is the signal that the model came from Hugging Face; it is absent on non-HF models. UI consumers should switch on it for lock-icon and error messaging.
+
+#### `hf_access_type`
+
+**Metadata Type**: `MetadataStringValue`
+
+**Values**: `public` | `private` | `gated_auto` | `gated_manual`
+
+| Value | Meaning | Catalog behavior |
+|-------|---------|------------------|
+| `public` | Public Hugging Face repository | Full metadata |
+| `private` | Private repository | Only listed when the source has a valid token with org access; always has full metadata |
+| `gated_auto` | Gated with automatic approval after the user accepts the license | See `hf_gated_access_granted` |
+| `gated_manual` | Gated with manual review by the model author | See `hf_gated_access_granted` |
+
+Legacy Hugging Face `gated: true` is treated as `gated_auto`. Private takes precedence over gated.
+
+#### `hf_gated_access_granted`
+
+**Metadata Type**: `MetadataStringValue`
+
+**Values**: `"true"` | `"false"`
+
+Present **only on gated models**. `"false"` means the token holder has not been granted access to the gated content (lock / "request access" state, readme empty). `"true"` means full access and full metadata.
+
+**Example: gated model, access granted**
+```json
+{
+  "name": "meta-llama/Llama-3-8B",
+  "readme": "# Llama 3\n\nMeta's latest generation...",
+  "customProperties": {
+    "hf_access_type": { "string_value": "gated_auto", "metadataType": "MetadataStringValue" },
+    "hf_gated_access_granted": { "string_value": "true", "metadataType": "MetadataStringValue" }
+  }
+}
+```
+
+**Example: gated model, access not granted (degraded metadata)**
+```json
+{
+  "name": "meta-llama/Llama-3-8B",
+  "description": "",
+  "readme": "",
+  "license": "unknown",
+  "tasks": [],
+  "customProperties": {
+    "hf_access_type": { "string_value": "gated_auto", "metadataType": "MetadataStringValue" },
+    "hf_gated_access_granted": { "string_value": "false", "metadataType": "MetadataStringValue" }
+  }
+}
+```
+
+**Source token state** on `GET /sources` (token value is never returned):
+
+| `hasApiKey` | `authenticated` | Meaning |
+|-------------|-----------------|--------|
+| `false` | `null` | No token stored |
+| `true` | `true` | Token stored and validated |
+| `true` | `false` | Token stored but validation failed (expired/revoked) |
+
+Filter Hugging Face models by access type:
+```bash
+GET /api/model_catalog/v1alpha1/models?source=huggingface&filterQuery=hf_access_type.string_value='gated_auto'
+```
+
 ### Querying and Filtering by Custom Properties
 
 #### Filter by Model Type
@@ -362,8 +429,8 @@ kubectl rollout restart deployment model-catalog-server -n kubeflow
 Set `apiKeyEnvVar` to use a different API key per source. The value must be `HF_API_KEY` (the default) or start with `HF_API_KEY_` — for example, `HF_API_KEY_META` for a Meta-specific key. Other env var names are rejected. This lets operators supply separate credentials for different HuggingFace organizations without exposing arbitrary environment variables.
 
 **Important Notes:**
-- **Private Models**: For private models, the API key must belong to an account that has been granted access to the model. Without proper access, the catalog service will not be able to retrieve model information.
-- **Gated Models**: For gated models (models with usage restrictions), you must accept the model's terms of service on Hugging Face before the catalog service can access all available model information. Visit the model's page on Hugging Face and accept the terms to ensure full metadata is available.
+- **Private Models**: Private models only appear when the source has a valid token with organization access, and they have all available metadata from Hugging Face (`hf_access_type="private"`). Without access the catalog omits the model entirely.
+- **Gated Models**: Gated models appear even when the token holder has not accepted the license. `hf_gated_access_granted="false"` means lock / "request access" (readme and some other metadata not accessible). `"true"` means full metadata. Accept the model's terms on Hugging Face to request access from the organization.
 
 #### 2. Configure the Source
 

--- a/catalog/pkg/openapi/model_catalog_source.go
+++ b/catalog/pkg/openapi/model_catalog_source.go
@@ -30,6 +30,10 @@ type CatalogSource struct {
 	Status *CatalogSourceStatus `json:"status,omitempty"`
 	// Detailed error information when the status is \"Error\". This field is null or empty when the source is functioning normally.
 	Error NullableString `json:"error,omitempty"`
+	// Whether an API token is stored for this source. The token value is never returned. False for sources that have no stored token.
+	HasApiKey *bool `json:"hasApiKey,omitempty"`
+	// Whether the stored API token validated successfully. Null when no token exists (`hasApiKey` is false).
+	Authenticated NullableBool `json:"authenticated,omitempty"`
 	// Optional list of glob patterns for models to include. If specified, only models matching at least one pattern will be included. If omitted, all models are considered for inclusion.  Pattern Syntax: - Only the `*` wildcard is supported (matches zero or more characters) - Patterns are case-insensitive (e.g., `Granite/_*` matches `granite/model` and `GRANITE/model`) - Patterns match the entire model name (anchored at start and end) - Wildcards can appear anywhere: `Granite/_*`, `*-beta`, `*deprecated*`, `*_/old*`  Examples: - `ibm-granite/_*` - matches all models starting with \"ibm-granite/\" - `meta-llama/_*` - matches all models in the meta-llama namespace - `*` - matches all models  Constraints: - Patterns cannot be empty or whitespace-only - A pattern cannot appear in both includedModels and excludedModels
 	IncludedModels []string `json:"includedModels,omitempty"`
 	// Optional list of glob patterns for models to exclude. Models matching any pattern will be excluded even if they match an includedModels pattern. Exclusions take precedence over inclusions.  Pattern Syntax: - Only the `*` wildcard is supported (matches zero or more characters) - Patterns are case-insensitive - Patterns match the entire model name (anchored at start and end) - Wildcards can appear anywhere in the pattern  Examples: - `*-draft` - excludes all models ending with \"-draft\" - `*-experimental` - excludes experimental models - `*deprecated*` - excludes models with \"deprecated\" anywhere in the name - `*_/beta-*` - excludes models with \"/beta-\" in the path  Constraints: - Patterns cannot be empty or whitespace-only - A pattern cannot appear in both includedModels and excludedModels
@@ -246,6 +250,81 @@ func (o *CatalogSource) UnsetError() {
 	o.Error.Unset()
 }
 
+// GetHasApiKey returns the HasApiKey field value if set, zero value otherwise.
+func (o *CatalogSource) GetHasApiKey() bool {
+	if o == nil || IsNil(o.HasApiKey) {
+		var ret bool
+		return ret
+	}
+	return *o.HasApiKey
+}
+
+// GetHasApiKeyOk returns a tuple with the HasApiKey field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *CatalogSource) GetHasApiKeyOk() (*bool, bool) {
+	if o == nil || IsNil(o.HasApiKey) {
+		return nil, false
+	}
+	return o.HasApiKey, true
+}
+
+// HasHasApiKey returns a boolean if a field has been set.
+func (o *CatalogSource) HasHasApiKey() bool {
+	if o != nil && !IsNil(o.HasApiKey) {
+		return true
+	}
+
+	return false
+}
+
+// SetHasApiKey gets a reference to the given bool and assigns it to the HasApiKey field.
+func (o *CatalogSource) SetHasApiKey(v bool) {
+	o.HasApiKey = &v
+}
+
+// GetAuthenticated returns the Authenticated field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *CatalogSource) GetAuthenticated() bool {
+	if o == nil || IsNil(o.Authenticated.Get()) {
+		var ret bool
+		return ret
+	}
+	return *o.Authenticated.Get()
+}
+
+// GetAuthenticatedOk returns a tuple with the Authenticated field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *CatalogSource) GetAuthenticatedOk() (*bool, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return o.Authenticated.Get(), o.Authenticated.IsSet()
+}
+
+// HasAuthenticated returns a boolean if a field has been set.
+func (o *CatalogSource) HasAuthenticated() bool {
+	if o != nil && o.Authenticated.IsSet() {
+		return true
+	}
+
+	return false
+}
+
+// SetAuthenticated gets a reference to the given NullableBool and assigns it to the Authenticated field.
+func (o *CatalogSource) SetAuthenticated(v bool) {
+	o.Authenticated.Set(&v)
+}
+
+// SetAuthenticatedNil sets the value for Authenticated to be an explicit nil
+func (o *CatalogSource) SetAuthenticatedNil() {
+	o.Authenticated.Set(nil)
+}
+
+// UnsetAuthenticated ensures that no value is present for Authenticated, not even an explicit nil
+func (o *CatalogSource) UnsetAuthenticated() {
+	o.Authenticated.Unset()
+}
+
 // GetIncludedModels returns the IncludedModels field value if set, zero value otherwise.
 func (o *CatalogSource) GetIncludedModels() []string {
 	if o == nil || IsNil(o.IncludedModels) {
@@ -363,6 +442,12 @@ func (o CatalogSource) ToMap() (map[string]interface{}, error) {
 	}
 	if o.Error.IsSet() {
 		toSerialize["error"] = o.Error.Get()
+	}
+	if !IsNil(o.HasApiKey) {
+		toSerialize["hasApiKey"] = o.HasApiKey
+	}
+	if o.Authenticated.IsSet() {
+		toSerialize["authenticated"] = o.Authenticated.Get()
 	}
 	if !IsNil(o.IncludedModels) {
 		toSerialize["includedModels"] = o.IncludedModels


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds openapi spec options for private and gated Hugging Face models for the model catalog. At this point, they are still blocked from retrieval and cannot be deployed. See the description below for a summary of changes:

CatalogSource — 2 new fields on GET /sources

- hasApiKey (boolean, read-only) — whether a token is stored for this source. Token value is never returned. Existing sources without tokens just don't have it.
- authenticated (boolean, nullable, read-only) — whether the stored token validated successfully. Null when no token exists.

CatalogModel — 2 new custom properties (via existing customProperties map)

- hf_access_type — public | private | gated_auto | gated_manual — primary switch for lock icon / error messaging. Presence indicates the model is from HuggingFace. Absent on non-HF models.
- hf_gated_access_granted — "true" | "false" — only present on gated models. "false" means the token holder has not been granted access to the gated content. "true" means full access.

Access types logic:

- hf_access_type = gated_* + hf_gated_access_granted = "false" → show lock / "request access" state, readme will be empty
- hf_access_type = gated_* + hf_gated_access_granted = "true" → full access, full metadata
- hf_access_type = private → model only appears when source has valid token with org access, always has full metadata
- hf_access_type absent → not an HF model, doesn't apply

No new endpoints

- Token write/validate/clear uses existing BFF secret pipeline
- validateHFModelDeployment() deployment block removed — deploy no longer 403s on private/gated models

Example: source with token

{
  "id": "hf-source-1",
  "name": "HuggingFace Hub",
  "enabled": true,
  "labels": ["huggingface"],
  "status": "partially-available",
  "error": "2 models returned 403: gated model requires agreement",
  "hasApiKey": true,
  "authenticated": true,
  "assetType": "models"
}

Example: source without token

{
  "id": "hf-source-2",
  "name": "Public HF Models",
  "enabled": true,
  "labels": ["huggingface"],
  "status": "available",
  "error": null,
  "hasApiKey": false,
  "authenticated": null,
  "assetType": "models"
}

Example: source with expired/revoked token

{
  "id": "hf-source-3",
  "name": "HuggingFace Hub",
  "enabled": true,
  "labels": ["huggingface"],
  "status": "error",
  "error": "Hugging Face API credential validation failed: 401 Unauthorized",
  "hasApiKey": true,
  "authenticated": false,
  "assetType": "models"
}

Example: private model (full metadata, only visible with valid token)

{
  "name": "my-org/private-llm",
  "sourceId": "hf-source-1",
  "description": "Internal fine-tuned LLM",
  "readme": "# Private LLM\n\nInternal model for...",
  "provider": "my-org",
  "tasks": ["text-generation"],
  "customProperties": {
    "hf_access_type": { "string_value": "private", "metadataType": "MetadataStringValue" }
  }
}

Example: gated model (access granted, full metadata)

{
  "name": "meta-llama/Llama-3-8B",
  "sourceId": "hf-source-1",
  "description": "Meta's Llama 3 8B base model",
  "readme": "# Llama 3\n\nMeta's latest generation...",
  "license": "llama3",
  "tasks": ["text-generation"],
  "customProperties": {
    "hf_access_type": { "string_value": "gated_auto", "metadataType": "MetadataStringValue" },
    "hf_gated_access_granted": { "string_value": "true", "metadataType": "MetadataStringValue" }
  }
}

Example: gated model (access NOT granted, degraded metadata)

{
  "name": "meta-llama/Llama-3-8B",
  "sourceId": "hf-source-1",
  "description": "",
  "readme": "",
  "license": "unknown",
  "tasks": [],
  "customProperties": {
    "hf_access_type": { "string_value": "gated_auto", "metadataType": "MetadataStringValue" },
    "hf_gated_access_granted": { "string_value": "false", "metadataType": "MetadataStringValue" }
  }
}

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] The commits have meaningful messages
- [ ] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work.
- [ ] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
