### PR TITLE
Remove temp feature flag for Hugging Face token

### DIFF
--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
@@ -1,4 +1,3 @@
-import { TempDevFeature } from '~/app/hooks/useTempDevFeatureAvailable';
 import { appChrome } from './appChrome';
 import { TableRow } from './components/table';
 import { Modal } from './components/Modal';
@@ -153,13 +152,7 @@ class CatalogSourceStatusErrorModal extends Modal {
 }
 
 class ModelCatalogSettings {
-  visit({
-    wait = true,
-    enableTempDevCatalogHuggingFaceApiKeyFeature = false,
-  }: { wait?: boolean; enableTempDevCatalogHuggingFaceApiKeyFeature?: boolean } = {}) {
-    if (enableTempDevCatalogHuggingFaceApiKeyFeature) {
-      window.localStorage.setItem(TempDevFeature.CatalogHuggingFaceApiKey, 'true');
-    }
+  visit({ wait = true }: { wait?: boolean } = {}) {
     cy.visit('/model-catalog-settings');
     if (wait) {
       this.wait();
@@ -243,29 +236,14 @@ class ModelCatalogSettings {
 }
 
 class ManageSourcePage {
-  visitAddSource({
-    wait = true,
-    enableTempDevCatalogHuggingFaceApiKeyFeature = false,
-  }: { wait?: boolean; enableTempDevCatalogHuggingFaceApiKeyFeature?: boolean } = {}) {
-    if (enableTempDevCatalogHuggingFaceApiKeyFeature) {
-      window.localStorage.setItem(TempDevFeature.CatalogHuggingFaceApiKey, 'true');
-    }
+  visitAddSource({ wait = true }: { wait?: boolean } = {}) {
     cy.visit('/model-catalog-settings/add-source');
     if (wait) {
       this.wait();
     }
   }
 
-  visitManageSource(
-    catalogSourceId: string,
-    {
-      wait = true,
-      enableTempDevCatalogHuggingFaceApiKeyFeature = false,
-    }: { wait?: boolean; enableTempDevCatalogHuggingFaceApiKeyFeature?: boolean } = {},
-  ) {
-    if (enableTempDevCatalogHuggingFaceApiKeyFeature) {
-      window.localStorage.setItem(TempDevFeature.CatalogHuggingFaceApiKey, 'true');
-    }
+  visitManageSource(catalogSourceId: string, { wait = true }: { wait?: boolean } = {}) {
     cy.visit(`/model-catalog-settings/manage-source/${encodeURIComponent(catalogSourceId)}`);
     if (wait) {
       this.wait();

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
@@ -747,7 +747,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should show Hugging Face fields by default', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.findSourceTypeHuggingFace().should('be.checked');
       manageSourcePage.findCredentialsSection().should('exist');
       manageSourcePage.findAccessTokenInput().should('exist');
@@ -782,7 +782,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should enable Add button when all required HF fields are filled', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillSourceName('Test Source');
       manageSourcePage.fillAccessToken('test-token-123');
       manageSourcePage.fillOrganization('Google');
@@ -790,7 +790,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should keep Preview disabled when HF credentials are filled but not validated', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillAccessToken('test-token-123');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('be.disabled');
@@ -809,7 +809,7 @@ describe('Manage Source Page', () => {
         },
       }).as('validateHfCredentials');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillAccessToken('test-token-123');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('be.disabled');
@@ -821,7 +821,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should enable Preview for HF when only organization is filled', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('not.be.disabled');
       manageSourcePage.findPreviewPanelHeaderButton().should('not.be.disabled');
@@ -921,7 +921,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should maintain form state when switching between source types', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
 
       // Fill name and HF fields
       manageSourcePage.fillSourceName('Test Source');
@@ -1001,7 +1001,7 @@ describe('Manage Source Page', () => {
     });
 
     it('should keep all three preview buttons disabled when token is entered but not validated', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillAccessToken('test-token');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('be.disabled');
@@ -1020,7 +1020,7 @@ describe('Manage Source Page', () => {
         },
       }).as('previewSource');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.findPreviewButton().should('not.be.disabled');
       manageSourcePage.findPreviewButton().click();
@@ -1078,7 +1078,7 @@ describe('Manage Source Page', () => {
       cy.intercept('POST', '/model-registry/api/v1/settings/model_catalog/source_configs', {
         data: mockHuggingFaceCatalogSourceConfig({}),
       }).as('addSourcewithHuggingFaceType');
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.findNameInput().type('sample source');
       manageSourcePage.selectSourceType('huggingface');
       manageSourcePage.findSourceTypeHuggingFace().should('be.checked');
@@ -1313,9 +1313,7 @@ describe('Manage Source Page', () => {
       },
     ).as('manageSourcewithHuggingFaceType');
 
-    manageSourcePage.visitManageSource('huggingface_source_3', {
-      enableTempDevCatalogHuggingFaceApiKeyFeature: true,
-    });
+    manageSourcePage.visitManageSource('huggingface_source_3');
     manageSourcePage.findNameInput().should('have.value', 'Huggingface source 3');
 
     manageSourcePage.findAccessTokenInput().should('have.value', '••••••••');
@@ -1411,19 +1409,6 @@ describe('HuggingFace Credentials Validation', () => {
     setupMocks([], mockCatalogSourceConfigList({}));
   });
 
-  describe('Feature flag behavior', () => {
-    it('should show credentials section when flag is enabled', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
-      manageSourcePage.findCredentialsSection().should('exist');
-      manageSourcePage.findAccessTokenInput().should('exist');
-    });
-
-    it('should hide credentials section when flag is disabled', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: false });
-      manageSourcePage.findCredentialsSection().should('not.exist');
-    });
-  });
-
   describe('Validation success/fail (mocked with qwen)', () => {
     it('should show success alert when org and token are valid', () => {
       cy.intercept('POST', '/model-registry/api/v1/settings/model_catalog/source_preview*', {
@@ -1431,7 +1416,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewSuccessResponse,
       }).as('validateSuccess');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('valid-token-123');
 
@@ -1448,7 +1433,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewFailResponse,
       }).as('validateFail');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('qwen');
       manageSourcePage.fillAccessToken('any-token');
 
@@ -1464,7 +1449,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewFailResponse,
       }).as('validateFail');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('qwen');
       manageSourcePage.fillAccessToken('any-token');
 
@@ -1484,7 +1469,7 @@ describe('HuggingFace Credentials Validation', () => {
 
   describe('Eye/mask toggle behavior', () => {
     it('should toggle password visibility with eye button', () => {
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillAccessToken('my-secret-token');
 
       manageSourcePage.findAccessTokenInput().should('have.attr', 'type', 'password');
@@ -1502,7 +1487,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewSuccessResponse,
       }).as('validateSuccess');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('my-secret-token');
 
@@ -1525,7 +1510,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewSuccessResponse,
       }).as('validateSuccess');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('valid-token-123');
 
@@ -1543,7 +1528,7 @@ describe('HuggingFace Credentials Validation', () => {
         body: previewSuccessResponse,
       }).as('validateSuccess');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('valid-token-123');
       manageSourcePage.clickValidate();
@@ -1584,7 +1569,7 @@ describe('HuggingFace Credentials Validation', () => {
         data: mockHuggingFaceCatalogSourceConfig({}),
       }).as('addSource');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillSourceName('My HF Source');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('my-secret-token');
@@ -1606,7 +1591,7 @@ describe('HuggingFace Credentials Validation', () => {
         data: mockHuggingFaceCatalogSourceConfig({}),
       }).as('addSource');
 
-      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.visitAddSource();
       manageSourcePage.fillSourceName('My HF Source');
       manageSourcePage.fillOrganization('Google');
       manageSourcePage.fillAccessToken('my-secret-token');

--- a/clients/ui/frontend/src/app/hooks/useTempDevFeatureAvailable.ts
+++ b/clients/ui/frontend/src/app/hooks/useTempDevFeatureAvailable.ts
@@ -3,7 +3,7 @@
  *
  * This hook provides a browser storage-backed feature flag that can be toggled
  * via the browser console using:
- *     window.setTempDevCatalogHuggingFaceApiKeyFeatureAvailable(true/false);
+ *     window.setTempFeatureFlagAvailable(true/false);
  * The state persists across page reloads using browser storage.
  *
  * Each TempDevFeature and corresponding window.set* here should be removed once that feature is ready.
@@ -17,7 +17,7 @@ import { useBrowserStorage } from 'mod-arch-core';
 
 declare global {
   interface Window {
-    setTempDevCatalogHuggingFaceApiKeyFeatureAvailable?: (enabled: boolean) => void;
+    setTempFeatureFlagAvailable?: (enabled: boolean) => void;
   }
 }
 
@@ -29,7 +29,8 @@ export const useTempDevFeatureAvailable = (feature: TempDevFeature): boolean => 
   const [isAvailable, setIsAvailable] = useBrowserStorage(feature, false);
 
   React.useEffect(() => {
-    window.setTempDevCatalogHuggingFaceApiKeyFeatureAvailable = setIsAvailable;
+    // Placeholder console API for the temporary feature using this hook.
+    window.setTempFeatureFlagAvailable = setIsAvailable;
   }, [feature, setIsAvailable]);
 
   return isAvailable;

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/CredentialsSection.tsx
@@ -29,7 +29,6 @@ import {
   SUCCESS_MESSAGES,
   CLEAR_ACCESS_TOKEN_MODAL,
 } from '~/app/pages/modelCatalogSettings/constants';
-import { TempDevFeature, useTempDevFeatureAvailable } from '~/app/hooks/useTempDevFeatureAvailable';
 
 type CredentialsSectionProps = {
   formData: ManageSourceFormData;
@@ -82,53 +81,6 @@ const CredentialsSection: React.FC<CredentialsSectionProps> = ({
       setIsClearing(false);
     }
   }, [setData, onClearValidationSuccess, onClearCredentials]);
-
-  const accessTokenFeatureAvailable = useTempDevFeatureAvailable(
-    TempDevFeature.CatalogHuggingFaceApiKey,
-  );
-
-  if (!accessTokenFeatureAvailable) {
-    return (
-      <>
-        <ThemeAwareFormGroupWrapper
-          label={FORM_LABELS.ORGANIZATION}
-          fieldId="organization"
-          isRequired
-          hasError={isOrganizationTouched && !isOrganizationValid}
-          helperTextNode={
-            isOrganizationTouched && !isOrganizationValid ? (
-              <FormHelperText>
-                <HelperText>
-                  <HelperTextItem variant="error" data-testid="organization-error">
-                    {VALIDATION_MESSAGES.ORGANIZATION_REQUIRED}
-                  </HelperTextItem>
-                </HelperText>
-              </FormHelperText>
-            ) : undefined
-          }
-          popoverHelpText={DESCRIPTION_TEXT.ORGANIZATION}
-        >
-          <TextInput
-            isRequired
-            type="text"
-            id="organization"
-            name="organization"
-            data-testid="organization-input"
-            placeholder={PLACEHOLDERS.ORGANIZATION}
-            value={formData.organization}
-            onChange={(_event, value) => setData('organization', value)}
-            onBlur={() => setIsOrganizationTouched(true)}
-            validated={isOrganizationTouched && !isOrganizationValid ? 'error' : 'default'}
-          />
-        </ThemeAwareFormGroupWrapper>
-        <FormHelperText>
-          <HelperText>
-            <HelperTextItem>{HELPER_TEXT.ORGANIZATION_SLUG}</HelperTextItem>
-          </HelperText>
-        </FormHelperText>
-      </>
-    );
-  }
 
   const organizationInput = (
     <TextInput


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- [UI] Include any screenshots of changed UI; Include any gifs if it was a flow / UX change -->
Remove the temporary feature flag for the Hugging Face token field. The token field, validation, clear modal, and preview gating are now available without `CatalogHuggingFaceApiKey`.

Related Cypress tests and page objects were updated to use the Hugging Face token flow by default. The temporary feature hook, enum, and browser-storage helper were removed.

<img width="605" height="75" alt="Screenshot 2026-09-11 at 5 06 22 PM" src="https://github.com/user-attachments/assets/7623a950-1c8a-4f8a-874c-f80072f7f6b0" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- `npm run test:lint -- --quiet`
- Cypress mocked model catalog settings coverage was updated to verify the default Hugging Face token flow.
- Type-checking reaches existing unrelated `popoverHelpText` errors in `CredentialsSection.tsx`.
- The temporary `CatalogHuggingFaceApiKey` console/local-storage toggle is no longer available.
- Tested manually in mock mode

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits) (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR; testing instructions have been added above.
- [x] The developer has manually verified the cleanup and default token flow.
- [x] Code changes follow the [Kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/model-registry/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] screenshot or gif is attached
- [x] Verify that UI/UX changes conform the UX guidelines for Kubeflow.