### PR TITLE
fix(catalog): stop paginate from panicking on an empty artifact list

### DIFF
--- a/catalog/internal/catalog/modelcatalog/performance_artifact_service.go
+++ b/catalog/internal/catalog/modelcatalog/performance_artifact_service.go
@@ -400,14 +400,16 @@ func (s *PerformanceArtifactService) paginate(list *dbmodels.ListWrapper[sharedm
 	}
 
 	if cursor != nil {
-		var index int
-		for index = range list.Items {
-			id := list.Items[index].GetID()
+		// A cursor that is not in this list, or an empty list, has nothing after it.
+		start := len(list.Items)
+		for i := range list.Items {
+			id := list.Items[i].GetID()
 			if id != nil && *id == cursor.ID {
+				start = i + 1
 				break
 			}
 		}
-		list.Items = list.Items[index+1:]
+		list.Items = list.Items[start:]
 	}
 
 	list.NextPageToken = ""

--- a/catalog/internal/catalog/modelcatalog/performance_artifact_service_test.go
+++ b/catalog/internal/catalog/modelcatalog/performance_artifact_service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kubeflow/hub/catalog/internal/catalog/modelcatalog/models"
 	sharedmodels "github.com/kubeflow/hub/catalog/internal/db/models"
 	dbmodels "github.com/kubeflow/hub/internal/platform/db/entity"
+	"github.com/kubeflow/hub/internal/platform/db/scopes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -831,4 +832,59 @@ func TestGetMinimumRecommendedLatency_NoArtifacts(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Nil(t, minLatency) // Should return nil for models without data
+}
+
+func TestPerformanceArtifactService_PaginateCursor(t *testing.T) {
+	service := NewPerformanceArtifactService(nil, nil)
+
+	newArtifact := func(id int32) sharedmodels.CatalogMetricsArtifact {
+		return &dbmodels.BaseEntity[models.CatalogMetricsArtifactAttributes]{
+			ID:         &id,
+			Attributes: &models.CatalogMetricsArtifactAttributes{},
+		}
+	}
+	newList := func(ids ...int32) *dbmodels.ListWrapper[sharedmodels.CatalogMetricsArtifact] {
+		items := make([]sharedmodels.CatalogMetricsArtifact, 0, len(ids))
+		for _, id := range ids {
+			items = append(items, newArtifact(id))
+		}
+		return &dbmodels.ListWrapper[sharedmodels.CatalogMetricsArtifact]{Items: items}
+	}
+
+	t.Run("cursor in list returns the items after it", func(t *testing.T) {
+		list := newList(1, 2, 3, 4)
+		token := scopes.CreateNextPageToken(2, "")
+		service.paginate(list, 10, &token)
+		require.Len(t, list.Items, 2)
+		assert.Equal(t, int32(3), *list.Items[0].GetID())
+		assert.Equal(t, int32(4), *list.Items[1].GetID())
+		assert.Empty(t, list.NextPageToken)
+		assert.Equal(t, int32(2), list.Size)
+	})
+
+	t.Run("cursor over an empty list does not panic", func(t *testing.T) {
+		list := newList()
+		token := scopes.CreateNextPageToken(1, "")
+		assert.NotPanics(t, func() { service.paginate(list, 10, &token) })
+		assert.Empty(t, list.Items)
+		assert.Empty(t, list.NextPageToken)
+		assert.Equal(t, int32(0), list.Size)
+	})
+
+	t.Run("cursor not in list returns no items", func(t *testing.T) {
+		list := newList(1, 2, 3)
+		token := scopes.CreateNextPageToken(99, "")
+		service.paginate(list, 10, &token)
+		assert.Empty(t, list.Items)
+		assert.Empty(t, list.NextPageToken)
+	})
+
+	t.Run("undecodable token returns the first page", func(t *testing.T) {
+		list := newList(1, 2, 3)
+		token := "not-a-token"
+		service.paginate(list, 2, &token)
+		require.Len(t, list.Items, 2)
+		assert.Equal(t, int32(1), *list.Items[0].GetID())
+		assert.NotEmpty(t, list.NextPageToken)
+	})
 }


### PR DESCRIPTION
## Description

`PerformanceArtifactService.paginate` slices `list.Items[index+1:]` after a `for index = range list.Items` loop. When the list is empty the loop never runs, `index` stays 0, and the slice is `[1:0]`, which panics. That path is reached by `GET .../artifacts/performance?recommendations=true&nextPageToken=<token>` whenever the Pareto filter has removed every artifact, and the catalog server has no recover middleware, so the client gets a closed connection instead of an empty page.

The loop now records where the cursor was found and starts after it; a cursor that is not in the list, including the empty list, yields no items. That is what a cursor past the end of a non-empty list already returned, so no observable behaviour changes apart from the panic. Undecodable tokens still return the first page, as the existing comment intends.

Fixes #3197

## How Has This Been Tested?

`TestPerformanceArtifactService_PaginateCursor` covers four cases: cursor in the list, cursor over an empty list (this one panicked before the change, checked by stashing the fix and running the test), cursor not in the list, and an undecodable token. `make -C catalog test`, `make test`, `make vet` and `make lint` pass locally on Go 1.27 with golangci-lint v2.12.2 from `make bin/golangci-lint`. The catalog module has no lint target, so I ran the same binary on `catalog/internal/catalog/modelcatalog/...` with `--new-from-rev origin/main`: 0 issues on the changed lines.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
