### PR TITLE
migrate fuzz tests from alpha API versions to v1

### DIFF
--- a/catalog/clients/python/tests/fuzz_api/conftest.py
+++ b/catalog/clients/python/tests/fuzz_api/conftest.py
@@ -113,7 +113,7 @@ def generated_schema(
         FileNotFoundError: If the schema file or config file cannot be found.
         schemathesis.SchemaError: If the schema is invalid.
     """
-    schema_file = getattr(request, "param", "catalog.yaml")
+    schema_file = getattr(request, "param", "catalog-v1.yaml")
     os.environ["API_HOST"] = CATALOG_URL
 
     # Read and modify schemathesis.toml if verify_ssl is False

--- a/catalog/clients/python/tests/fuzz_api/test_catalog_stateless.py
+++ b/catalog/clients/python/tests/fuzz_api/test_catalog_stateless.py
@@ -7,7 +7,7 @@ from hypothesis import settings
 schema = schemathesis.pytest.from_fixture("generated_schema")
 
 
-@pytest.mark.parametrize("generated_schema", ["catalog.yaml"], indirect=True)
+@pytest.mark.parametrize("generated_schema", ["catalog-v1.yaml"], indirect=True)
 @schema.parametrize()
 @settings(
     deadline=None,

--- a/clients/python/tests/fuzz_api/conftest.py
+++ b/clients/python/tests/fuzz_api/conftest.py
@@ -18,40 +18,32 @@ from tests.constants import DEFAULT_API_TIMEOUT, REGISTRY_URL
 logger = logging.getLogger(__name__)
 
 SINGLETON_GET_PATHS = {
-    "/api/model_registry/v1alpha3/registered_model",
-    "/api/model_registry/v1alpha3/model_version",
-    "/api/model_registry/v1alpha3/experiment",
-    "/api/model_registry/v1alpha3/experiment_run",
-    "/api/model_registry/v1alpha3/inference_service",
-    "/api/model_registry/v1alpha3/serving_environment",
-    "/api/model_registry/v1alpha3/artifact",
-    "/api/model_registry/v1alpha3/model_artifact",
+    "/api/model_registry/v1/registered_model",
+    "/api/model_registry/v1/model_version",
+    "/api/model_registry/v1/inference_service",
+    "/api/model_registry/v1/serving_environment",
+    "/api/model_registry/v1/artifact",
+    "/api/model_registry/v1/model_artifact",
 }
 
 
 _PATH_PROPERTIES: dict[str, set[str]] = {
-    "/api/model_registry/v1alpha3/artifacts": {"artifactType", "customProperties", "description", "digest", "externalId", "modelFormatName", "modelFormatVersion", "modelSourceClass", "modelSourceGroup", "modelSourceId", "modelSourceKind", "modelSourceName", "name", "parameterType", "profile", "schema", "serviceAccountName", "source", "sourceType", "state", "step", "storageKey", "storagePath", "timestamp", "uri", "value"},
-    "/api/model_registry/v1alpha3/artifacts/{id}": {"artifactType", "customProperties", "description", "digest", "externalId", "modelFormatName", "modelFormatVersion", "modelSourceClass", "modelSourceGroup", "modelSourceId", "modelSourceKind", "modelSourceName", "parameterType", "profile", "schema", "serviceAccountName", "source", "sourceType", "state", "step", "storageKey", "storagePath", "timestamp", "uri", "value"},
-    "/api/model_registry/v1alpha3/experiment_runs": {"customProperties", "description", "endTimeSinceEpoch", "experimentId", "externalId", "name", "owner", "startTimeSinceEpoch", "state", "status"},
-    "/api/model_registry/v1alpha3/experiment_runs/{experimentrunId}": {"customProperties", "description", "endTimeSinceEpoch", "externalId", "owner", "state", "status"},
-    "/api/model_registry/v1alpha3/experiment_runs/{experimentrunId}/artifacts": {"artifactType", "customProperties", "description", "digest", "experimentId", "experimentRunId", "externalId", "modelFormatName", "modelFormatVersion", "modelSourceClass", "modelSourceGroup", "modelSourceId", "modelSourceKind", "modelSourceName", "name", "parameterType", "profile", "schema", "serviceAccountName", "source", "sourceType", "state", "step", "storageKey", "storagePath", "timestamp", "uri", "value"},
-    "/api/model_registry/v1alpha3/experiments": {"customProperties", "description", "externalId", "name", "owner", "state"},
-    "/api/model_registry/v1alpha3/experiments/{experimentId}": {"customProperties", "description", "externalId", "owner", "state"},
-    "/api/model_registry/v1alpha3/experiments/{experimentId}/experiment_runs": {"customProperties", "description", "endTimeSinceEpoch", "experimentId", "externalId", "name", "owner", "startTimeSinceEpoch", "state", "status"},
-    "/api/model_registry/v1alpha3/inference_services": {"customProperties", "description", "desiredState", "externalId", "modelVersionId", "name", "registeredModelId", "runtime", "servingEnvironmentId"},
-    "/api/model_registry/v1alpha3/inference_services/{inferenceserviceId}": {"customProperties", "description", "desiredState", "externalId", "modelVersionId", "runtime"},
-    "/api/model_registry/v1alpha3/inference_services/{inferenceserviceId}/serves": {"customProperties", "description", "externalId", "lastKnownState", "modelVersionId", "name"},
-    "/api/model_registry/v1alpha3/model_artifacts": {"artifactType", "customProperties", "description", "externalId", "modelFormatName", "modelFormatVersion", "modelSourceClass", "modelSourceGroup", "modelSourceId", "modelSourceKind", "modelSourceName", "name", "serviceAccountName", "state", "storageKey", "storagePath", "uri"},
-    "/api/model_registry/v1alpha3/model_artifacts/{modelartifactId}": {"artifactType", "customProperties", "description", "externalId", "modelFormatName", "modelFormatVersion", "modelSourceClass", "modelSourceGroup", "modelSourceId", "modelSourceKind", "modelSourceName", "serviceAccountName", "state", "storageKey", "storagePath", "uri"},
-    "/api/model_registry/v1alpha3/model_versions": {"author", "customProperties", "description", "externalId", "name", "registeredModelId", "state"},
-    "/api/model_registry/v1alpha3/model_versions/{modelversionId}": {"author", "customProperties", "description", "externalId", "state"},
-    "/api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts": {"artifactType", "customProperties", "description", "digest", "experimentId", "experimentRunId", "externalId", "modelFormatName", "modelFormatVersion", "modelSourceClass", "modelSourceGroup", "modelSourceId", "modelSourceKind", "modelSourceName", "name", "parameterType", "profile", "schema", "serviceAccountName", "source", "sourceType", "state", "step", "storageKey", "storagePath", "timestamp", "uri", "value"},
-    "/api/model_registry/v1alpha3/registered_models": {"customProperties", "description", "externalId", "language", "libraryName", "license", "licenseLink", "logo", "maturity", "name", "owner", "provider", "readme", "state", "tasks"},
-    "/api/model_registry/v1alpha3/registered_models/{registeredmodelId}": {"customProperties", "description", "externalId", "language", "libraryName", "license", "licenseLink", "logo", "maturity", "owner", "provider", "readme", "state", "tasks"},
-    "/api/model_registry/v1alpha3/registered_models/{registeredmodelId}/versions": {"author", "customProperties", "description", "externalId", "name", "registeredModelId", "state"},
-    "/api/model_registry/v1alpha3/serving_environments": {"customProperties", "description", "externalId", "name"},
-    "/api/model_registry/v1alpha3/serving_environments/{servingenvironmentId}": {"customProperties", "description", "externalId"},
-    "/api/model_registry/v1alpha3/serving_environments/{servingenvironmentId}/inference_services": {"customProperties", "description", "desiredState", "externalId", "modelVersionId", "name", "registeredModelId", "runtime", "servingEnvironmentId"},
+    "/api/model_registry/v1/artifacts": {"artifactType", "customProperties", "description", "digest", "externalId", "modelFormatName", "modelFormatVersion", "modelSourceClass", "modelSourceGroup", "modelSourceId", "modelSourceKind", "modelSourceName", "name", "parameterType", "profile", "schema", "serviceAccountName", "source", "sourceType", "state", "step", "storageKey", "storagePath", "timestamp", "uri", "value"},
+    "/api/model_registry/v1/artifacts/{id}": {"artifactType", "customProperties", "description", "digest", "externalId", "modelFormatName", "modelFormatVersion", "modelSourceClass", "modelSourceGroup", "modelSourceId", "modelSourceKind", "modelSourceName", "parameterType", "profile", "schema", "serviceAccountName", "source", "sourceType", "state", "step", "storageKey", "storagePath", "timestamp", "uri", "value"},
+    "/api/model_registry/v1/inference_services": {"customProperties", "description", "desiredState", "externalId", "modelVersionId", "name", "registeredModelId", "runtime", "servingEnvironmentId"},
+    "/api/model_registry/v1/inference_services/{inference_service_id}": {"customProperties", "description", "desiredState", "externalId", "modelVersionId", "runtime"},
+    "/api/model_registry/v1/inference_services/{inference_service_id}/serves": {"customProperties", "description", "externalId", "lastKnownState", "modelVersionId", "name"},
+    "/api/model_registry/v1/model_artifacts": {"artifactType", "customProperties", "description", "externalId", "modelFormatName", "modelFormatVersion", "modelSourceClass", "modelSourceGroup", "modelSourceId", "modelSourceKind", "modelSourceName", "name", "serviceAccountName", "state", "storageKey", "storagePath", "uri"},
+    "/api/model_registry/v1/model_artifacts/{modelartifactId}": {"artifactType", "customProperties", "description", "externalId", "modelFormatName", "modelFormatVersion", "modelSourceClass", "modelSourceGroup", "modelSourceId", "modelSourceKind", "modelSourceName", "serviceAccountName", "state", "storageKey", "storagePath", "uri"},
+    "/api/model_registry/v1/model_versions": {"author", "customProperties", "description", "externalId", "name", "registeredModelId", "state"},
+    "/api/model_registry/v1/model_versions/{model_version_id}": {"author", "customProperties", "description", "externalId", "state"},
+    "/api/model_registry/v1/model_versions/{model_version_id}/artifacts": {"artifactType", "customProperties", "description", "digest", "experimentId", "experimentRunId", "externalId", "modelFormatName", "modelFormatVersion", "modelSourceClass", "modelSourceGroup", "modelSourceId", "modelSourceKind", "modelSourceName", "name", "parameterType", "profile", "schema", "serviceAccountName", "source", "sourceType", "state", "step", "storageKey", "storagePath", "timestamp", "uri", "value"},
+    "/api/model_registry/v1/registered_models": {"customProperties", "description", "externalId", "language", "libraryName", "license", "licenseLink", "logo", "maturity", "name", "owner", "provider", "readme", "state", "tasks"},
+    "/api/model_registry/v1/registered_models/{registered_model_id}": {"customProperties", "description", "externalId", "language", "libraryName", "license", "licenseLink", "logo", "maturity", "owner", "provider", "readme", "state", "tasks"},
+    "/api/model_registry/v1/registered_models/{registered_model_id}/versions": {"author", "customProperties", "description", "externalId", "name", "registeredModelId", "state"},
+    "/api/model_registry/v1/serving_environments": {"customProperties", "description", "externalId", "name"},
+    "/api/model_registry/v1/serving_environments/{serving_environment_id}": {"customProperties", "description", "externalId"},
+    "/api/model_registry/v1/serving_environments/{serving_environment_id}/inference_services": {"customProperties", "description", "desiredState", "externalId", "modelVersionId", "name", "registeredModelId", "runtime", "servingEnvironmentId"},
 }
 
 _ALL_BODY_PROPERTIES = set().union(*_PATH_PROPERTIES.values())
@@ -211,8 +203,8 @@ def _fix_body_id(case: Case) -> None:
         del case.body["id"]
 
 
-_ID_PATH_PARAMS = {"id", "registeredmodelId", "modelversionId", "experimentId", "experimentrunId",
-                   "inferenceserviceId", "servingenvironmentId", "servemodelId"}
+_ID_PATH_PARAMS = {"id", "registered_model_id", "model_version_id",
+                   "inference_service_id", "serving_environment_id", "servemodelId"}
 
 
 def _fix_path_param_ids(case: Case) -> None:
@@ -241,10 +233,9 @@ def _is_valid_id(val: Any) -> bool:
 
 
 _GENERIC_ARTIFACT_PATHS = {
-    "/api/model_registry/v1alpha3/artifacts",
-    "/api/model_registry/v1alpha3/artifacts/{id}",
-    "/api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts",
-    "/api/model_registry/v1alpha3/experiment_runs/{experimentrunId}/artifacts",
+    "/api/model_registry/v1/artifacts",
+    "/api/model_registry/v1/artifacts/{id}",
+    "/api/model_registry/v1/model_versions/{model_version_id}/artifacts",
 }
 
 
@@ -352,7 +343,7 @@ def _strip_filter_unsafe(s: str) -> str:
 def generated_schema(request: pytest.FixtureRequest, pytestconfig: pytest.Config,
                      verify_ssl: bool) -> OpenApiSchema:
     """Generate schema for the API based on the schema_file parameter"""
-    schema_file = getattr(request, "param", "model-registry.yaml")
+    schema_file = getattr(request, "param", "model-registry-v1.yaml")
     os.environ["API_HOST"] = REGISTRY_URL
 
     # Read and modify schemathesis.toml if verify_ssl is False
@@ -439,7 +430,7 @@ def cleanup_artifacts(request: pytest.FixtureRequest, auth_headers: dict, verify
     yield register
 
     for artifact_id in created_ids:
-        del_url = f"{REGISTRY_URL}/api/model_registry/v1alpha3/artifacts/{artifact_id}"
+        del_url = f"{REGISTRY_URL}/api/model_registry/v1/artifacts/{artifact_id}"
         try:
             requests.delete(del_url, headers=auth_headers, timeout=DEFAULT_API_TIMEOUT, verify=verify_ssl)
         except Exception as e:
@@ -452,7 +443,7 @@ def artifact_resource(verify_ssl: bool):
 
     @contextlib.contextmanager
     def _artifact_resource(auth_headers: dict, payload: dict) -> Generator[str, None, None]:
-        create_endpoint = f"{REGISTRY_URL}/api/model_registry/v1alpha3/artifacts"
+        create_endpoint = f"{REGISTRY_URL}/api/model_registry/v1/artifacts"
         resp = requests.post(create_endpoint, headers=auth_headers, json=payload, timeout=DEFAULT_API_TIMEOUT,
                              verify=verify_ssl)
         resp.raise_for_status()
@@ -460,11 +451,10 @@ def artifact_resource(verify_ssl: bool):
         try:
             yield artifact_id
         finally:
-            del_url = f"{REGISTRY_URL}/api/model_registry/v1alpha3/artifacts/{artifact_id}"
+            del_url = f"{REGISTRY_URL}/api/model_registry/v1/artifacts/{artifact_id}"
             try:
                 requests.delete(del_url, headers=auth_headers, timeout=DEFAULT_API_TIMEOUT, verify=verify_ssl)
             except Exception as e:
                 print(f"Failed to delete artifact {artifact_id}: {e}")
 
     return _artifact_resource
-

--- a/clients/python/tests/fuzz_api/model_catalog/test_catalog_stateful.py
+++ b/clients/python/tests/fuzz_api/model_catalog/test_catalog_stateful.py
@@ -7,7 +7,7 @@ from hypothesis.errors import Unsatisfiable
 
 @pytest.mark.fuzz
 class TestCatalogAPIStateful:
-    @pytest.mark.parametrize("generated_schema", ["catalog.yaml"], indirect=True)
+    @pytest.mark.parametrize("generated_schema", ["catalog-v1.yaml"], indirect=True)
     def test_catalog_api_stateful(self, state_machine):
         """Launches stateful tests against the Model Catalog API endpoints defined in its openAPI yaml spec file"""
         try:

--- a/clients/python/tests/fuzz_api/model_catalog/test_catalog_stateless.py
+++ b/clients/python/tests/fuzz_api/model_catalog/test_catalog_stateless.py
@@ -6,7 +6,7 @@ from tests.fuzz_api.model_registry.test_mr_stateless import call_and_validate_wi
 
 schema = schemathesis.pytest.from_fixture("generated_schema")
 
-@pytest.mark.parametrize("generated_schema", ["catalog.yaml"], indirect=True)
+@pytest.mark.parametrize("generated_schema", ["catalog-v1.yaml"], indirect=True)
 @schema.parametrize()
 @settings(
     deadline=None,

--- a/clients/python/tests/fuzz_api/model_registry/test_mr_stateful.py
+++ b/clients/python/tests/fuzz_api/model_registry/test_mr_stateful.py
@@ -7,7 +7,7 @@ from hypothesis.errors import Unsatisfiable
 
 @pytest.mark.fuzz
 class TestRestAPIStateful:
-    @pytest.mark.parametrize("generated_schema", ["model-registry.yaml"], indirect=True)
+    @pytest.mark.parametrize("generated_schema", ["model-registry-v1.yaml"], indirect=True)
     def test_mr_api_stateful(self, state_machine):
         """Launches stateful tests against the Model Registry API endpoints defined in its openAPI yaml spec file"""
         try:

--- a/clients/python/tests/fuzz_api/model_registry/test_mr_stateless.py
+++ b/clients/python/tests/fuzz_api/model_registry/test_mr_stateless.py
@@ -161,77 +161,6 @@ def validate_artifact_response(response: requests.Response, expected_payload: di
     return response_json["id"]
 
 
-def create_experiment_and_run(auth_headers: dict[str, str], verify_tls: bool) -> tuple[str, str]:
-    """Create an experiment and an experiment run.
-
-    Args:
-        auth_headers: Authentication headers for the API
-        verify_tls: Verify TLS
-    Returns:
-        Tuple of (experiment_id, experiment_run_id)
-
-    Raises:
-        AssertionError: If creation fails
-    """
-    # Create an experiment
-    experiment_payload = {
-        "name": f"test-experiment-{secrets.randbelow(1000000)}",
-        "externalId": generate_random_id(),
-        "description": "Test experiment for artifact testing"
-    }
-    exp_response = requests.post(
-        f"{REGISTRY_URL}/api/model_registry/v1alpha3/experiments",
-        headers=auth_headers,
-        json=experiment_payload,
-        timeout=DEFAULT_API_TIMEOUT, verify=verify_tls
-    )
-    assert exp_response.status_code in {200, 201}, f"Failed to create experiment: {exp_response.text}"
-    experiment_id = exp_response.json()["id"]
-
-    # Create an experiment run
-    experiment_run_payload = {
-        "experimentId": experiment_id,
-        "name": f"test-run-{secrets.randbelow(1000000)}",
-        "externalId": generate_random_id(),
-        "description": "Test experiment run for artifact testing"
-    }
-    run_response = requests.post(
-        f"{REGISTRY_URL}/api/model_registry/v1alpha3/experiment_runs",
-        headers=auth_headers,
-        json=experiment_run_payload,
-        timeout=DEFAULT_API_TIMEOUT, verify=verify_tls
-    )
-    assert run_response.status_code in {200, 201}, f"Failed to create experiment run: {run_response.text}"
-    experiment_run_id = run_response.json()["id"]
-
-    return experiment_id, experiment_run_id
-
-
-def cleanup_experiment_and_run(auth_headers: dict[str, str], experiment_id: str, experiment_run_id: str,
-                               verify_tls: bool) -> None:
-    """Best effort cleanup of experiment run and experiment.
-
-    Args:
-        auth_headers: Authentication headers for the API
-        experiment_id: ID of the experiment to delete
-        experiment_run_id: ID of the experiment run to delete
-        verify_tls: Verify TLS
-    """
-    try:
-        requests.delete(
-            f"{REGISTRY_URL}/api/model_registry/v1alpha3/experiment_runs/{experiment_run_id}",
-            headers=auth_headers,
-            timeout=DEFAULT_API_TIMEOUT, verify=verify_tls
-        )
-        requests.delete(
-            f"{REGISTRY_URL}/api/model_registry/v1alpha3/experiments/{experiment_id}",
-            headers=auth_headers,
-            timeout=DEFAULT_API_TIMEOUT, verify=verify_tls
-        )
-    except Exception as e:
-        logging.warning(f"Failed to cleanup experiment (id={experiment_id}) and/or experiment run (id={experiment_run_id}): {e}")
-
-
 # Null byte validation for Model Registry API endpoints specifically
 @schemathesis.check
 def check_null_byte_validation_mr(ctx, response, case):
@@ -249,15 +178,11 @@ schema = schemathesis.pytest.from_fixture("generated_schema")
 base_schema = (
     schema
     .exclude(
-        path="/api/model_registry/v1alpha3/artifacts/{id}",
+        path="/api/model_registry/v1/artifacts/{id}",
         method="PATCH"
     )
     .exclude(
-        path="/api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts",
-        method="POST"
-    )
-    .exclude(
-        path="/api/model_registry/v1alpha3/experiment_runs/{experimentrunId}/artifacts",
+        path="/api/model_registry/v1/model_versions/{model_version_id}/artifacts",
         method="POST"
     )
 )
@@ -266,7 +191,7 @@ base_schema = (
 # This creates many small test functions that can be distributed across workers
 
 # GET endpoints - split by resource type
-@pytest.mark.parametrize("generated_schema", ["model-registry.yaml"], indirect=True)
+@pytest.mark.parametrize("generated_schema", ["model-registry-v1.yaml"], indirect=True)
 @base_schema.include(method="GET", path_regex=".*/(registered_model|model_version).*").parametrize()
 @settings(
     max_examples=100,
@@ -283,7 +208,7 @@ def test_mr_api_stateless_get_models(auth_headers: dict, case: schemathesis.Case
     call_and_validate_with_null_byte_handling(case, auth_headers, verify_ssl)
 
 
-@pytest.mark.parametrize("generated_schema", ["model-registry.yaml"], indirect=True)
+@pytest.mark.parametrize("generated_schema", ["model-registry-v1.yaml"], indirect=True)
 @base_schema.include(method="GET", path_regex=".*/artifact.*").parametrize()
 @settings(
     max_examples=100,
@@ -300,24 +225,7 @@ def test_mr_api_stateless_get_artifacts(auth_headers: dict, case: schemathesis.C
     call_and_validate_with_null_byte_handling(case, auth_headers, verify_ssl)
 
 
-@pytest.mark.parametrize("generated_schema", ["model-registry.yaml"], indirect=True)
-@base_schema.include(method="GET", path_regex=".*/experiment.*").parametrize()
-@settings(
-    max_examples=100,
-    deadline=None,
-    suppress_health_check=[
-        HealthCheck.filter_too_much,
-        HealthCheck.too_slow,
-        HealthCheck.data_too_large,
-    ],
-)
-@pytest.mark.fuzz
-def test_mr_api_stateless_get_experiments(auth_headers: dict, case: schemathesis.Case, verify_ssl: bool) -> None:
-    """Test GET endpoints for Experiments and ExperimentRuns."""
-    call_and_validate_with_null_byte_handling(case, auth_headers, verify_ssl)
-
-
-@pytest.mark.parametrize("generated_schema", ["model-registry.yaml"], indirect=True)
+@pytest.mark.parametrize("generated_schema", ["model-registry-v1.yaml"], indirect=True)
 @base_schema.include(method="GET", path_regex=".*/inference_service.*|.*/serving_environment.*|.*/serve.*").parametrize()
 @settings(
     max_examples=100,
@@ -335,7 +243,7 @@ def test_mr_api_stateless_get_serving(auth_headers: dict, case: schemathesis.Cas
 
 
 # POST endpoints - split by resource type
-@pytest.mark.parametrize("generated_schema", ["model-registry.yaml"], indirect=True)
+@pytest.mark.parametrize("generated_schema", ["model-registry-v1.yaml"], indirect=True)
 @base_schema.include(method="POST", path_regex=".*/(registered_model|model_version).*").parametrize()
 @settings(
     max_examples=100,
@@ -352,7 +260,7 @@ def test_mr_api_stateless_post_models(auth_headers: dict, case: schemathesis.Cas
     call_and_validate_with_null_byte_handling(case, auth_headers, verify_ssl)
 
 
-@pytest.mark.parametrize("generated_schema", ["model-registry.yaml"], indirect=True)
+@pytest.mark.parametrize("generated_schema", ["model-registry-v1.yaml"], indirect=True)
 @base_schema.include(method="POST", path_regex=".*/artifact.*").parametrize()
 @settings(
     max_examples=100,
@@ -369,24 +277,7 @@ def test_mr_api_stateless_post_artifacts(auth_headers: dict, case: schemathesis.
     call_and_validate_with_null_byte_handling(case, auth_headers, verify_ssl)
 
 
-@pytest.mark.parametrize("generated_schema", ["model-registry.yaml"], indirect=True)
-@base_schema.include(method="POST", path_regex=".*/experiment.*").parametrize()
-@settings(
-    max_examples=100,
-    deadline=None,
-    suppress_health_check=[
-        HealthCheck.filter_too_much,
-        HealthCheck.too_slow,
-        HealthCheck.data_too_large,
-    ],
-)
-@pytest.mark.fuzz
-def test_mr_api_stateless_post_experiments(auth_headers: dict, case: schemathesis.Case, verify_ssl: bool) -> None:
-    """Test POST endpoints for Experiments and ExperimentRuns."""
-    call_and_validate_with_null_byte_handling(case, auth_headers, verify_ssl)
-
-
-@pytest.mark.parametrize("generated_schema", ["model-registry.yaml"], indirect=True)
+@pytest.mark.parametrize("generated_schema", ["model-registry-v1.yaml"], indirect=True)
 @base_schema.include(method="POST", path_regex=".*/inference_service.*|.*/serving_environment.*").parametrize()
 @settings(
     max_examples=100,
@@ -404,7 +295,7 @@ def test_mr_api_stateless_post_serving(auth_headers: dict, case: schemathesis.Ca
 
 
 # PATCH endpoints - split by resource type
-@pytest.mark.parametrize("generated_schema", ["model-registry.yaml"], indirect=True)
+@pytest.mark.parametrize("generated_schema", ["model-registry-v1.yaml"], indirect=True)
 @base_schema.include(method="PATCH", path_regex=".*/(registered_model|model_version).*").parametrize()
 @settings(
     max_examples=100,
@@ -421,8 +312,8 @@ def test_mr_api_stateless_patch_models(auth_headers: dict, case: schemathesis.Ca
     call_and_validate_with_null_byte_handling(case, auth_headers, verify_ssl)
 
 
-@pytest.mark.parametrize("generated_schema", ["model-registry.yaml"], indirect=True)
-@base_schema.include(method="PATCH", path_regex=".*/artifact.*|.*/experiment.*|.*/inference_service.*|.*/serving_environment.*").parametrize()
+@pytest.mark.parametrize("generated_schema", ["model-registry-v1.yaml"], indirect=True)
+@base_schema.include(method="PATCH", path_regex=".*/artifact.*|.*/inference_service.*|.*/serving_environment.*").parametrize()
 @settings(
     max_examples=100,
     deadline=None,
@@ -434,7 +325,7 @@ def test_mr_api_stateless_patch_models(auth_headers: dict, case: schemathesis.Ca
 )
 @pytest.mark.fuzz
 def test_mr_api_stateless_patch_others(auth_headers: dict, case: schemathesis.Case, verify_ssl: bool) -> None:
-    """Test PATCH endpoints for Artifacts, Experiments, and Serving resources."""
+    """Test PATCH endpoints for Artifacts and Serving resources."""
     call_and_validate_with_null_byte_handling(case, auth_headers, verify_ssl)
 
 @pytest.mark.fuzz
@@ -443,10 +334,10 @@ def test_mr_api_stateless_patch_others(auth_headers: dict, case: schemathesis.Ca
 def test_post_model_version_artifacts(auth_headers: dict, artifact_type: str, uri_prefix: str, state: str,
                                       cleanup_artifacts: Callable, verify_ssl: bool):
     """
-    Direct test for POST /api/model_registry/v1alpha3/model_versions/{modelversionId}/artifacts.
+    Direct test for POST /api/model_registry/v1/model_versions/{model_version_id}/artifacts.
     """
     model_version_id = generate_random_id()
-    endpoint = f"{REGISTRY_URL}/api/model_registry/v1alpha3/model_versions/{model_version_id}/artifacts"
+    endpoint = f"{REGISTRY_URL}/api/model_registry/v1/model_versions/{model_version_id}/artifacts"
 
     # Build payload using helper function
     payload = build_artifact_payload(
@@ -470,46 +361,10 @@ def test_post_model_version_artifacts(auth_headers: dict, artifact_type: str, ur
 
 @pytest.mark.fuzz
 @pytest.mark.parametrize(("artifact_type", "uri_prefix"), ARTIFACT_TYPE_PARAMS)
-@pytest.mark.parametrize("state", ARTIFACT_STATES)
-def test_post_experiment_run_artifacts(auth_headers: dict, artifact_type: str, uri_prefix: str, state: str,
-                                       cleanup_artifacts: Callable, verify_ssl: bool):
-    """
-    Direct test for POST /api/model_registry/v1alpha3/experiment_runs/{experimentrunId}/artifacts.
-    """
-    # Create experiment and experiment run using helper
-    experiment_id, experiment_run_id = create_experiment_and_run(auth_headers=auth_headers, verify_tls=verify_ssl)
-
-    endpoint = f"{REGISTRY_URL}/api/model_registry/v1alpha3/experiment_runs/{experiment_run_id}/artifacts"
-
-    # Build payload using helper function
-    payload = build_artifact_payload(
-        artifact_type=artifact_type,
-        uri_prefix=uri_prefix,
-        state=state,
-        name=f"my-test-experiment-artifact-post-{secrets.randbelow(1000000)}",
-        description="A test experiment artifact created via direct POST test."
-    )
-
-    # Make the API request
-    response = requests.post(endpoint, headers=auth_headers, json=payload, timeout=DEFAULT_API_TIMEOUT, verify=verify_ssl)
-
-    # Validate response and get artifact ID
-    artifact_id = validate_artifact_response(response, payload)
-
-    # Cleanup artifacts (only if artifact was created)
-    if artifact_id is not None:
-        cleanup_artifacts(artifact_id)
-
-    # Cleanup experiment and run
-    cleanup_experiment_and_run(auth_headers=auth_headers, experiment_id=experiment_id, experiment_run_id=experiment_run_id, verify_tls=verify_ssl)
-
-
-@pytest.mark.fuzz
-@pytest.mark.parametrize(("artifact_type", "uri_prefix"), ARTIFACT_TYPE_PARAMS)
 def test_patch_artifact(auth_headers: dict, artifact_resource: Callable, artifact_type: str, uri_prefix: str,
                         verify_ssl: bool):
     """
-    Direct test for PATCH /api/model_registry/v1alpha3/artifacts/{id}.
+    Direct test for PATCH /api/model_registry/v1/artifacts/{id}.
     """
     initial_state = "PENDING"
     target_state = "LIVE"
@@ -548,7 +403,7 @@ def test_patch_artifact(auth_headers: dict, artifact_resource: Callable, artifac
         create_payload["parameterType"] = "string"
 
     with artifact_resource(auth_headers, create_payload) as artifact_id:
-        patch_endpoint = f"{REGISTRY_URL}/api/model_registry/v1alpha3/artifacts/{artifact_id}"
+        patch_endpoint = f"{REGISTRY_URL}/api/model_registry/v1/artifacts/{artifact_id}"
         patch_payload = {
             "artifactType": artifact_type,
             "description": f"Updated description for {artifact_type} ({target_state})",


### PR DESCRIPTION
## Description

Model registry fuzz tests exercised `v1alpha3` and catalog fuzz tests exercised `v1alpha1`; both are slated for deprecation. Point the Schemathesis fixtures and hard-coded path helpers at the stable v1 specs instead. The `v1` `model-registry` API has no experiment endpoints, so the experiment-specific fuzz tests and helpers are removed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
