### PR TITLE
fix(catalog): stop preview pagination repeating or looping on duplicate names

### DIFF
--- a/catalog/internal/server/openapi/v1/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/v1/api_model_catalog_service_service_test.go
@@ -2690,3 +2690,44 @@ func TestClearSourceStatus(t *testing.T) {
 func strPtr(s string) *string {
 	return new(s)
 }
+
+func TestPreviewCatalogSourceDuplicateNames(t *testing.T) {
+	service := newTestServiceWithSources(map[string]*model.CatalogModel{})
+	catalogData := `
+models:
+  - name: "acme/granite-3b"
+    description: "first entry"
+  - name: "acme/granite-3b"
+    description: "second entry, same name"
+  - name: "acme/llama-7b"
+    description: "third entry"
+`
+	want := []string{"acme/granite-3b", "acme/granite-3b", "acme/llama-7b"}
+
+	for _, pageSize := range []string{"1", "2"} {
+		t.Run("pageSize="+pageSize, func(t *testing.T) {
+			var got []string
+			token := ""
+			for range 10 {
+				configFile := writeTempYAML(t, "config", "type: yaml\n")
+				catalogDataFile := writeTempYAML(t, "catalogdata", catalogData)
+
+				resp, err := service.PreviewCatalogSource(context.Background(), configFile, pageSize, token, "", catalogDataFile)
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, resp.Code)
+				body, ok := resp.Body.(model.CatalogSourcePreviewResponse)
+				require.True(t, ok, "expected CatalogSourcePreviewResponse, got %T", resp.Body)
+
+				for _, item := range body.Items {
+					got = append(got, item.Name)
+				}
+				if body.NextPageToken == "" {
+					break
+				}
+				require.NotEqual(t, token, body.NextPageToken, "nextPageToken did not advance")
+				token = body.NextPageToken
+			}
+			assert.Equal(t, want, got)
+		})
+	}
+}

