### PR TITLE
feat(bff,catalog): resolve HF API key from source-specific env var

### DIFF
--- a/catalog/internal/catalog/modelcatalog/hf_catalog.go
+++ b/catalog/internal/catalog/modelcatalog/hf_catalog.go
@@ -852,12 +852,13 @@ func (p *hfModelProvider) validateCredentials(ctx context.Context) error {
 }
 
 // sanitizeHFProperties validates security-sensitive properties and returns the env var name to
-// use for the API key. The apiKeyEnvVar property is accepted only when it equals defaultAPIKeyEnvVar
-// ("HF_API_KEY") or starts with apiKeyEnvVarPrefix ("HF_API_KEY_"); all other values are rejected
-// and the default is used. Custom URLs are always rejected to prevent SSRF. In both cases the
-// property is removed from the map to prevent it from leaking into downstream metadata.
+// use for the API key, or "" when no valid apiKeyEnvVar property is set. The apiKeyEnvVar property
+// is accepted only when it equals defaultAPIKeyEnvVar ("HF_API_KEY") or starts with
+// apiKeyEnvVarPrefix ("HF_API_KEY_"); all other values are rejected. Custom URLs are always
+// rejected to prevent SSRF. In both cases the property is removed from the map to prevent it from
+// leaking into downstream metadata.
 func sanitizeHFProperties(props map[string]any, label string) string {
-	envVarName := defaultAPIKeyEnvVar
+	var envVarName string
 	if envVar, ok := props[apiKeyEnvVarKey].(string); ok && envVar != "" {
 		if envVar == defaultAPIKeyEnvVar || strings.HasPrefix(envVar, apiKeyEnvVarPrefix) {
 			envVarName = envVar
@@ -874,6 +875,68 @@ func sanitizeHFProperties(props map[string]any, label string) string {
 	return envVarName
 }
 
+// envVarSuffixMaxLen bounds envVarSuffix's output to 63 characters — the same
+// limit Kubernetes enforces on label values — so a source ID always yields a
+// value usable both as an env var suffix here and as the
+// "hub.kubeflow.org/hf-source" label value set by the BFF (see
+// hfSourceLabelValue in
+// clients/ui/bff/internal/repositories/model_catalog_settings.go). The two
+// must stay in sync: whatever normalization changes here should be mirrored
+// there, and vice versa.
+const envVarSuffixMaxLen = 63
+
+// envVarSuffix converts a source ID into a suffix usable in an environment
+// variable name (and, via the same normalization in the BFF, as a Kubernetes
+// label value): it uppercases the ID, replaces every character that is not
+// A-Z, 0-9, or '_' with '_', trims leading/trailing '_', and truncates to
+// envVarSuffixMaxLen characters (re-trimming any trailing '_' left by the
+// truncation). For example "my-source" becomes "MY_SOURCE", and "_test"
+// becomes "TEST".
+func envVarSuffix(sourceID string) string {
+	var b strings.Builder
+	b.Grow(len(sourceID))
+	for _, r := range strings.ToUpper(sourceID) {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	raw := b.String()
+
+	trimmed := strings.Trim(raw, "_")
+	if len(trimmed) > envVarSuffixMaxLen {
+		trimmed = strings.TrimRight(trimmed[:envVarSuffixMaxLen], "_")
+	}
+
+	// Degenerate case: the ID normalized to all underscores (e.g. "___").
+	// Fall back to the untrimmed form rather than returning "".
+	if trimmed == "" {
+		return raw
+	}
+	return trimmed
+}
+
+// resolveHFAPIKey resolves the Hugging Face API key for the regular (non-preview)
+// provider from the environment. Precedence (first non-empty wins):
+//  1. The env var named by a validly-set apiKeyEnvVar property (propertyEnvVar).
+//  2. HF_API_KEY_<SOURCEID>, where <SOURCEID> is the source ID transformed by envVarSuffix.
+//  3. HF_API_KEY, the global fallback.
+//
+// Returns "" when none are set, meaning requests are made unauthenticated.
+func resolveHFAPIKey(sourceID, propertyEnvVar string) string {
+	if propertyEnvVar != "" {
+		if key := os.Getenv(propertyEnvVar); key != "" {
+			return key
+		}
+	}
+	if key := os.Getenv(apiKeyEnvVarPrefix + envVarSuffix(sourceID)); key != "" {
+		return key
+	}
+	return os.Getenv(defaultAPIKeyEnvVar)
+}
+
 func newHFModelProvider(ctx context.Context, source *basecatalog.ModelSource, reldir string) (<-chan ModelProviderRecord, error) {
 	p := &hfModelProvider{}
 	p.client = &http.Client{Timeout: 30 * time.Second}
@@ -886,8 +949,9 @@ func newHFModelProvider(ctx context.Context, source *basecatalog.ModelSource, re
 	p.sourceId = sourceId
 
 	// Reject custom URLs (SSRF prevention) and validate apiKeyEnvVar (must be HF_API_KEY or HF_API_KEY_*).
+	// Resolve the API key with precedence: apiKeyEnvVar property > HF_API_KEY_<SOURCEID> > HF_API_KEY.
 	apiKeyEnvVar := sanitizeHFProperties(source.Properties, "HuggingFace catalog")
-	apiKey := os.Getenv(apiKeyEnvVar)
+	apiKey := resolveHFAPIKey(sourceId, apiKeyEnvVar)
 	if apiKey == "" {
 		glog.Infof("No API key configured for Hugging Face. Only public models and limited data for gated models will be available.")
 	}
@@ -962,6 +1026,9 @@ func NewHFPreviewProvider(config *PreviewConfig) (*hfModelProvider, error) {
 
 	// Reject custom URLs (SSRF prevention) and validate apiKeyEnvVar (must be HF_API_KEY or HF_API_KEY_*).
 	apiKeyEnvVar := sanitizeHFProperties(config.Properties, "HuggingFace preview")
+	if apiKeyEnvVar == "" {
+		apiKeyEnvVar = defaultAPIKeyEnvVar
+	}
 	apiKey := os.Getenv(apiKeyEnvVar)
 	if apiKey == "" {
 		glog.Infof("No API key configured for Hugging Face preview. Only public models and limited data for gated models will be available.")

--- a/catalog/internal/catalog/modelcatalog/hf_catalog_test.go
+++ b/catalog/internal/catalog/modelcatalog/hf_catalog_test.go
@@ -1770,3 +1770,69 @@ func TestNewHFModelProvider_SanitizesSecurityProperties(t *testing.T) {
 	_, envVarExists := source.Properties[apiKeyEnvVarKey]
 	assert.False(t, envVarExists, "apiKeyEnvVar property must be removed to prevent env var oracle")
 }
+
+func TestEnvVarSuffix(t *testing.T) {
+	tests := []struct {
+		name     string
+		sourceID string
+		want     string
+	}{
+		{"lowercase with dash", "my-source", "MY_SOURCE"},
+		{"mixed case", "MySource", "MYSOURCE"},
+		{"dots and slashes", "org.name/sub", "ORG_NAME_SUB"},
+		{"already valid", "ABC_123", "ABC_123"},
+		{"digits", "abc123", "ABC123"},
+		{"empty", "", ""},
+		{"leading underscore", "_test", "TEST"},
+		{"trailing slash", "org/", "ORG"},
+		{"leading and trailing special chars", "-my-source-", "MY_SOURCE"},
+		{"all underscores", "___", "___"},
+		{"longer than 63 chars", strings.Repeat("a", 70), strings.Repeat("A", 63)},
+		{"truncation lands on underscore", strings.Repeat("a", 62) + "_bbb", strings.Repeat("A", 62)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, envVarSuffix(tt.sourceID))
+		})
+	}
+}
+
+func TestResolveHFAPIKey(t *testing.T) {
+	t.Run("property env var takes precedence", func(t *testing.T) {
+		t.Setenv("HF_API_KEY_ORG1", "hf_org1")
+		t.Setenv("HF_API_KEY_MY_SOURCE", "hf_derived")
+		t.Setenv("HF_API_KEY", "hf_global")
+		assert.Equal(t, "hf_org1", resolveHFAPIKey("my-source", "HF_API_KEY_ORG1"))
+	})
+
+	t.Run("falls back to source-specific var", func(t *testing.T) {
+		t.Setenv("HF_API_KEY_MY_SOURCE", "hf_derived")
+		t.Setenv("HF_API_KEY", "hf_global")
+		assert.Equal(t, "hf_derived", resolveHFAPIKey("my-source", ""))
+	})
+
+	t.Run("source id is sanitized when building the derived var", func(t *testing.T) {
+		t.Setenv("HF_API_KEY_ORG_NAME_SUB", "hf_sanitized")
+		t.Setenv("HF_API_KEY", "hf_global")
+		assert.Equal(t, "hf_sanitized", resolveHFAPIKey("org.name/sub", ""))
+	})
+
+	t.Run("falls back to global var", func(t *testing.T) {
+		t.Setenv("HF_API_KEY_MY_SOURCE", "")
+		t.Setenv("HF_API_KEY", "hf_global")
+		assert.Equal(t, "hf_global", resolveHFAPIKey("my-source", ""))
+	})
+
+	t.Run("property var empty falls through to derived", func(t *testing.T) {
+		t.Setenv("HF_API_KEY_ORG1", "")
+		t.Setenv("HF_API_KEY_MY_SOURCE", "hf_derived")
+		t.Setenv("HF_API_KEY", "hf_global")
+		assert.Equal(t, "hf_derived", resolveHFAPIKey("my-source", "HF_API_KEY_ORG1"))
+	})
+
+	t.Run("returns empty when nothing is set", func(t *testing.T) {
+		t.Setenv("HF_API_KEY_MY_SOURCE", "")
+		t.Setenv("HF_API_KEY", "")
+		assert.Equal(t, "", resolveHFAPIKey("my-source", ""))
+	})
+}

--- a/clients/ui/bff/internal/repositories/model_catalog_settings.go
+++ b/clients/ui/bff/internal/repositories/model_catalog_settings.go
@@ -31,6 +31,7 @@ var (
 	ErrCannotChangeDefaultSource = errors.New("cannot change the default source")
 	ErrCannotDeleteDefaultSource = errors.New("cannot delete the default source")
 	ErrCatalogIDTooLong          = errors.New("catalog source ID exceeds maximum length for secret name")
+	ErrCatalogIdInvalid          = errors.New("catalog source ID must contain at least one letter or digit")
 	ErrCannotChangeType          = errors.New("cannot change catalog source type")
 	ErrValidationFailed          = errors.New("validation failed")
 	ErrCatalogSourceConflict     = errors.New("catalog source was modified by another request")
@@ -499,6 +500,7 @@ func createSecretForHuggingFace(ctx context.Context,
 			Namespace: namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/component": "model-catalog",
+				"hub.kubeflow.org/hf-source":  hfSourceLabelValue(catalogId),
 			},
 		},
 		Type: corev1.SecretTypeOpaque,
@@ -529,6 +531,51 @@ func deleteSecretForHuggingFace(ctx context.Context,
 	}
 }
 
+// hfSourceLabelValueMaxLen bounds hfSourceLabelValue's output to 63 characters,
+// the Kubernetes limit on label values.
+const hfSourceLabelValueMaxLen = 63
+
+// hfSourceLabelValue converts a catalog source ID into a value usable both as
+// the "hub.kubeflow.org/hf-source" label on the HuggingFace API key secret and
+// as the suffix of the HF_API_KEY_<SUFFIX> environment variable the catalog
+// service resolves the key from (see envVarSuffix in
+// catalog/internal/catalog/modelcatalog/hf_catalog.go). The two must stay in
+// sync: whatever normalization changes here should be mirrored there, and
+// vice versa.
+//
+// It uppercases the ID, replaces every character that is not A-Z, 0-9, or '_'
+// with '_', trims leading/trailing '_' (a Kubernetes label value must begin
+// and end with an alphanumeric), and truncates to hfSourceLabelValueMaxLen
+// characters (re-trimming any trailing '_' left by the truncation).
+// validateCatalogId already restricts source IDs to [a-z0-9_]+, so the only
+// normalization this performs in practice is uppercasing, trimming leading or
+// trailing underscores, and truncating IDs longer than 63 characters.
+func hfSourceLabelValue(id string) string {
+	var b strings.Builder
+	b.Grow(len(id))
+	for _, r := range strings.ToUpper(id) {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('_')
+		}
+	}
+	raw := b.String()
+
+	trimmed := strings.Trim(raw, "_")
+	if len(trimmed) > hfSourceLabelValueMaxLen {
+		trimmed = strings.TrimRight(trimmed[:hfSourceLabelValueMaxLen], "_")
+	}
+
+	// Degenerate case: the ID normalized to all underscores (e.g. "___").
+	// Fall back to the untrimmed form rather than returning "".
+	if trimmed == "" {
+		return raw
+	}
+	return trimmed
+}
+
 var validCatalogIdRegex = regexp.MustCompile(`^[a-z0-9_]+$`)
 
 func validateCatalogId(id string) error {
@@ -538,6 +585,10 @@ func validateCatalogId(id string) error {
 
 	if !validCatalogIdRegex.MatchString(id) {
 		return fmt.Errorf("invalid catalog ID: must contain only lowercase letters, numbers, and underscores")
+	}
+
+	if strings.Trim(id, "_") == "" {
+		return ErrCatalogIdInvalid
 	}
 
 	if len(id) > 238 {

--- a/clients/ui/bff/internal/repositories/model_catalog_settings_helpers_test.go
+++ b/clients/ui/bff/internal/repositories/model_catalog_settings_helpers_test.go
@@ -1,0 +1,73 @@
+package repositories
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestHfSourceLabelValue(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want string
+		// validLabel is false only for the documented degenerate case (an ID
+		// that normalizes to all underscores), where hfSourceLabelValue falls
+		// back to a value that is not a valid Kubernetes label value.
+		validLabel bool
+	}{
+		{"lowercase with underscore", "my_source", "MY_SOURCE", true},
+		{"already valid", "abc_123", "ABC_123", true},
+		{"digits", "abc123", "ABC123", true},
+		{"leading underscore", "_test", "TEST", true},
+		{"trailing underscore", "my_source_", "MY_SOURCE", true},
+		{"leading and trailing underscores", "_my_source_", "MY_SOURCE", true},
+		{"all underscores", "___", "___", false},
+		{"longer than 63 chars", strings.Repeat("a", 70), strings.Repeat("A", 63), true},
+		{"truncation lands on underscore", strings.Repeat("a", 62) + "_bbb", strings.Repeat("A", 62), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hfSourceLabelValue(tt.id)
+			assert.Equal(t, tt.want, got)
+			errs := validation.IsValidLabelValue(got)
+			if tt.validLabel {
+				assert.Empty(t, errs, "expected %q to be a valid label value", got)
+			} else {
+				assert.NotEmpty(t, errs, "expected %q to be an invalid label value", got)
+			}
+		})
+	}
+}
+
+func TestValidateCatalogId(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		wantErr error
+	}{
+		{"valid with underscore", "my_source", nil},
+		{"valid alphanumeric with underscore", "abc_123", nil},
+		{"empty", "", ErrCatalogSourceIdRequired},
+		{"uppercase rejected by regex", "MySource", nil},
+		{"hyphen rejected by regex", "my-source", nil},
+		{"all underscores", "___", ErrCatalogIdInvalid},
+		{"single underscore", "_", ErrCatalogIdInvalid},
+		{"too long", strings.Repeat("a", 239), ErrCatalogIDTooLong},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCatalogId(tt.id)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+			} else if tt.name == "uppercase rejected by regex" || tt.name == "hyphen rejected by regex" {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Look up the HuggingFace API key using an env var name derived from the
source ID, and label HF key secrets accordingly. Keeps the generated
secret label and env var suffix within Kubernetes naming limits.

## How Has This Been Tested?
Unit tests and manual verification on a kind cluster.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
