### PR TITLE
Handle the preview gating in Add source form

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
@@ -435,6 +435,23 @@ class ManageSourcePage {
   findClearAccessTokenConfirmButton() {
     return cy.findByTestId('clear-access-token-confirm-button');
   }
+
+  findRefreshPreviewAlert() {
+    return cy.contains('Source configuration changed. Refresh the preview.');
+  }
+
+  findRefreshPreviewLink() {
+    return cy.findByTestId('refresh-preview-link');
+  }
+
+  findValidateButton() {
+    return cy.findByRole('button', { name: 'Validate' });
+  }
+
+  clickValidate() {
+    this.findValidateButton().click();
+    return this;
+  }
 }
 
 export const modelCatalogSettings = new ModelCatalogSettings();

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
@@ -110,6 +110,19 @@ class CatalogSourceConfigRow extends TableRow {
     this.findValidationStatusErrorLink().click();
     return this;
   }
+
+  findValidationStatusIndicator(testId: string) {
+    return this.findValidationStatus().findByTestId(testId);
+  }
+
+  findDeleteSourceMenuItem() {
+    return cy.findByRole('menuitem', { name: 'Delete source' });
+  }
+
+  clickDeleteSourceMenuItem() {
+    this.findDeleteSourceMenuItem().click();
+    return this;
+  }
 }
 
 class CatalogSourceStatusErrorModal extends Modal {
@@ -127,6 +140,15 @@ class CatalogSourceStatusErrorModal extends Modal {
 
   findMessage() {
     return cy.findByTestId('catalog-source-status-error-message');
+  }
+
+  findCloseButton() {
+    return this.find().findByRole('button', { name: 'Close' });
+  }
+
+  clickClose() {
+    this.findCloseButton().click();
+    return this;
   }
 }
 
@@ -416,12 +438,20 @@ class ManageSourcePage {
     return cy.contains('To view the models from this source that will appear');
   }
 
+  findPreviewPanelHeaderButton() {
+    return this.findPreviewPanel().findByTestId('preview-button-header');
+  }
+
+  findPreviewPanelBodyButton() {
+    return this.findPreviewPanel().findByTestId('preview-button-panel');
+  }
+
   findPreviewButtonHeader() {
-    return cy.findByTestId('preview-button-header');
+    return this.findPreviewPanelHeaderButton();
   }
 
   findPreviewButtonPanel() {
-    return cy.findByTestId('preview-button-panel');
+    return this.findPreviewPanelBodyButton();
   }
 
   findAccessTokenHiddenHelper() {
@@ -451,6 +481,54 @@ class ManageSourcePage {
   clickValidate() {
     this.findValidateButton().click();
     return this;
+  }
+
+  findShowAccessTokenButton() {
+    return cy.findByRole('button', { name: 'Show access token' });
+  }
+
+  findHideAccessTokenButton() {
+    return cy.findByRole('button', { name: 'Hide access token' });
+  }
+
+  clickShowAccessToken() {
+    this.findShowAccessTokenButton().click();
+    return this;
+  }
+
+  clickHideAccessToken() {
+    this.findHideAccessTokenButton().click();
+    return this;
+  }
+
+  findClearAccessTokenButton() {
+    return cy.findByRole('button', { name: 'Clear' });
+  }
+
+  clickClearAccessToken() {
+    this.findClearAccessTokenButton().click();
+    return this;
+  }
+
+  findClearAccessTokenModalCancelButton() {
+    return this.findClearAccessTokenModal().findByRole('button', { name: 'Cancel' });
+  }
+
+  clickClearAccessTokenModalCancel() {
+    this.findClearAccessTokenModalCancelButton().click();
+    return this;
+  }
+
+  findValidationSuccessAlert() {
+    return cy.contains('Credentials validated');
+  }
+
+  findValidationFailedAlert() {
+    return cy.contains('Credentials validation failed');
+  }
+
+  findPreviewModelsIncludedSummary(count: number, total: number) {
+    return cy.contains(`${count} of ${total} models included:`);
   }
 }
 

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
@@ -446,14 +446,6 @@ class ManageSourcePage {
     return this.findPreviewPanel().findByTestId('preview-button-panel');
   }
 
-  findPreviewButtonHeader() {
-    return this.findPreviewPanelHeaderButton();
-  }
-
-  findPreviewButtonPanel() {
-    return this.findPreviewPanelBodyButton();
-  }
-
   findAccessTokenHiddenHelper() {
     return cy.findByTestId('access-token-hidden-helper');
   }

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
@@ -360,9 +360,7 @@ describe('Catalog Source Configs Table', () => {
       row.findName().should('be.visible');
       row.shouldHaveKebab(true);
       row.findKebab().should('be.visible').click();
-      cy.findByRole('menuitem', { name: 'Delete source' })
-        .should('be.visible')
-        .and('not.be.disabled');
+      row.findDeleteSourceMenuItem().should('be.visible').and('not.be.disabled');
     });
 
     it('should not show kebab menu for default sources', () => {
@@ -388,7 +386,7 @@ describe('Catalog Source Configs Table', () => {
       modelCatalogSettings.visit();
       const row = modelCatalogSettings.getRow('HuggingFace Google');
       row.findKebab().click();
-      cy.findByRole('menuitem', { name: 'Delete source' }).click();
+      row.clickDeleteSourceMenuItem();
 
       deleteSourceModal.shouldBeOpen();
       deleteSourceModal.find().should('contain', 'HuggingFace Google');
@@ -399,7 +397,7 @@ describe('Catalog Source Configs Table', () => {
       modelCatalogSettings.visit();
       const row = modelCatalogSettings.getRow('HuggingFace Google');
       row.findKebab().click();
-      cy.findByRole('menuitem', { name: 'Delete source' }).click();
+      row.clickDeleteSourceMenuItem();
 
       deleteSourceModal.shouldBeOpen();
       deleteSourceModal.findDeleteButton().should('be.disabled');
@@ -415,7 +413,7 @@ describe('Catalog Source Configs Table', () => {
       modelCatalogSettings.visit();
       const row = modelCatalogSettings.getRow('HuggingFace Google');
       row.findKebab().click();
-      cy.findByRole('menuitem', { name: 'Delete source' }).click();
+      row.clickDeleteSourceMenuItem();
 
       deleteSourceModal.shouldBeOpen();
       deleteSourceModal.findCancelButton().click();
@@ -437,7 +435,7 @@ describe('Catalog Source Configs Table', () => {
       modelCatalogSettings.visit();
       const row = modelCatalogSettings.getRow('Custom YAML');
       row.findKebab().click();
-      cy.findByRole('menuitem', { name: 'Delete source' }).click();
+      row.clickDeleteSourceMenuItem();
 
       deleteSourceModal.shouldBeOpen();
       deleteSourceModal.typeConfirmation('Custom YAML');
@@ -507,7 +505,7 @@ describe('Catalog Source Configs Table', () => {
       const row = modelCatalogSettings.getRow('HuggingFace Google');
       row.findName().should('be.visible');
       row.shouldHaveValidationStatus('Ready');
-      row.findValidationStatus().findByTestId('source-status-connected-hf-google').should('exist');
+      row.findValidationStatusIndicator('source-status-connected-hf-google').should('exist');
     });
 
     it('should show "Starting" status when no matching source found', () => {
@@ -516,7 +514,7 @@ describe('Catalog Source Configs Table', () => {
       const row = modelCatalogSettings.getRow('HuggingFace Google');
       row.findName().should('be.visible');
       row.shouldHaveValidationStatus('Starting');
-      row.findValidationStatus().findByTestId('source-status-starting-hf-google').should('exist');
+      row.findValidationStatusIndicator('source-status-starting-hf-google').should('exist');
     });
 
     it('should show "Starting" status when source has no status field', () => {
@@ -543,7 +541,7 @@ describe('Catalog Source Configs Table', () => {
       const row = modelCatalogSettings.getRow('HuggingFace Google');
       row.findName().should('be.visible');
       row.shouldHaveValidationStatus('Starting');
-      row.findValidationStatus().findByTestId('source-status-starting-hf-google').should('exist');
+      row.findValidationStatusIndicator('source-status-starting-hf-google').should('exist');
     });
 
     it('should show "Failed" status with error message for error sources', () => {
@@ -558,7 +556,7 @@ describe('Catalog Source Configs Table', () => {
       const row = modelCatalogSettings.getRow('HuggingFace Google');
       row.findName().should('be.visible');
       row.shouldHaveValidationStatus('Failed');
-      row.findValidationStatus().findByTestId('source-status-failed-hf-google').should('exist');
+      row.findValidationStatusIndicator('source-status-failed-hf-google').should('exist');
       row.findValidationStatusErrorLink().should('exist');
     });
 
@@ -616,7 +614,7 @@ describe('Catalog Source Configs Table', () => {
       row.clickValidationStatusErrorLink();
 
       catalogSourceStatusErrorModal.find().should('exist');
-      catalogSourceStatusErrorModal.find().findByRole('button', { name: 'Close' }).click();
+      catalogSourceStatusErrorModal.clickClose();
       catalogSourceStatusErrorModal.find().should('not.exist');
     });
   });
@@ -693,7 +691,7 @@ describe('Catalog Source Configs Table', () => {
       });
 
       row.findKebab().click();
-      cy.findByRole('menuitem', { name: 'Delete source' }).click();
+      row.clickDeleteSourceMenuItem();
 
       deleteSourceModal.shouldBeOpen();
       deleteSourceModal.typeConfirmation('HuggingFace Google');
@@ -796,8 +794,8 @@ describe('Manage Source Page', () => {
       manageSourcePage.fillAccessToken('test-token-123');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('be.disabled');
-      manageSourcePage.findPreviewButtonHeader().should('be.disabled');
-      manageSourcePage.findPreviewButtonPanel().should('be.disabled');
+      manageSourcePage.findPreviewPanelHeaderButton().should('be.disabled');
+      manageSourcePage.findPreviewPanelBodyButton().should('be.disabled');
     });
 
     it('should enable Preview after HF credentials are validated', () => {
@@ -818,16 +816,16 @@ describe('Manage Source Page', () => {
       manageSourcePage.clickValidate();
       cy.wait('@validateHfCredentials');
       manageSourcePage.findPreviewButton().should('not.be.disabled');
-      manageSourcePage.findPreviewButtonHeader().should('not.be.disabled');
-      manageSourcePage.findPreviewButtonPanel().should('not.be.disabled');
+      manageSourcePage.findPreviewPanelHeaderButton().should('not.be.disabled');
+      manageSourcePage.findPreviewPanelBodyButton().should('not.be.disabled');
     });
 
     it('should enable Preview for HF when only organization is filled', () => {
       manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('not.be.disabled');
-      manageSourcePage.findPreviewButtonHeader().should('not.be.disabled');
-      manageSourcePage.findPreviewButtonPanel().should('not.be.disabled');
+      manageSourcePage.findPreviewPanelHeaderButton().should('not.be.disabled');
+      manageSourcePage.findPreviewPanelBodyButton().should('not.be.disabled');
     });
 
     it('should enable Add button when all required YAML fields are filled', () => {
@@ -990,16 +988,16 @@ describe('Manage Source Page', () => {
       // One in the action group (bottom left)
       manageSourcePage.findPreviewButton().should('exist');
       // One in the preview panel header (top right)
-      manageSourcePage.findPreviewButtonHeader().should('exist');
+      manageSourcePage.findPreviewPanelHeaderButton().should('exist');
       // One in the preview panel body (center)
-      manageSourcePage.findPreviewButtonPanel().should('exist');
+      manageSourcePage.findPreviewPanelBodyButton().should('exist');
     });
 
     it('should have all three preview buttons disabled by default', () => {
       manageSourcePage.visitAddSource();
       manageSourcePage.findPreviewButton().should('be.disabled');
-      manageSourcePage.findPreviewButtonHeader().should('be.disabled');
-      manageSourcePage.findPreviewButtonPanel().should('be.disabled');
+      manageSourcePage.findPreviewPanelHeaderButton().should('be.disabled');
+      manageSourcePage.findPreviewPanelBodyButton().should('be.disabled');
     });
 
     it('should keep all three preview buttons disabled when token is entered but not validated', () => {
@@ -1007,8 +1005,8 @@ describe('Manage Source Page', () => {
       manageSourcePage.fillAccessToken('test-token');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('be.disabled');
-      manageSourcePage.findPreviewButtonHeader().should('be.disabled');
-      manageSourcePage.findPreviewButtonPanel().should('be.disabled');
+      manageSourcePage.findPreviewPanelHeaderButton().should('be.disabled');
+      manageSourcePage.findPreviewPanelBodyButton().should('be.disabled');
     });
 
     it('should show refresh alert with disabled link when token is typed after preview without token', () => {
@@ -1028,15 +1026,15 @@ describe('Manage Source Page', () => {
       manageSourcePage.findPreviewButton().click();
       cy.wait('@previewSource');
 
-      cy.contains('1 of 1 models included:').should('exist');
+      manageSourcePage.findPreviewModelsIncludedSummary(1, 1).should('exist');
       manageSourcePage.fillAccessToken('new-token');
 
       manageSourcePage.findPreviewButton().should('be.disabled');
-      manageSourcePage.findPreviewButtonHeader().should('be.disabled');
-      manageSourcePage.findPreviewButtonPanel().should('be.disabled');
+      manageSourcePage.findPreviewPanelHeaderButton().should('be.disabled');
+      manageSourcePage.findPreviewPanelBodyButton().should('not.exist');
       manageSourcePage.findRefreshPreviewAlert().should('exist');
       manageSourcePage.findRefreshPreviewLink().should('exist').and('be.disabled');
-      cy.contains('1 of 1 models included:').should('exist');
+      manageSourcePage.findPreviewModelsIncludedSummary(1, 1).should('exist');
     });
 
     it('submit add source form with yaml source type', () => {
@@ -1422,11 +1420,11 @@ describe('HuggingFace Credentials Validation', () => {
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('valid-token-123');
 
-      cy.findByRole('button', { name: 'Validate' }).click();
+      manageSourcePage.clickValidate();
       cy.wait('@validateSuccess');
 
       manageSourcePage.findAccessTokenHiddenHelper().should('exist');
-      cy.contains('Credentials validated').should('exist');
+      manageSourcePage.findValidationSuccessAlert().should('exist');
     });
 
     it('should show error alert when org is qwen (mocked failure)', () => {
@@ -1439,10 +1437,10 @@ describe('HuggingFace Credentials Validation', () => {
       manageSourcePage.fillOrganization('qwen');
       manageSourcePage.fillAccessToken('any-token');
 
-      cy.findByRole('button', { name: 'Validate' }).click();
+      manageSourcePage.clickValidate();
       cy.wait('@validateFail');
 
-      cy.contains('Credentials validation failed').should('exist');
+      manageSourcePage.findValidationFailedAlert().should('exist');
     });
 
     it('should keep Preview disabled after failed Validate', () => {
@@ -1456,16 +1454,16 @@ describe('HuggingFace Credentials Validation', () => {
       manageSourcePage.fillAccessToken('any-token');
 
       manageSourcePage.findPreviewButton().should('be.disabled');
-      manageSourcePage.findPreviewButtonHeader().should('be.disabled');
-      manageSourcePage.findPreviewButtonPanel().should('be.disabled');
+      manageSourcePage.findPreviewPanelHeaderButton().should('be.disabled');
+      manageSourcePage.findPreviewPanelBodyButton().should('be.disabled');
 
-      cy.findByRole('button', { name: 'Validate' }).click();
+      manageSourcePage.clickValidate();
       cy.wait('@validateFail');
 
-      cy.contains('Credentials validation failed').should('exist');
+      manageSourcePage.findValidationFailedAlert().should('exist');
       manageSourcePage.findPreviewButton().should('be.disabled');
-      manageSourcePage.findPreviewButtonHeader().should('be.disabled');
-      manageSourcePage.findPreviewButtonPanel().should('be.disabled');
+      manageSourcePage.findPreviewPanelHeaderButton().should('be.disabled');
+      manageSourcePage.findPreviewPanelBodyButton().should('be.disabled');
     });
   });
 
@@ -1476,10 +1474,10 @@ describe('HuggingFace Credentials Validation', () => {
 
       manageSourcePage.findAccessTokenInput().should('have.attr', 'type', 'password');
 
-      cy.findByRole('button', { name: 'Show access token' }).click();
+      manageSourcePage.clickShowAccessToken();
       manageSourcePage.findAccessTokenInput().should('have.attr', 'type', 'text');
 
-      cy.findByRole('button', { name: 'Hide access token' }).click();
+      manageSourcePage.clickHideAccessToken();
       manageSourcePage.findAccessTokenInput().should('have.attr', 'type', 'password');
     });
 
@@ -1493,14 +1491,14 @@ describe('HuggingFace Credentials Validation', () => {
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('my-secret-token');
 
-      cy.findByRole('button', { name: 'Show access token' }).click();
+      manageSourcePage.clickShowAccessToken();
       manageSourcePage.findAccessTokenInput().should('have.attr', 'type', 'text');
 
-      cy.findByRole('button', { name: 'Validate' }).click();
+      manageSourcePage.clickValidate();
       cy.wait('@validateSuccess');
 
-      cy.findByRole('button', { name: 'Show access token' }).should('not.exist');
-      cy.findByRole('button', { name: 'Hide access token' }).should('not.exist');
+      manageSourcePage.findShowAccessTokenButton().should('not.exist');
+      manageSourcePage.findHideAccessTokenButton().should('not.exist');
       manageSourcePage.findAccessTokenInput().should('have.attr', 'type', 'password');
     });
   });
@@ -1516,7 +1514,7 @@ describe('HuggingFace Credentials Validation', () => {
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('valid-token-123');
 
-      cy.findByRole('button', { name: 'Validate' }).click();
+      manageSourcePage.clickValidate();
       cy.wait('@validateSuccess');
 
       manageSourcePage.findOrganizationInput().should('have.value', 'Google');
@@ -1533,35 +1531,35 @@ describe('HuggingFace Credentials Validation', () => {
       manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('valid-token-123');
-      cy.findByRole('button', { name: 'Validate' }).click();
+      manageSourcePage.clickValidate();
       cy.wait('@validateSuccess');
     });
 
     it('should open clear token modal when Clear button is clicked', () => {
-      cy.findByRole('button', { name: 'Clear' }).click();
+      manageSourcePage.clickClearAccessToken();
       manageSourcePage.findClearAccessTokenModal().should('exist');
     });
 
     it('should close modal and keep org and token when Cancel is clicked', () => {
-      cy.findByRole('button', { name: 'Clear' }).click();
+      manageSourcePage.clickClearAccessToken();
       manageSourcePage.findClearAccessTokenModal().should('exist');
 
-      cy.findByRole('button', { name: 'Cancel' }).click();
+      manageSourcePage.clickClearAccessTokenModalCancel();
       manageSourcePage.findClearAccessTokenModal().should('not.exist');
 
       manageSourcePage.findOrganizationInput().should('have.value', 'Google');
-      cy.contains('Credentials validated').should('exist');
+      manageSourcePage.findValidationSuccessAlert().should('exist');
     });
 
     it('should clear token and close preview when Confirm is clicked', () => {
-      cy.findByRole('button', { name: 'Clear' }).click();
+      manageSourcePage.clickClearAccessToken();
       manageSourcePage.findClearAccessTokenModal().should('exist');
 
       manageSourcePage.findClearAccessTokenConfirmButton().click();
       manageSourcePage.findClearAccessTokenModal().should('not.exist');
 
       manageSourcePage.findAccessTokenInput().should('have.value', '');
-      cy.contains('Credentials validated').should('not.exist');
+      manageSourcePage.findValidationSuccessAlert().should('not.exist');
     });
   });
 
@@ -1598,10 +1596,10 @@ describe('HuggingFace Credentials Validation', () => {
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('my-secret-token');
 
-      cy.findByRole('button', { name: 'Validate' }).click();
+      manageSourcePage.clickValidate();
       cy.wait('@validateSuccess');
 
-      cy.findByRole('button', { name: 'Clear' }).click();
+      manageSourcePage.clickClearAccessToken();
       manageSourcePage.findClearAccessTokenConfirmButton().click();
 
       manageSourcePage.findSubmitButton().click();

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
@@ -791,11 +791,43 @@ describe('Manage Source Page', () => {
       manageSourcePage.findSubmitButton().should('not.be.disabled');
     });
 
-    it('should enable Preview button when HF credentials are filled', () => {
+    it('should keep Preview disabled when HF credentials are filled but not validated', () => {
       manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
       manageSourcePage.fillAccessToken('test-token-123');
       manageSourcePage.fillOrganization('Google');
+      manageSourcePage.findPreviewButton().should('be.disabled');
+      manageSourcePage.findPreviewButtonHeader().should('be.disabled');
+      manageSourcePage.findPreviewButtonPanel().should('be.disabled');
+    });
+
+    it('should enable Preview after HF credentials are validated', () => {
+      cy.intercept('POST', '/model-registry/api/v1/settings/model_catalog/source_preview*', {
+        data: {
+          items: [{ name: 'Google/model-1', included: true }],
+          summary: { totalModels: 1, includedModels: 1, excludedModels: 0 },
+          nextPageToken: '',
+          pageSize: 20,
+          size: 1,
+        },
+      }).as('validateHfCredentials');
+
+      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.fillAccessToken('test-token-123');
+      manageSourcePage.fillOrganization('Google');
+      manageSourcePage.findPreviewButton().should('be.disabled');
+      manageSourcePage.clickValidate();
+      cy.wait('@validateHfCredentials');
       manageSourcePage.findPreviewButton().should('not.be.disabled');
+      manageSourcePage.findPreviewButtonHeader().should('not.be.disabled');
+      manageSourcePage.findPreviewButtonPanel().should('not.be.disabled');
+    });
+
+    it('should enable Preview for HF when only organization is filled', () => {
+      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.fillOrganization('Google');
+      manageSourcePage.findPreviewButton().should('not.be.disabled');
+      manageSourcePage.findPreviewButtonHeader().should('not.be.disabled');
+      manageSourcePage.findPreviewButtonPanel().should('not.be.disabled');
     });
 
     it('should enable Add button when all required YAML fields are filled', () => {
@@ -970,13 +1002,41 @@ describe('Manage Source Page', () => {
       manageSourcePage.findPreviewButtonPanel().should('be.disabled');
     });
 
-    it('should enable all three preview buttons when credentials are filled', () => {
+    it('should keep all three preview buttons disabled when token is entered but not validated', () => {
       manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
       manageSourcePage.fillAccessToken('test-token');
       manageSourcePage.fillOrganization('Google');
+      manageSourcePage.findPreviewButton().should('be.disabled');
+      manageSourcePage.findPreviewButtonHeader().should('be.disabled');
+      manageSourcePage.findPreviewButtonPanel().should('be.disabled');
+    });
+
+    it('should show refresh alert with disabled link when token is typed after preview without token', () => {
+      cy.intercept('POST', '/model-registry/api/v1/settings/model_catalog/source_preview*', {
+        data: {
+          items: [{ name: 'Google/model-1', included: true }],
+          summary: { totalModels: 1, includedModels: 1, excludedModels: 0 },
+          nextPageToken: '',
+          pageSize: 20,
+          size: 1,
+        },
+      }).as('previewSource');
+
+      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('not.be.disabled');
-      manageSourcePage.findPreviewButtonHeader().should('not.be.disabled');
-      manageSourcePage.findPreviewButtonPanel().should('not.be.disabled');
+      manageSourcePage.findPreviewButton().click();
+      cy.wait('@previewSource');
+
+      cy.contains('1 of 1 models included:').should('exist');
+      manageSourcePage.fillAccessToken('new-token');
+
+      manageSourcePage.findPreviewButton().should('be.disabled');
+      manageSourcePage.findPreviewButtonHeader().should('be.disabled');
+      manageSourcePage.findPreviewButtonPanel().should('be.disabled');
+      manageSourcePage.findRefreshPreviewAlert().should('exist');
+      manageSourcePage.findRefreshPreviewLink().should('exist').and('be.disabled');
+      cy.contains('1 of 1 models included:').should('exist');
     });
 
     it('submit add source form with yaml source type', () => {
@@ -1383,6 +1443,29 @@ describe('HuggingFace Credentials Validation', () => {
       cy.wait('@validateFail');
 
       cy.contains('Credentials validation failed').should('exist');
+    });
+
+    it('should keep Preview disabled after failed Validate', () => {
+      cy.intercept('POST', '/model-registry/api/v1/settings/model_catalog/source_preview*', {
+        statusCode: 401,
+        body: previewFailResponse,
+      }).as('validateFail');
+
+      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.fillOrganization('qwen');
+      manageSourcePage.fillAccessToken('any-token');
+
+      manageSourcePage.findPreviewButton().should('be.disabled');
+      manageSourcePage.findPreviewButtonHeader().should('be.disabled');
+      manageSourcePage.findPreviewButtonPanel().should('be.disabled');
+
+      cy.findByRole('button', { name: 'Validate' }).click();
+      cy.wait('@validateFail');
+
+      cy.contains('Credentials validation failed').should('exist');
+      manageSourcePage.findPreviewButton().should('be.disabled');
+      manageSourcePage.findPreviewButtonHeader().should('be.disabled');
+      manageSourcePage.findPreviewButtonPanel().should('be.disabled');
     });
   });
 

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/__tests__/useSourcePreview.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/__tests__/useSourcePreview.spec.ts
@@ -116,6 +116,11 @@ describe('isPreviewEnabled', () => {
   it('disables preview for HF when token validation failed', () => {
     expect(isPreviewEnabled(hfFormData, 'invalid')).toBe(false);
   });
+
+  it('allows preview for HF in edit mode without token validation', () => {
+    expect(isPreviewEnabled(hfFormData, 'unknown', true)).toBe(true);
+    expect(isPreviewEnabled(hfFormData, 'invalid', true)).toBe(true);
+  });
 });
 
 describe('getPreviewDisabledTooltip', () => {
@@ -133,6 +138,10 @@ describe('getPreviewDisabledTooltip', () => {
       getPreviewDisabledTooltip({ ...hfFormData, accessToken: '' }, 'unknown'),
     ).toBeUndefined();
     expect(getPreviewDisabledTooltip(hfFormData, 'valid')).toBeUndefined();
+  });
+
+  it('returns undefined in edit mode even when HF token is not validated', () => {
+    expect(getPreviewDisabledTooltip(hfFormData, 'unknown', true)).toBeUndefined();
   });
 });
 
@@ -325,6 +334,27 @@ describe('useSourcePreview', () => {
     ).toHaveLength(0);
     expect(result.current.previewState.summary).toBeUndefined();
     expect(apiState.api.previewCatalogSource).toHaveBeenCalledTimes(1);
+  });
+
+  it('should auto-preview on mount in edit mode for HF sources with token', async () => {
+    const apiState = createMockApiState();
+
+    testHook(useSourcePreview)(
+      createHookParams(hfFormData, { apiState, isEditMode: true }),
+    );
+
+    await waitFor(() => {
+      expect(apiState.api.previewCatalogSource).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should enable preview on mount in edit mode without requiring validation', () => {
+    const { result } = testHook(useSourcePreview)(
+      createHookParams(hfFormData, { isEditMode: true }),
+    );
+
+    expect(result.current.canPreview).toBe(true);
+    expect(result.current.previewDisabledTooltip).toBeUndefined();
   });
 
   it('should enable preview after successful token validation for HF sources', async () => {

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/__tests__/useSourcePreview.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/__tests__/useSourcePreview.spec.ts
@@ -4,6 +4,7 @@ import {
   useSourcePreview,
   isPreviewEnabled,
   getPreviewDisabledTooltip,
+  UseSourcePreviewOptions,
 } from '~/app/pages/modelCatalogSettings/useSourcePreview';
 import { ManageSourceFormData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
 import { CatalogSourceType } from '~/app/modelCatalogTypes';
@@ -76,6 +77,19 @@ const createMockApiState = (
     deleteCatalogSourceConfig: jest.fn(),
     previewCatalogSource: jest.fn().mockResolvedValue(mockPreviewResult),
   },
+  ...overrides,
+});
+
+const createHookParams = (
+  formData: ManageSourceFormData = mockFormData,
+  overrides: Partial<Omit<UseSourcePreviewOptions, 'formData'>> & {
+    apiState?: ModelCatalogSettingsAPIState;
+  } = {},
+): UseSourcePreviewOptions => ({
+  formData,
+  existingSourceConfig: undefined,
+  apiState: overrides.apiState ?? createMockApiState(),
+  isEditMode: false,
   ...overrides,
 });
 
@@ -569,5 +583,73 @@ describe('useSourcePreview', () => {
     await waitFor(() => {
       expect(result.current.previewState.error?.message).toBe('Network error');
     });
+  });
+
+  it('should assert stability of handlers when hook props are unchanged', () => {
+    const hookParams = createHookParams();
+    const renderResult = testHook(useSourcePreview)(hookParams);
+
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    renderResult.rerender(hookParams);
+
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult).hookToBeStable({
+      handlePreview: true,
+      handleValidate: true,
+      handleTabChange: true,
+      handleLoadMore: true,
+      clearValidationSuccess: true,
+      canPreview: true,
+      hasFormChanged: true,
+      previewDisabledTooltip: true,
+    });
+  });
+
+  it('should update preview gating when access token changes', () => {
+    const apiState = createMockApiState();
+    const formDataWithoutToken: ManageSourceFormData = { ...hfFormData, accessToken: '' };
+    const initialParams = createHookParams(formDataWithoutToken, { apiState });
+
+    const renderResult = testHook(useSourcePreview)(initialParams);
+
+    expect(renderResult).hookToHaveUpdateCount(1);
+    expect(renderResult.result.current.canPreview).toBe(true);
+    expect(renderResult.result.current.previewDisabledTooltip).toBeUndefined();
+
+    renderResult.rerender(
+      createHookParams({ ...formDataWithoutToken, accessToken: 'new-token' }, { apiState }),
+    );
+
+    expect(renderResult).hookToHaveUpdateCount(2);
+    expect(renderResult.result.current.canPreview).toBe(false);
+    expect(renderResult.result.current.previewDisabledTooltip).toBe(
+      'Validate the access token to preview models.',
+    );
+  });
+
+  it('should reset validation state when credentials change', async () => {
+    const apiState = createMockApiState();
+    const renderResult = testHook(useSourcePreview)(createHookParams(hfFormData, { apiState }));
+
+    expect(renderResult).hookToHaveUpdateCount(1);
+
+    await act(async () => {
+      await renderResult.result.current.handleValidate();
+    });
+
+    await waitFor(() => {
+      expect(renderResult.result.current.isValidationSuccess).toBe(true);
+    });
+
+    const updateCountAfterValidate = renderResult.getUpdateCount();
+
+    renderResult.rerender(
+      createHookParams({ ...hfFormData, accessToken: 'updated-token' }, { apiState }),
+    );
+
+    expect(renderResult.result.current.isValidationSuccess).toBe(false);
+    expect(renderResult.result.current.validationError).toBeUndefined();
+    expect(renderResult.getUpdateCount()).toBeGreaterThan(updateCountAfterValidate);
   });
 });

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/__tests__/useSourcePreview.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/__tests__/useSourcePreview.spec.ts
@@ -1,6 +1,10 @@
 import { act, waitFor } from '@testing-library/react';
 import { testHook } from '~/__tests__/unit/testUtils/hooks';
-import { useSourcePreview, PreviewMode } from '~/app/pages/modelCatalogSettings/useSourcePreview';
+import {
+  useSourcePreview,
+  isPreviewEnabled,
+  getPreviewDisabledTooltip,
+} from '~/app/pages/modelCatalogSettings/useSourcePreview';
 import { ManageSourceFormData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
 import { CatalogSourceType } from '~/app/modelCatalogTypes';
 import { ModelCatalogSettingsAPIState } from '~/app/hooks/modelCatalogSettings/useModelCatalogSettingsAPIState';
@@ -13,12 +17,24 @@ jest.mock('~/app/pages/modelCatalogSettings/utils/validation', () => ({
 
 // Mock the transform utility
 jest.mock('~/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils', () => ({
-  transformFormDataToConfig: jest.fn(() => ({
-    type: 'yaml',
-    includedModels: ['*'],
-    excludedModels: [],
-    yaml: 'models:\n  - name: test',
-  })),
+  transformFormDataToConfig: jest.fn((formData: ManageSourceFormData) => {
+    if (formData.sourceType === CatalogSourceType.HUGGING_FACE) {
+      return {
+        type: CatalogSourceType.HUGGING_FACE,
+        includedModels: [],
+        excludedModels: [],
+        allowedOrganization: formData.organization,
+        apiKey: formData.accessToken,
+      };
+    }
+
+    return {
+      type: CatalogSourceType.YAML,
+      includedModels: ['*'],
+      excludedModels: [],
+      yaml: formData.yamlContent || 'models:\n  - name: test',
+    };
+  }),
 }));
 
 const mockFormData: ManageSourceFormData = {
@@ -61,6 +77,49 @@ const createMockApiState = (
     previewCatalogSource: jest.fn().mockResolvedValue(mockPreviewResult),
   },
   ...overrides,
+});
+
+const hfFormData: ManageSourceFormData = {
+  ...mockFormData,
+  sourceType: CatalogSourceType.HUGGING_FACE,
+  organization: 'qwen',
+  accessToken: 'hf_test_token',
+};
+
+describe('isPreviewEnabled', () => {
+  it('allows preview for HF when organization is valid and token is empty', () => {
+    expect(isPreviewEnabled({ ...hfFormData, accessToken: '' }, 'unknown')).toBe(true);
+  });
+
+  it('disables preview for HF with token before validation', () => {
+    expect(isPreviewEnabled(hfFormData, 'unknown')).toBe(false);
+  });
+
+  it('allows preview for HF after successful validation', () => {
+    expect(isPreviewEnabled(hfFormData, 'valid')).toBe(true);
+  });
+
+  it('disables preview for HF when token validation failed', () => {
+    expect(isPreviewEnabled(hfFormData, 'invalid')).toBe(false);
+  });
+});
+
+describe('getPreviewDisabledTooltip', () => {
+  it('returns validation tooltip when HF token is present and not validated', () => {
+    expect(getPreviewDisabledTooltip(hfFormData, 'unknown')).toBe(
+      'Validate the access token to preview models.',
+    );
+    expect(getPreviewDisabledTooltip(hfFormData, 'invalid')).toBe(
+      'Validate the access token to preview models.',
+    );
+  });
+
+  it('returns undefined when preview is allowed or token is empty', () => {
+    expect(
+      getPreviewDisabledTooltip({ ...hfFormData, accessToken: '' }, 'unknown'),
+    ).toBeUndefined();
+    expect(getPreviewDisabledTooltip(hfFormData, 'valid')).toBeUndefined();
+  });
 });
 
 describe('useSourcePreview', () => {
@@ -228,11 +287,11 @@ describe('useSourcePreview', () => {
     // we can't easily test form changes without more complex mocking
   });
 
-  it('should handle validation mode', async () => {
+  it('should handle validation without populating preview state', async () => {
     const apiState = createMockApiState();
 
     const { result } = testHook(useSourcePreview)({
-      formData: mockFormData,
+      formData: hfFormData,
       existingSourceConfig: undefined,
       apiState,
       isEditMode: false,
@@ -243,7 +302,114 @@ describe('useSourcePreview', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.previewState.mode).toBe(PreviewMode.VALIDATE);
+      expect(result.current.isValidating).toBe(false);
+    });
+
+    expect(result.current.isValidationSuccess).toBe(true);
+    expect(
+      result.current.previewState.tabStates[CatalogSettingsPreviewTab.INCLUDED].items,
+    ).toHaveLength(0);
+    expect(result.current.previewState.summary).toBeUndefined();
+    expect(apiState.api.previewCatalogSource).toHaveBeenCalledTimes(1);
+  });
+
+  it('should enable preview after successful token validation for HF sources', async () => {
+    const apiState = createMockApiState();
+
+    const { result } = testHook(useSourcePreview)({
+      formData: hfFormData,
+      existingSourceConfig: undefined,
+      apiState,
+      isEditMode: false,
+    });
+
+    expect(result.current.canPreview).toBe(false);
+
+    await act(async () => {
+      await result.current.handleValidate();
+    });
+
+    await waitFor(() => {
+      expect(result.current.canPreview).toBe(true);
+    });
+  });
+
+  it('should disable preview after failed token validation for HF sources', async () => {
+    const apiState = createMockApiState();
+    (apiState.api.previewCatalogSource as jest.Mock).mockRejectedValueOnce(
+      new Error('invalid Hugging Face API credentials'),
+    );
+
+    const { result } = testHook(useSourcePreview)({
+      formData: hfFormData,
+      existingSourceConfig: undefined,
+      apiState,
+      isEditMode: false,
+    });
+
+    expect(result.current.canPreview).toBe(false);
+
+    await act(async () => {
+      await result.current.handleValidate();
+    });
+
+    await waitFor(() => {
+      expect(result.current.canPreview).toBe(false);
+    });
+
+    expect(result.current.validationError?.message).toBe('invalid Hugging Face API credentials');
+    expect(
+      result.current.previewState.tabStates[CatalogSettingsPreviewTab.INCLUDED].items,
+    ).toHaveLength(0);
+  });
+
+  it('should re-enable preview when token is cleared after failed validation', async () => {
+    const apiState = createMockApiState();
+    (apiState.api.previewCatalogSource as jest.Mock).mockRejectedValueOnce(
+      new Error('invalid Hugging Face API credentials'),
+    );
+
+    const { result, rerender } = testHook(useSourcePreview)({
+      formData: hfFormData,
+      existingSourceConfig: undefined,
+      apiState,
+      isEditMode: false,
+    });
+
+    await act(async () => {
+      await result.current.handleValidate();
+    });
+
+    await waitFor(() => {
+      expect(result.current.canPreview).toBe(false);
+    });
+
+    rerender({
+      formData: { ...hfFormData, accessToken: '' },
+      existingSourceConfig: undefined,
+      apiState,
+      isEditMode: false,
+    });
+
+    expect(result.current.canPreview).toBe(true);
+  });
+
+  it('should handle validation mode', async () => {
+    const apiState = createMockApiState();
+
+    const { result } = testHook(useSourcePreview)({
+      formData: hfFormData,
+      existingSourceConfig: undefined,
+      apiState,
+      isEditMode: false,
+    });
+
+    await act(async () => {
+      await result.current.handleValidate();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isValidating).toBe(false);
     });
 
     expect(result.current.isValidationSuccess).toBe(true);
@@ -253,7 +419,7 @@ describe('useSourcePreview', () => {
     const apiState = createMockApiState();
 
     const { result } = testHook(useSourcePreview)({
-      formData: mockFormData,
+      formData: hfFormData,
       existingSourceConfig: undefined,
       apiState,
       isEditMode: false,
@@ -273,6 +439,114 @@ describe('useSourcePreview', () => {
 
     expect(result.current.isValidationSuccess).toBe(false);
     expect(result.current.previewState.resultDismissed).toBe(true);
+  });
+
+  it('should keep preview results and require refresh when access token changes', async () => {
+    const apiState = createMockApiState();
+
+    const { result, rerender } = testHook(useSourcePreview)({
+      formData: { ...hfFormData, accessToken: '' },
+      existingSourceConfig: undefined,
+      apiState,
+      isEditMode: false,
+    });
+
+    await act(async () => {
+      await result.current.handlePreview();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.previewState.tabStates[CatalogSettingsPreviewTab.INCLUDED].items,
+      ).toHaveLength(2);
+    });
+
+    rerender({
+      formData: { ...hfFormData, accessToken: 'new-token' },
+      existingSourceConfig: undefined,
+      apiState,
+      isEditMode: false,
+    });
+
+    expect(
+      result.current.previewState.tabStates[CatalogSettingsPreviewTab.INCLUDED].items,
+    ).toHaveLength(2);
+    expect(result.current.previewState.summary?.totalModels).toBe(10);
+    expect(result.current.hasFormChanged).toBe(true);
+    expect(result.current.canPreview).toBe(false);
+  });
+
+  it('should keep preview results and require refresh when access token is cleared', async () => {
+    const apiState = createMockApiState();
+
+    const { result, rerender } = testHook(useSourcePreview)({
+      formData: hfFormData,
+      existingSourceConfig: undefined,
+      apiState,
+      isEditMode: false,
+    });
+
+    await act(async () => {
+      await result.current.handleValidate();
+    });
+
+    await act(async () => {
+      await result.current.handlePreview();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.previewState.tabStates[CatalogSettingsPreviewTab.INCLUDED].items,
+      ).toHaveLength(2);
+    });
+
+    rerender({
+      formData: { ...hfFormData, accessToken: '' },
+      existingSourceConfig: undefined,
+      apiState,
+      isEditMode: false,
+    });
+
+    expect(
+      result.current.previewState.tabStates[CatalogSettingsPreviewTab.INCLUDED].items,
+    ).toHaveLength(2);
+    expect(result.current.previewState.summary?.totalModels).toBe(10);
+    expect(result.current.hasFormChanged).toBe(true);
+    expect(result.current.canPreview).toBe(true);
+  });
+
+  it('should keep preview results and require refresh when organization changes', async () => {
+    const apiState = createMockApiState();
+
+    const { result, rerender } = testHook(useSourcePreview)({
+      formData: { ...hfFormData, accessToken: '', organization: 'google' },
+      existingSourceConfig: undefined,
+      apiState,
+      isEditMode: false,
+    });
+
+    await act(async () => {
+      await result.current.handlePreview();
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.previewState.tabStates[CatalogSettingsPreviewTab.INCLUDED].items,
+      ).toHaveLength(2);
+    });
+
+    rerender({
+      formData: { ...hfFormData, accessToken: '', organization: 'Googl' },
+      existingSourceConfig: undefined,
+      apiState,
+      isEditMode: false,
+    });
+
+    expect(
+      result.current.previewState.tabStates[CatalogSettingsPreviewTab.INCLUDED].items,
+    ).toHaveLength(2);
+    expect(result.current.hasFormChanged).toBe(true);
+    expect(result.current.canPreview).toBe(true);
   });
 
   it('should handle API errors', async () => {

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/__tests__/useSourcePreview.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/__tests__/useSourcePreview.spec.ts
@@ -339,9 +339,7 @@ describe('useSourcePreview', () => {
   it('should auto-preview on mount in edit mode for HF sources with token', async () => {
     const apiState = createMockApiState();
 
-    testHook(useSourcePreview)(
-      createHookParams(hfFormData, { apiState, isEditMode: true }),
-    );
+    testHook(useSourcePreview)(createHookParams(hfFormData, { apiState, isEditMode: true }));
 
     await waitFor(() => {
       expect(apiState.api.previewCatalogSource).toHaveBeenCalledTimes(1);

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -245,7 +245,7 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
           isInline
           variant="danger"
           title={ERROR_MESSAGES.VALIDATION_FAILED}
-          className="pf-v6-u-mt-md"
+          className="pf-v6-u"
         >
           {validationError.message}
         </Alert>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -242,20 +242,12 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
         {accessTokenInput}
       </ThemeAwareFormGroupWrapper>
       {validationError && (
-        <Alert
-          isInline
-          variant="danger"
-          title={ERROR_MESSAGES.VALIDATION_FAILED}
-        >
+        <Alert isInline variant="danger" title={ERROR_MESSAGES.VALIDATION_FAILED}>
           {validationError.message}
         </Alert>
       )}
       {isValidationSuccess && !isTokenLocked && (
-        <Alert
-          isInline
-          variant="success"
-          title={SUCCESS_MESSAGES.VALIDATION_SUCCESSFUL}
-        >
+        <Alert isInline variant="success" title={SUCCESS_MESSAGES.VALIDATION_SUCCESSFUL}>
           {SUCCESS_MESSAGES.VALIDATION_SUCCESSFUL_BODY}
         </Alert>
       )}

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -124,6 +124,7 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
       onChange={(_event, value) => setData('organization', value)}
       onBlur={() => setIsOrganizationTouched(true)}
       validated={isOrganizationTouched && !isOrganizationValid ? 'error' : 'default'}
+      isDisabled={isValidating}
     />
   );
 
@@ -190,7 +191,7 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
       onChange={(_event, value) => setData('accessToken', value)}
       ariaLabelShow="Show access token"
       ariaLabelHide="Hide access token"
-      isDisabled={isValidationSuccess}
+      isDisabled={isValidating || isValidationSuccess}
       hideToggleButton={isValidationSuccess}
       forceHidden={isValidationSuccess}
     />
@@ -245,7 +246,6 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
           isInline
           variant="danger"
           title={ERROR_MESSAGES.VALIDATION_FAILED}
-          className="pf-v6-u"
         >
           {validationError.message}
         </Alert>
@@ -254,14 +254,13 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
         <Alert
           isInline
           variant="success"
-          className="pf-v6-u"
           title={SUCCESS_MESSAGES.VALIDATION_SUCCESSFUL}
         >
           {SUCCESS_MESSAGES.VALIDATION_SUCCESSFUL_BODY}
         </Alert>
       )}
 
-      <ActionList className="pf-v6-u">
+      <ActionList>
         {tokenValidationBtn}
         {tokenClearBtn}
       </ActionList>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ManageSourceForm.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ManageSourceForm.tsx
@@ -210,6 +210,7 @@ const ManageSourceForm: React.FC<ManageSourceFormProps> = ({
         isPreviewDisabled={!preview.canPreview}
         isPreviewLoading={preview.previewState.isLoadingInitial}
         onPreview={() => preview.handlePreview()}
+        previewDisabledTooltip={preview.previewDisabledTooltip}
       />
     </>
   );

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ManageSourceFormFooter.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/ManageSourceFormFooter.tsx
@@ -22,6 +22,7 @@ type ManageSourceFormFooterProps = {
   isPreviewDisabled: boolean;
   isPreviewLoading: boolean;
   onPreview: () => void;
+  previewDisabledTooltip?: string;
 };
 
 const ManageSourceFormFooter: React.FC<ManageSourceFormFooterProps> = ({
@@ -34,6 +35,7 @@ const ManageSourceFormFooter: React.FC<ManageSourceFormFooterProps> = ({
   isPreviewDisabled,
   isPreviewLoading,
   onPreview,
+  previewDisabledTooltip,
 }) => (
   <PageSection hasBodyWrapper={false} stickyOnBreakpoint={{ default: 'bottom' }}>
     <Stack hasGutter>
@@ -66,6 +68,7 @@ const ManageSourceFormFooter: React.FC<ManageSourceFormFooterProps> = ({
                 isLoading={isPreviewLoading}
                 variant="secondary"
                 testId="preview-button"
+                disabledTooltip={previewDisabledTooltip}
               />
             </ActionListItem>
             <ActionListItem>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewButton.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ButtonProps } from '@patternfly/react-core';
+import { Button, ButtonProps, Tooltip } from '@patternfly/react-core';
 import { BUTTON_LABELS } from '~/app/pages/modelCatalogSettings/constants';
 
 type PreviewButtonProps = {
@@ -8,6 +8,7 @@ type PreviewButtonProps = {
   isLoading?: boolean;
   variant?: ButtonProps['variant'];
   testId?: string;
+  disabledTooltip?: string;
 };
 
 const PreviewButton: React.FC<PreviewButtonProps> = ({
@@ -16,16 +17,29 @@ const PreviewButton: React.FC<PreviewButtonProps> = ({
   isLoading = false,
   variant = 'primary',
   testId = 'preview-button',
-}) => (
-  <Button
-    variant={variant}
-    onClick={onClick}
-    isDisabled={isDisabled}
-    isLoading={isLoading}
-    data-testid={testId}
-  >
-    {BUTTON_LABELS.PREVIEW}
-  </Button>
-);
+  disabledTooltip,
+}) => {
+  const button = (
+    <Button
+      variant={variant}
+      onClick={onClick}
+      isDisabled={isDisabled}
+      isLoading={isLoading}
+      data-testid={testId}
+    >
+      {BUTTON_LABELS.PREVIEW}
+    </Button>
+  );
+
+  if (disabledTooltip && isDisabled) {
+    return (
+      <Tooltip content={disabledTooltip}>
+        <span className="pf-v6-u-display-inline-block">{button}</span>
+      </Tooltip>
+    );
+  }
+
+  return button;
+};
 
 export default PreviewButton;

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
@@ -44,6 +44,7 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
     handleLoadMore,
     hasFormChanged,
     canPreview,
+    previewDisabledTooltip,
   } = preview;
   const { isLoadingInitial, isLoadingMore, activeTab, summary, tabStates, error, mode } =
     previewState;
@@ -76,6 +77,7 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
                 isLoading={isLoadingInitial}
                 variant="link"
                 testId="preview-button-panel-retry"
+                disabledTooltip={previewDisabledTooltip}
               />
             </EmptyStateActions>
           </EmptyStateFooter>
@@ -97,6 +99,7 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
               isLoading={isLoadingInitial}
               variant="link"
               testId="preview-button-panel"
+              disabledTooltip={previewDisabledTooltip}
             />
           </EmptyStateActions>
         </EmptyStateFooter>
@@ -136,7 +139,11 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
               title="Source configuration changed. Refresh the preview."
               className="pf-v6-u-mb-md"
               actionLinks={
-                <AlertActionLink onClick={onPreview} data-testid="refresh-preview-link">
+                <AlertActionLink
+                  onClick={onPreview}
+                  isDisabled={!canPreview}
+                  data-testid="refresh-preview-link"
+                >
                   Refresh preview
                 </AlertActionLink>
               }
@@ -218,6 +225,7 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
             isLoading={isLoadingInitial}
             variant="secondary"
             testId="preview-button-header"
+            disabledTooltip={previewDisabledTooltip}
           />
         </FlexItem>
       </Flex>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
@@ -24,9 +24,7 @@ import {
   ERROR_MESSAGES,
   EMPTY_STATE_TEXT,
 } from '~/app/pages/modelCatalogSettings/constants';
-import {
-  UseSourcePreviewResult,
-} from '~/app/pages/modelCatalogSettings/useSourcePreview';
+import { UseSourcePreviewResult } from '~/app/pages/modelCatalogSettings/useSourcePreview';
 import { CatalogSettingsPreviewTab } from '~/app/shared/catalogSettings/hooks/previewTypes';
 import PreviewButton from './PreviewButton';
 

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
@@ -26,7 +26,6 @@ import {
 } from '~/app/pages/modelCatalogSettings/constants';
 import {
   UseSourcePreviewResult,
-  PreviewMode,
 } from '~/app/pages/modelCatalogSettings/useSourcePreview';
 import { CatalogSettingsPreviewTab } from '~/app/shared/catalogSettings/hooks/previewTypes';
 import PreviewButton from './PreviewButton';
@@ -46,10 +45,9 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
     canPreview,
     previewDisabledTooltip,
   } = preview;
-  const { isLoadingInitial, isLoadingMore, activeTab, summary, tabStates, error, mode } =
-    previewState;
+  const { isLoadingInitial, isLoadingMore, activeTab, summary, tabStates, error } = previewState;
   const { items, hasMore } = tabStates[activeTab];
-  const previewError = mode === PreviewMode.PREVIEW ? error : undefined;
+  const previewError = error;
 
   const onPreview = () => handlePreview();
   const onLoadMore = () => handleLoadMore();

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/__tests__/PreviewPanel.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/__tests__/PreviewPanel.spec.tsx
@@ -223,6 +223,32 @@ describe('PreviewPanel', () => {
     expect(screen.getByTestId('refresh-preview-link')).toBeInTheDocument();
   });
 
+  it('shows refresh alert with disabled link when hasFormChanged is true and preview is disabled', () => {
+    const preview = createMockPreview({ hasFormChanged: true, canPreview: false });
+    render(<PreviewPanel preview={preview} />);
+
+    expect(
+      screen.getByText('Source configuration changed. Refresh the preview.'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('refresh-preview-link')).toBeInTheDocument();
+    expect(screen.getByTestId('refresh-preview-link')).toBeDisabled();
+  });
+
+  it('shows preview disabled tooltip when token validation is required', async () => {
+    const user = userEvent.setup();
+    const preview = createMockPreview({
+      canPreview: false,
+      previewDisabledTooltip: 'Validate the access token to preview models.',
+    });
+
+    render(<PreviewPanel preview={preview} />);
+
+    await user.hover(screen.getByTestId('preview-button-header'));
+    expect(
+      await screen.findByText('Validate the access token to preview models.'),
+    ).toBeInTheDocument();
+  });
+
   it('calls handlePreview when refresh link clicked', async () => {
     const user = userEvent.setup();
     const handlePreview = jest.fn();

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/__tests__/PreviewPanel.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/__tests__/PreviewPanel.spec.tsx
@@ -121,6 +121,24 @@ describe('PreviewPanel', () => {
     expect(screen.getByTestId('preview-button-panel-retry')).toBeInTheDocument();
   });
 
+  it('renders error state when preview failed during edit auto-preview', () => {
+    const preview = createMockPreview(
+      {},
+      {
+        error: new Error('invalid Hugging Face API credentials'),
+        summary: undefined,
+        tabStates: {
+          [CatalogSettingsPreviewTab.INCLUDED]: { items: [], hasMore: false },
+          [CatalogSettingsPreviewTab.EXCLUDED]: { items: [], hasMore: false },
+        },
+      },
+    );
+    render(<PreviewPanel preview={preview} />);
+
+    expect(screen.getByText('Preview failed')).toBeInTheDocument();
+    expect(screen.getByText('invalid Hugging Face API credentials')).toBeInTheDocument();
+  });
+
   it('renders tabs for included/excluded models', () => {
     const preview = createMockPreview();
     render(<PreviewPanel preview={preview} />);

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/__tests__/PreviewPanel.spec.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/__tests__/PreviewPanel.spec.tsx
@@ -312,6 +312,27 @@ describe('PreviewPanel', () => {
     expect(screen.getByText('model-3')).toBeInTheDocument();
   });
 
+  it('does not render panel body preview button when preview results are shown', () => {
+    const preview = createMockPreview(
+      {
+        canPreview: false,
+        hasFormChanged: true,
+        previewDisabledTooltip: 'Validate the access token to preview models.',
+      },
+      {
+        summary: mockSummary,
+        tabStates: {
+          [CatalogSettingsPreviewTab.INCLUDED]: { items: mockIncludedItems, hasMore: false },
+          [CatalogSettingsPreviewTab.EXCLUDED]: { items: mockExcludedItems, hasMore: false },
+        },
+      },
+    );
+    render(<PreviewPanel preview={preview} />);
+
+    expect(screen.queryByTestId('preview-button-panel')).not.toBeInTheDocument();
+    expect(screen.getByTestId('preview-button-header')).toBeDisabled();
+  });
+
   it('disables preview button when canPreview is false', () => {
     const preview = createMockPreview(
       { canPreview: false },

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/constants.tsx
@@ -91,6 +91,10 @@ export const SUCCESS_MESSAGES = {
   VALIDATION_SUCCESSFUL_BODY: 'Organization and access token were validated successfully.',
 } as const;
 
+export const TOOLTIP_MESSAGES = {
+  PREVIEW_REQUIRES_VALIDATION: 'Validate the access token to preview models.',
+} as const;
+
 export const TABLE_COLUMN_LABELS = {
   SOURCE_NAME: 'Source name',
   ORGANIZATION: 'Organization',

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/useSourcePreview.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/useSourcePreview.ts
@@ -9,14 +9,49 @@ import {
   CatalogSourcePreviewSummary,
 } from '~/app/modelCatalogTypes';
 import { ModelCatalogSettingsAPIState } from '~/app/hooks/modelCatalogSettings/useModelCatalogSettingsAPIState';
-import { CatalogSettingsPreviewTab } from '~/app/shared/catalogSettings/hooks/previewTypes';
+import {
+  CatalogSettingsPreviewTab,
+  DEFAULT_PREVIEW_PAGE_SIZE,
+} from '~/app/shared/catalogSettings/hooks/previewTypes';
 import { useCatalogSourcePreviewCore } from '~/app/shared/catalogSettings/hooks/useCatalogSourcePreviewCore';
+import { TOOLTIP_MESSAGES } from './constants';
 import { ManageSourceFormData } from './useManageSourceData';
 
 export enum PreviewMode {
   PREVIEW = 'preview',
-  VALIDATE = 'validate',
 }
+
+type CredentialsValidationStatus = 'unknown' | 'valid' | 'invalid';
+
+const isHuggingFaceWithAccessToken = (formData: ManageSourceFormData): boolean =>
+  formData.sourceType === CatalogSourceType.HUGGING_FACE && formData.accessToken.trim().length > 0;
+
+export const isPreviewEnabled = (
+  formData: ManageSourceFormData,
+  credentialsValidationStatus: CredentialsValidationStatus,
+): boolean => {
+  if (!isPreviewReady(formData)) {
+    return false;
+  }
+  if (isHuggingFaceWithAccessToken(formData)) {
+    return credentialsValidationStatus === 'valid';
+  }
+  return true;
+};
+
+export const getPreviewDisabledTooltip = (
+  formData: ManageSourceFormData,
+  credentialsValidationStatus: CredentialsValidationStatus,
+): string | undefined => {
+  if (
+    isPreviewReady(formData) &&
+    isHuggingFaceWithAccessToken(formData) &&
+    credentialsValidationStatus !== 'valid'
+  ) {
+    return TOOLTIP_MESSAGES.PREVIEW_REQUIRES_VALIDATION;
+  }
+  return undefined;
+};
 
 export type PreviewTabState = {
   items: CatalogSourcePreviewModel[];
@@ -55,6 +90,7 @@ export interface UseSourcePreviewResult {
   validationError?: Error;
   isValidationSuccess: boolean;
   canPreview: boolean;
+  previewDisabledTooltip?: string;
 }
 
 export const useSourcePreview = ({
@@ -63,9 +99,15 @@ export const useSourcePreview = ({
   apiState,
   isEditMode,
 }: UseSourcePreviewOptions): UseSourcePreviewResult => {
-  const canPreview = isPreviewReady(formData);
-  const [mode, setMode] = React.useState<PreviewMode | undefined>();
+  const [credentialsValidationStatus, setCredentialsValidationStatus] =
+    React.useState<CredentialsValidationStatus>('unknown');
+  const [isValidating, setIsValidating] = React.useState(false);
+  const [validationError, setValidationError] = React.useState<Error | undefined>();
   const [resultDismissed, setResultDismissed] = React.useState(false);
+  const [mode, setMode] = React.useState<PreviewMode | undefined>();
+
+  const canPreview = isPreviewEnabled(formData, credentialsValidationStatus);
+  const previewDisabledTooltip = getPreviewDisabledTooltip(formData, credentialsValidationStatus);
 
   const buildPreviewRequest = React.useCallback((): CatalogSourcePreviewRequest => {
     const payload = transformFormDataToConfig(formData, existingSourceConfig);
@@ -124,26 +166,44 @@ export const useSourcePreview = ({
     resultDismissed,
   };
 
-  const isValidating = mode === PreviewMode.VALIDATE && previewState.isLoadingInitial;
-  const validationError = mode === PreviewMode.VALIDATE ? previewState.error : undefined;
-  const isValidationSuccess =
-    mode === PreviewMode.VALIDATE &&
-    !previewState.isLoadingInitial &&
-    !previewState.error &&
-    !resultDismissed;
+  React.useEffect(() => {
+    setCredentialsValidationStatus('unknown');
+    setValidationError(undefined);
+    setResultDismissed(false);
+  }, [formData.accessToken, formData.organization]);
 
-  const handlePreview = React.useCallback(
-    async (nextMode: PreviewMode = PreviewMode.PREVIEW) => {
-      setMode(nextMode);
-      setResultDismissed(false);
-      await handlePreviewInternal();
-    },
-    [handlePreviewInternal],
-  );
+  const isValidationSuccess = credentialsValidationStatus === 'valid' && !resultDismissed;
+
+  const handlePreview = React.useCallback(async () => {
+    setMode(PreviewMode.PREVIEW);
+    await handlePreviewInternal();
+  }, [handlePreviewInternal]);
 
   const handleValidate = React.useCallback(async () => {
-    await handlePreview(PreviewMode.VALIDATE);
-  }, [handlePreview]);
+    if (!apiState.apiAvailable) {
+      setValidationError(new Error('API is not available'));
+      setCredentialsValidationStatus('invalid');
+      return;
+    }
+
+    setIsValidating(true);
+    setValidationError(undefined);
+    setResultDismissed(false);
+
+    try {
+      await previewApi({}, buildPreviewRequest(), {
+        filterStatus: CatalogSettingsPreviewTab.INCLUDED,
+        pageSize: DEFAULT_PREVIEW_PAGE_SIZE,
+      });
+      setCredentialsValidationStatus('valid');
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error('Failed to validate credentials');
+      setValidationError(err);
+      setCredentialsValidationStatus('invalid');
+    } finally {
+      setIsValidating(false);
+    }
+  }, [apiState.apiAvailable, buildPreviewRequest, previewApi]);
 
   const clearValidationSuccess = React.useCallback(() => {
     setResultDismissed(true);
@@ -161,5 +221,6 @@ export const useSourcePreview = ({
     validationError,
     isValidationSuccess,
     canPreview,
+    previewDisabledTooltip,
   };
 };

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/useSourcePreview.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/useSourcePreview.ts
@@ -29,9 +29,13 @@ const isHuggingFaceWithAccessToken = (formData: ManageSourceFormData): boolean =
 export const isPreviewEnabled = (
   formData: ManageSourceFormData,
   credentialsValidationStatus: CredentialsValidationStatus,
+  isEditMode = false,
 ): boolean => {
   if (!isPreviewReady(formData)) {
     return false;
+  }
+  if (isEditMode) {
+    return true;
   }
   if (isHuggingFaceWithAccessToken(formData)) {
     return credentialsValidationStatus === 'valid';
@@ -42,7 +46,11 @@ export const isPreviewEnabled = (
 export const getPreviewDisabledTooltip = (
   formData: ManageSourceFormData,
   credentialsValidationStatus: CredentialsValidationStatus,
+  isEditMode = false,
 ): string | undefined => {
+  if (isEditMode) {
+    return undefined;
+  }
   if (
     isPreviewReady(formData) &&
     isHuggingFaceWithAccessToken(formData) &&
@@ -106,8 +114,12 @@ export const useSourcePreview = ({
   const [resultDismissed, setResultDismissed] = React.useState(false);
   const [mode, setMode] = React.useState<PreviewMode | undefined>();
 
-  const canPreview = isPreviewEnabled(formData, credentialsValidationStatus);
-  const previewDisabledTooltip = getPreviewDisabledTooltip(formData, credentialsValidationStatus);
+  const canPreview = isPreviewEnabled(formData, credentialsValidationStatus, isEditMode);
+  const previewDisabledTooltip = getPreviewDisabledTooltip(
+    formData,
+    credentialsValidationStatus,
+    isEditMode,
+  );
 
   const buildPreviewRequest = React.useCallback((): CatalogSourcePreviewRequest => {
     const payload = transformFormDataToConfig(formData, existingSourceConfig);

--- a/clients/ui/frontend/src/app/shared/catalogSettings/hooks/useCatalogSourcePreviewCore.ts
+++ b/clients/ui/frontend/src/app/shared/catalogSettings/hooks/useCatalogSourcePreviewCore.ts
@@ -42,6 +42,7 @@ export type UseCatalogSourcePreviewCoreResult<TItem, TSummary, TRequest> = {
   handleTabChange: (tab: CatalogSettingsPreviewTab) => void;
   handleLoadMore: () => void;
   hasFormChanged: boolean;
+  resetPreview: () => void;
 };
 
 const createInitialPreviewState = <TItem, TSummary, TRequest>(): CatalogSettingsPreviewCoreState<
@@ -187,6 +188,10 @@ export const useCatalogSourcePreviewCore = <TItem, TSummary, TRequest>({
     handlePreviewInternal({ loadMore: true });
   }, [handlePreviewInternal]);
 
+  const resetPreview = React.useCallback(() => {
+    setPreviewState(createInitialPreviewState<TItem, TSummary, TRequest>());
+  }, []);
+
   // mount-only: auto-preview when entering edit mode
   React.useEffect(() => {
     const hasNoResults =
@@ -203,5 +208,6 @@ export const useCatalogSourcePreviewCore = <TItem, TSummary, TRequest>({
     handleTabChange,
     handleLoadMore,
     hasFormChanged,
+    resetPreview,
   };
 };

--- a/clients/ui/frontend/src/app/shared/catalogSettings/hooks/useCatalogSourcePreviewCore.ts
+++ b/clients/ui/frontend/src/app/shared/catalogSettings/hooks/useCatalogSourcePreviewCore.ts
@@ -42,7 +42,6 @@ export type UseCatalogSourcePreviewCoreResult<TItem, TSummary, TRequest> = {
   handleTabChange: (tab: CatalogSettingsPreviewTab) => void;
   handleLoadMore: () => void;
   hasFormChanged: boolean;
-  resetPreview: () => void;
 };
 
 const createInitialPreviewState = <TItem, TSummary, TRequest>(): CatalogSettingsPreviewCoreState<
@@ -188,10 +187,6 @@ export const useCatalogSourcePreviewCore = <TItem, TSummary, TRequest>({
     handlePreviewInternal({ loadMore: true });
   }, [handlePreviewInternal]);
 
-  const resetPreview = React.useCallback(() => {
-    setPreviewState(createInitialPreviewState<TItem, TSummary, TRequest>());
-  }, []);
-
   // mount-only: auto-preview when entering edit mode
   React.useEffect(() => {
     const hasNoResults =
@@ -208,6 +203,5 @@ export const useCatalogSourcePreviewCore = <TItem, TSummary, TRequest>({
     handleTabChange,
     handleLoadMore,
     hasFormChanged,
-    resetPreview,
   };
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to cover the preview button gating and showing refresh preview alert cases for HF sources.
make sue to test every possible cases, I might be missing any other cases.


## How Has This Been Tested?
Run the application in mock mode and test these scenario:

- Validate uses the preview API only; preview panel is not populated until the user clicks Preview.
- Token present, not validated  - preview is disabled.
- Invalid token — Preview buttons disabled after failed Validate
- Valid token — Preview buttons enabled after successful Validate.
- No token — Preview enabled for public models; empty token is not treated as invalid.

refresh alert appears, when :
- Included models changed 
- Excluded models changed
- Organization changed
- Access token typed/changed
- Access token cleared
- YAML content changed 


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [ ] The developer has added tests or explained why testing cannot be added.
- [ ] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