--- a/catalog/internal/server/openapi/v1/pagination.go
+++ b/catalog/internal/server/openapi/v1/pagination.go
@@ -116,13 +116,16 @@ func (p *paginator[T]) Token() string {
 func (p *paginator[T]) Paginate(items []T) ([]T, *paginator[T]) {
 	startIndex := 0
 	if p.cursor != nil {
+		seen := 0
 		for i, item := range items {
-			itemValue := item.SortValue(p.OrderBy)
-			id := item.SortValue(model.ORDERBYFIELD_ID)
-			if id != "" && id == p.cursor.ID && itemValue == p.cursor.Value {
+			if !p.cursor.matches(item, p.OrderBy) {
+				continue
+			}
+			if seen == p.cursor.Skip {
 				startIndex = i + 1
 				break
 			}
+			seen++
 		}
 	}
 
@@ -140,14 +143,20 @@ func (p *paginator[T]) Paginate(items []T) ([]T, *paginator[T]) {
 		lastItem := pagedItems[len(pagedItems)-1]
 		lastItemID := lastItem.SortValue(model.ORDERBYFIELD_ID)
 		if lastItemID != "" {
+			cursor := &stringCursor{
+				Value: lastItem.SortValue(p.OrderBy),
+				ID:    lastItemID,
+			}
+			for _, item := range items[:endIndex-1] {
+				if cursor.matches(item, p.OrderBy) {
+					cursor.Skip++
+				}
+			}
 			next = &paginator[T]{
 				PageSize:  p.PageSize,
 				OrderBy:   p.OrderBy,
 				SortOrder: p.SortOrder,
-				cursor: &stringCursor{
-					Value: lastItem.SortValue(p.OrderBy),
-					ID:    lastItemID,
-				},
+				cursor:    cursor,
 			}
 		}
 	}
@@ -158,10 +167,19 @@ func (p *paginator[T]) Paginate(items []T) ([]T, *paginator[T]) {
 type stringCursor struct {
 	Value string
 	ID    string
+	// Skip is the number of items with the same Value and ID that precede the
+	// item this cursor points at. Preview results are keyed by name, and names
+	// can repeat, so Value and ID alone cannot say which duplicate ended the page.
+	Skip int
+}
+
+func (c *stringCursor) matches(item model.Sortable, orderBy model.OrderByField) bool {
+	id := item.SortValue(model.ORDERBYFIELD_ID)
+	return id != "" && id == c.ID && item.SortValue(orderBy) == c.Value
 }
 
 func (c *stringCursor) String() string {
-	return base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%s:%s", c.Value, c.ID))
+	return base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%d:%s:%s", c.Skip, c.Value, c.ID))
 }
 
 func decodeStringCursor(encoded string) (*stringCursor, error) {
@@ -169,6 +187,14 @@ func decodeStringCursor(encoded string) (*stringCursor, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid token encoding: %w", err)
 	}
+	// "skip:value:id"; the id is last so it can contain colons.
+	if parts := strings.SplitN(string(decoded), ":", 3); len(parts) == 3 {
+		if skip, err := strconv.Atoi(parts[0]); err == nil && skip >= 0 {
+			return &stringCursor{Value: parts[1], ID: parts[2], Skip: skip}, nil
+		}
+	}
+	// Tokens issued before Skip existed are "value:id". Keep accepting them so
+	// a client walking pages across an upgrade does not get a 400.
 	parts := strings.SplitN(string(decoded), ":", 2)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid token format")

--- a/catalog/internal/server/openapi/v1/pagination_test.go
+++ b/catalog/internal/server/openapi/v1/pagination_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"encoding/base64"
 	"fmt"
 	"math"
 	"strconv"
@@ -376,4 +377,53 @@ func TestPaginateSources_NoDuplicates(t *testing.T) {
 	}
 
 	assert.Equal(t, len(allSources), totalSeen, "Total number of items seen should match the original slice")
+}
+
+// Preview results are keyed by name, and names repeat: a YAML catalog can list
+// the same model twice, an HF source can match a model through both "org/*" and
+// "org/model", and a skill repository previewed at two refs reports every skill
+// twice. A cursor that only carries the name cannot say which duplicate ended
+// the page, so the walk either loops on one token or serves an item twice.
+func TestPaginateDuplicateIDs(t *testing.T) {
+	items := []model.AssetPreviewResult{
+		{Name: "code-review", Included: true},
+		{Name: "code-review", Included: true},
+		{Name: "deploy", Included: true},
+	}
+	want := []string{"code-review", "code-review", "deploy"}
+
+	for _, pageSize := range []string{"1", "2", "3"} {
+		t.Run("pageSize="+pageSize, func(t *testing.T) {
+			var got []string
+			token := ""
+			for range 10 {
+				p, err := newPaginator[model.AssetPreviewResult](pageSize, "", "", token)
+				require.NoError(t, err)
+				page, next := p.Paginate(items)
+				for _, item := range page {
+					got = append(got, item.Name)
+				}
+				if next == nil {
+					break
+				}
+				require.NotEqual(t, token, next.Token(), "nextPageToken did not advance")
+				token = next.Token()
+			}
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestDecodeStringCursorLegacyFormat(t *testing.T) {
+	// Tokens minted before the position field existed are "value:id".
+	legacy := base64.StdEncoding.EncodeToString([]byte("Source 4:source4"))
+	cursor, err := decodeStringCursor(legacy)
+	require.NoError(t, err)
+	assert.Equal(t, &stringCursor{Value: "Source 4", ID: "source4"}, cursor)
+
+	// The id may still contain colons, as stored model names do.
+	current := (&stringCursor{Value: "v", ID: "src:model", Skip: 2}).String()
+	cursor, err = decodeStringCursor(current)
+	require.NoError(t, err)
+	assert.Equal(t, &stringCursor{Value: "v", ID: "src:model", Skip: 2}, cursor)
 }

--- a/catalog/internal/server/openapi/v1alpha1/api_model_catalog_service_service_test.go
+++ b/catalog/internal/server/openapi/v1alpha1/api_model_catalog_service_service_test.go
@@ -2617,3 +2617,44 @@ func TestFindModelsOrderByRecommendedPagination(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.Code, "numeric nextPageToken must be accepted for orderBy=RECOMMENDED")
 	require.NoError(t, err)
 }
+
+func TestPreviewCatalogSourceDuplicateNames(t *testing.T) {
+	service := newTestServiceWithSources(map[string]*model.CatalogModel{})
+	catalogData := `
+models:
+  - name: "acme/granite-3b"
+    description: "first entry"
+  - name: "acme/granite-3b"
+    description: "second entry, same name"
+  - name: "acme/llama-7b"
+    description: "third entry"
+`
+	want := []string{"acme/granite-3b", "acme/granite-3b", "acme/llama-7b"}
+
+	for _, pageSize := range []string{"1", "2"} {
+		t.Run("pageSize="+pageSize, func(t *testing.T) {
+			var got []string
+			token := ""
+			for range 10 {
+				configFile := writeTempYAML(t, "config", "type: yaml\n")
+				catalogDataFile := writeTempYAML(t, "catalogdata", catalogData)
+
+				resp, err := service.PreviewCatalogSource(context.Background(), configFile, pageSize, token, "", catalogDataFile)
+				require.NoError(t, err)
+				require.Equal(t, http.StatusOK, resp.Code)
+				body, ok := resp.Body.(model.CatalogSourcePreviewResponse)
+				require.True(t, ok, "expected CatalogSourcePreviewResponse, got %T", resp.Body)
+
+				for _, item := range body.Items {
+					got = append(got, item.Name)
+				}
+				if body.NextPageToken == "" {
+					break
+				}
+				require.NotEqual(t, token, body.NextPageToken, "nextPageToken did not advance")
+				token = body.NextPageToken
+			}
+			assert.Equal(t, want, got)
+		})
+	}
+}

--- a/catalog/internal/server/openapi/v1alpha1/pagination.go
+++ b/catalog/internal/server/openapi/v1alpha1/pagination.go
@@ -116,13 +116,16 @@ func (p *paginator[T]) Token() string {
 func (p *paginator[T]) Paginate(items []T) ([]T, *paginator[T]) {
 	startIndex := 0
 	if p.cursor != nil {
+		seen := 0
 		for i, item := range items {
-			itemValue := item.SortValue(p.OrderBy)
-			id := item.SortValue(model.ORDERBYFIELD_ID)
-			if id != "" && id == p.cursor.ID && itemValue == p.cursor.Value {
+			if !p.cursor.matches(item, p.OrderBy) {
+				continue
+			}
+			if seen == p.cursor.Skip {
 				startIndex = i + 1
 				break
 			}
+			seen++
 		}
 	}
 
@@ -140,14 +143,20 @@ func (p *paginator[T]) Paginate(items []T) ([]T, *paginator[T]) {
 		lastItem := pagedItems[len(pagedItems)-1]
 		lastItemID := lastItem.SortValue(model.ORDERBYFIELD_ID)
 		if lastItemID != "" {
+			cursor := &stringCursor{
+				Value: lastItem.SortValue(p.OrderBy),
+				ID:    lastItemID,
+			}
+			for _, item := range items[:endIndex-1] {
+				if cursor.matches(item, p.OrderBy) {
+					cursor.Skip++
+				}
+			}
 			next = &paginator[T]{
 				PageSize:  p.PageSize,
 				OrderBy:   p.OrderBy,
 				SortOrder: p.SortOrder,
-				cursor: &stringCursor{
-					Value: lastItem.SortValue(p.OrderBy),
-					ID:    lastItemID,
-				},
+				cursor:    cursor,
 			}
 		}
 	}
@@ -158,10 +167,19 @@ func (p *paginator[T]) Paginate(items []T) ([]T, *paginator[T]) {
 type stringCursor struct {
 	Value string
 	ID    string
+	// Skip is the number of items with the same Value and ID that precede the
+	// item this cursor points at. Preview results are keyed by name, and names
+	// can repeat, so Value and ID alone cannot say which duplicate ended the page.
+	Skip int
+}
+
+func (c *stringCursor) matches(item model.Sortable, orderBy model.OrderByField) bool {
+	id := item.SortValue(model.ORDERBYFIELD_ID)
+	return id != "" && id == c.ID && item.SortValue(orderBy) == c.Value
 }
 
 func (c *stringCursor) String() string {
-	return base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%s:%s", c.Value, c.ID))
+	return base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%d:%s:%s", c.Skip, c.Value, c.ID))
 }
 
 func decodeStringCursor(encoded string) (*stringCursor, error) {
@@ -169,6 +187,14 @@ func decodeStringCursor(encoded string) (*stringCursor, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid token encoding: %w", err)
 	}
+	// "skip:value:id"; the id is last so it can contain colons.
+	if parts := strings.SplitN(string(decoded), ":", 3); len(parts) == 3 {
+		if skip, err := strconv.Atoi(parts[0]); err == nil && skip >= 0 {
+			return &stringCursor{Value: parts[1], ID: parts[2], Skip: skip}, nil
+		}
+	}
+	// Tokens issued before Skip existed are "value:id". Keep accepting them so
+	// a client walking pages across an upgrade does not get a 400.
 	parts := strings.SplitN(string(decoded), ":", 2)
 	if len(parts) != 2 {
 		return nil, fmt.Errorf("invalid token format")

--- a/catalog/internal/server/openapi/v1alpha1/pagination_test.go
+++ b/catalog/internal/server/openapi/v1alpha1/pagination_test.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"encoding/base64"
 	"fmt"
 	"math"
 	"strconv"
@@ -376,4 +377,53 @@ func TestPaginateSources_NoDuplicates(t *testing.T) {
 	}
 
 	assert.Equal(t, len(allSources), totalSeen, "Total number of items seen should match the original slice")
+}
+
+// Preview results are keyed by name, and names repeat: a YAML catalog can list
+// the same model twice, an HF source can match a model through both "org/*" and
+// "org/model", and a skill repository previewed at two refs reports every skill
+// twice. A cursor that only carries the name cannot say which duplicate ended
+// the page, so the walk either loops on one token or serves an item twice.
+func TestPaginateDuplicateIDs(t *testing.T) {
+	items := []model.AssetPreviewResult{
+		{Name: "code-review", Included: true},
+		{Name: "code-review", Included: true},
+		{Name: "deploy", Included: true},
+	}
+	want := []string{"code-review", "code-review", "deploy"}
+
+	for _, pageSize := range []string{"1", "2", "3"} {
+		t.Run("pageSize="+pageSize, func(t *testing.T) {
+			var got []string
+			token := ""
+			for range 10 {
+				p, err := newPaginator[model.AssetPreviewResult](pageSize, "", "", token)
+				require.NoError(t, err)
+				page, next := p.Paginate(items)
+				for _, item := range page {
+					got = append(got, item.Name)
+				}
+				if next == nil {
+					break
+				}
+				require.NotEqual(t, token, next.Token(), "nextPageToken did not advance")
+				token = next.Token()
+			}
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestDecodeStringCursorLegacyFormat(t *testing.T) {
+	// Tokens minted before the position field existed are "value:id".
+	legacy := base64.StdEncoding.EncodeToString([]byte("Source 4:source4"))
+	cursor, err := decodeStringCursor(legacy)
+	require.NoError(t, err)
+	assert.Equal(t, &stringCursor{Value: "Source 4", ID: "source4"}, cursor)
+
+	// The id may still contain colons, as stored model names do.
+	current := (&stringCursor{Value: "v", ID: "src:model", Skip: 2}).String()
+	cursor, err = decodeStringCursor(current)
+	require.NoError(t, err)
+	assert.Equal(t, &stringCursor{Value: "v", ID: "src:model", Skip: 2}, cursor)
 }


### PR DESCRIPTION
## Description

Fixes #3202.

The in-memory `paginator` in `catalog/internal/server/openapi/v1/pagination.go` (and its `v1alpha1` copy) identifies the last item of a page by its sort value and `SortValue(ORDERBYFIELD_ID)`. For `ModelPreviewResult` and `AssetPreviewResult` that ID is the name, and preview names repeat: a YAML catalog can list a model twice, a Hugging Face source can match a model through both `org/*` and `org/model`, and a skill repository previewed at two refs reports every skill under its frontmatter name once per ref. `Paginate` resumed after the first item with the cursor's name, so with a page smaller than the run of duplicates the token never changed and a client following `nextPageToken` looped forever; with a larger page the duplicate was served on two pages.

The cursor now also carries `Skip`, the number of identical items that precede the item it points at, and `Paginate` resumes after that exact one. The token becomes `skip:value:id`, with the id last so stored names such as `sourceId:modelName` still round-trip. The previous `value:id` form is still decoded, so a client mid-walk during an upgrade keeps working instead of getting a 400 from the new replica.

`FindSources` uses the same paginator but keys on source IDs, which are unique, so its behaviour is unchanged apart from the token format.

## How Has This Been Tested?

New tests, added to both `v1` and `v1alpha1`:

- `TestPaginateDuplicateIDs` walks three items with a repeated name through the paginator at page sizes 1, 2 and 3 and requires every item exactly once, with the token advancing on each page.
- `TestPreviewCatalogSourceDuplicateNames` does the same through `PreviewCatalogSource` with a YAML catalog, at page sizes 1 and 2.
- `TestDecodeStringCursorLegacyFormat` covers the old `value:id` token and a current token whose id contains a colon.

Before the fix, the handler walk on `main` (`b15fb0f2`) produced:

```
--- pageSize=1
request 1: items=[acme/granite-3b] nextPageToken="OmFjbWUvZ3Jhbml0ZS0zYg=="
request 2: items=[acme/granite-3b] nextPageToken="OmFjbWUvZ3Jhbml0ZS0zYg=="
request 3: items=[acme/granite-3b] nextPageToken="OmFjbWUvZ3Jhbml0ZS0zYg=="
--- pageSize=2
request 1: items=[acme/granite-3b acme/granite-3b] nextPageToken="OmFjbWUvZ3Jhbml0ZS0zYg=="
request 2: items=[acme/granite-3b acme/llama-7b] nextPageToken=""
```

Run locally on this branch: `make -C catalog test` (all 17 packages ok, against the Postgres test container), `go vet ./internal/server/openapi/...`, and `golangci-lint run ./internal/server/openapi/... --new-from-rev origin/main` with 0 issues.

This change was written with the assistance of Claude Code (noted in the commit trailer); the fix and the tests were reviewed and run by hand.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.
