### PR TITLE
Add icon in preview section and update error state for the gated models

### DIFF
--- a/clients/ui/api/openapi/mod-arch.yaml
+++ b/clients/ui/api/openapi/mod-arch.yaml
@@ -2980,6 +2980,13 @@ components:
           type: boolean
           nullable: true
           readOnly: true
+        hfUsername:
+          description: |-
+            The Hugging Face username associated with the stored API token.
+            Null when no token exists or authentication failed.
+          type: string
+          nullable: true
+          readOnly: true
         assetType:
           $ref: "#/components/schemas/assetType"
           description: |-
@@ -3631,6 +3638,17 @@ components:
         included:
           type: boolean
           description: Whether this asset would be included based on the source configuration
+        hfAccessType:
+          type: string
+          description: |-
+            Hugging Face access type classification. Only present for Hugging Face sources.
+            Possible values: public, private, gated_auto, gated_manual.
+          example: gated_auto
+        hfGatedAccessGranted:
+          type: boolean
+          description: |-
+            Whether the configured API key has been granted access to this gated model.
+            Only present for gated Hugging Face models when the information is available.
     CatalogSourcePreviewModel:
       description: |-
         Deprecated alias for `CatalogSourcePreviewItem`. A model or asset with its inclusion status.

--- a/clients/ui/bff/internal/mocks/static_data_mock.go
+++ b/clients/ui/bff/internal/mocks/static_data_mock.go
@@ -338,6 +338,18 @@ func hfAccessCustomProperties(accessType string, gatedAccessGranted ...string) *
 	return &result
 }
 
+func hfPreviewModel(name string, included bool, accessType string, gatedAccessGranted ...bool) models.CatalogSourcePreviewModel {
+	model := models.CatalogSourcePreviewModel{
+		Name:         name,
+		Included:     included,
+		HfAccessType: stringToPointer(accessType),
+	}
+	if len(gatedAccessGranted) > 0 {
+		model.HfGatedAccessGranted = BoolPtr(gatedAccessGranted[0])
+	}
+	return model
+}
+
 func NewMockSessionContext(parent context.Context) context.Context {
 	if parent == nil {
 		parent = context.TODO()
@@ -1004,6 +1016,7 @@ func GetCatalogSourceMocks() []models.CatalogSource {
 			Labels:        []string{"Sample category 2", "Sample category"},
 			HasApiKey:     &hasApiKeyTrue,
 			Authenticated: &authenticatedTrue,
+			HfUsername:    "johndoe",
 			// Status is nil - represents "Starting" state (no status yet)
 			Status: nil,
 		},
@@ -1016,6 +1029,7 @@ func GetCatalogSourceMocks() []models.CatalogSource {
 			Error:         &invalidCredentialError,
 			HasApiKey:     &hasApiKeyTrue,
 			Authenticated: &authenticatedFalse,
+			HfUsername:    "bob",
 		},
 		{
 			Id:      "adminModel2",
@@ -1062,6 +1076,7 @@ func GetCatalogSourceMocks() []models.CatalogSource {
 			Error:         &partialAvailabilityError,
 			HasApiKey:     &hasApiKeyTrue,
 			Authenticated: &authenticatedTrue,
+			HfUsername:    "alice",
 		},
 	}
 }
@@ -2680,16 +2695,36 @@ func GetModelsWithInclusionStatusListMocks() []models.CatalogSourcePreviewModel 
 	// We want 45 included and 25 excluded = 70 total models
 	var allModels []models.CatalogSourcePreviewModel
 
-	// Add 45 included models
-	for i := 1; i <= 45; i++ {
+	// Hugging Face access preview matrix (hfAccessType / hfGatedAccessGranted):
+	//   public              — no hfGatedAccessGranted
+	//   private             — no hfGatedAccessGranted
+	//   gated_auto + true   — access granted
+	//   gated_auto + false  — access denied
+	//   gated_manual + true — access granted
+	//   gated_manual + false— access denied
+	allModels = append(allModels,
+		hfPreviewModel("hf-mock/public-model", true, "public"),
+		hfPreviewModel("my-org/private-model", true, "private"),
+		hfPreviewModel("meta-llama/gated-auto-granted", true, "gated_auto", true),
+		hfPreviewModel("meta-llama/gated-auto-denied", false, "gated_auto", false),
+		hfPreviewModel("hf-mock/gated-manual-granted", true, "gated_manual", true),
+		hfPreviewModel("hf-mock/gated-manual-denied", false, "gated_manual", false),
+	)
+
+	// Add remaining included models (first two are gated for preview icon testing)
+	allModels = append(allModels,
+		hfPreviewModel("sample-source/included-model-1", true, "gated_auto", true),
+		hfPreviewModel("sample-source/included-model-2", true, "gated_manual", false),
+	)
+	for i := 3; i <= 41; i++ {
 		allModels = append(allModels, models.CatalogSourcePreviewModel{
 			Name:     fmt.Sprintf("sample-source/included-model-%d", i),
 			Included: true,
 		})
 	}
 
-	// Add 25 excluded models
-	for i := 1; i <= 25; i++ {
+	// Add remaining excluded models
+	for i := 1; i <= 23; i++ {
 		allModels = append(allModels, models.CatalogSourcePreviewModel{
 			Name:     fmt.Sprintf("sample-source/excluded-model-%d", i),
 			Included: false,

--- a/clients/ui/bff/internal/models/catalog_source_list.go
+++ b/clients/ui/bff/internal/models/catalog_source_list.go
@@ -9,6 +9,7 @@ type CatalogSource struct {
 	Error         *string  `json:"error,omitempty"`
 	HasApiKey     *bool    `json:"hasApiKey,omitempty"`
 	Authenticated *bool    `json:"authenticated,omitempty"`
+	HfUsername    string   `json:"hfUsername,omitempty"`
 }
 
 type CatalogSourceList struct {

--- a/clients/ui/bff/internal/models/catalog_source_preview.go
+++ b/clients/ui/bff/internal/models/catalog_source_preview.go
@@ -11,8 +11,10 @@ type CatalogSourcePreviewRequest struct {
 }
 
 type CatalogSourcePreviewModel struct {
-	Name     string `json:"name"`
-	Included bool   `json:"included"`
+	Name                 string  `json:"name"`
+	Included             bool    `json:"included"`
+	HfAccessType         *string `json:"hfAccessType,omitempty"`
+	HfGatedAccessGranted *bool   `json:"hfGatedAccessGranted,omitempty"`
 }
 
 type CatalogSourcePreviewSummary struct {

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/pages/modelCatalogSettings.ts
@@ -522,6 +522,23 @@ class ManageSourcePage {
   findPreviewModelsIncludedSummary(count: number, total: number) {
     return cy.contains(`${count} of ${total} models included:`);
   }
+
+  findPreviewModelsExcludedSummary(count: number, total: number) {
+    return cy.contains(`${count} of ${total} models excluded:`);
+  }
+
+  clickPreviewExcludedTab() {
+    this.findPreviewPanel().contains('Models excluded').click();
+    return this;
+  }
+
+  findPreviewModelRow(modelName: string) {
+    return this.findPreviewPanel().contains('li', modelName);
+  }
+
+  findPreviewGatedAccessWarningIcon(modelName: string) {
+    return this.findPreviewModelRow(modelName).findByLabelText('Gated access warning');
+  }
 }
 
 export const modelCatalogSettings = new ModelCatalogSettings();

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
@@ -618,3 +618,50 @@ export const setupHfAccessCardIntercepts = (models: CatalogModel[]): void => {
     mockCatalogModelList({ items: models }),
   );
 };
+
+export const GATED_DENIED_DETAILS_SOURCE_ID = 'hugging_face_source';
+export const GATED_DENIED_DETAILS_MODEL_NAME = 'meta-llama/Llama-3.1-8B-Instruct-INT8';
+
+export type GatedDeniedDetailsInterceptOptions = {
+  hfUsername?: string;
+};
+
+export const createGatedDeniedDetailsModel = (): CatalogModel =>
+  mockCatalogModel({
+    name: GATED_DENIED_DETAILS_MODEL_NAME,
+    provider: 'Meta',
+    description: '',
+    readme: '',
+    source_id: GATED_DENIED_DETAILS_SOURCE_ID,
+    customProperties: buildHfAccessCustomProperties('gated_auto', 'false'),
+  });
+
+/**
+ * Sets up intercepts for gated-denied model details tests without relying on
+ * setupModelCatalogIntercepts override behavior.
+ */
+export const setupGatedDeniedDetailsIntercepts = (
+  options: GatedDeniedDetailsInterceptOptions = {},
+): void => {
+  const { hfUsername } = options;
+  const gatedDeniedModel = createGatedDeniedDetailsModel();
+
+  cy.intercept('GET', '/model-registry/api/v1/model_registry*', [
+    mockModelRegistry({ name: 'modelregistry-sample' }),
+  ]).as('getModelRegistries');
+
+  interceptSources([
+    ...defaultSources(),
+    mockCatalogSource({
+      id: GATED_DENIED_DETAILS_SOURCE_ID,
+      name: 'Hugging face source',
+      labels: [],
+      ...(hfUsername ? { hfUsername, hasApiKey: true, authenticated: true } : {}),
+    }),
+  ]);
+  interceptLabels();
+  interceptFilterOptions();
+  interceptSingleModel(GATED_DENIED_DETAILS_SOURCE_ID, gatedDeniedModel);
+  interceptSingleModelRegex(gatedDeniedModel);
+  interceptArtifactsList({ items: [], size: 0, pageSize: 10, nextPageToken: '' });
+};

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog.ts
@@ -591,6 +591,9 @@ export const setupHfAccessCardIntercepts = (models: CatalogModel[]): void => {
     id: 'hugging_face_source',
     name: 'Hugging face source',
     labels: [],
+    hfUsername: 'alice',
+    hasApiKey: true,
+    authenticated: true,
   });
 
   interceptSources([hfSource]);

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -4,12 +4,14 @@ import { modelCatalog } from '~/__tests__/cypress/cypress/pages/modelCatalog';
 import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 import { mockModelRegistry } from '~/__mocks__/mockModelRegistry';
 import {
+  defaultSources,
+  interceptSources,
   setupModelCatalogIntercepts,
   setupValidatedModelIntercepts,
   interceptArtifactsList,
   interceptPerformanceArtifactsList,
 } from '~/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog';
-import { mockCatalogModelArtifact, mockCatalogModel } from '~/__mocks__';
+import { mockCatalogModelArtifact, mockCatalogModel, mockCatalogSource } from '~/__mocks__';
 import { mockRegisteredModelList } from '~/__mocks__/mockRegisteredModelsList';
 import { ModelRegistryMetadataType } from '~/app/types';
 import {
@@ -552,7 +554,19 @@ describe('Model Catalog Details Page - Gated access denied', () => {
       mockModelRegistry({ name: 'modelregistry-sample' }),
     ]).as('getModelRegistries');
 
-    setupModelCatalogIntercepts({});
+    setupModelCatalogIntercepts({
+      sources: [
+        ...defaultSources(),
+        mockCatalogSource({
+          id: 'hugging_face_source',
+          name: 'Hugging face source',
+          labels: [],
+          hfUsername: 'alice',
+          hasApiKey: true,
+          authenticated: true,
+        }),
+      ],
+    });
     cy.interceptApi(
       `GET /api/:apiVersion/model_catalog/sources/:sourceId/models/:modelName`,
       {
@@ -573,10 +587,43 @@ describe('Model Catalog Details Page - Gated access denied', () => {
 
     modelCatalog.findGatedAccessRequiredState().should('be.visible');
     modelCatalog.findGatedAccessRequiredState().should('contain.text', 'Model access required');
+    modelCatalog
+      .findGatedAccessRequiredState()
+      .should('contain.text', 'Log in to the Hugging Face account');
+    modelCatalog.findGatedAccessRequiredState().should('contain.text', 'alice');
     modelCatalog.findGatedAccessRequestLink().should('be.visible');
     modelCatalog.findDetailsDescription().should('not.exist');
     modelCatalog.findModelCardMarkdown().should('not.exist');
-    modelCatalog.findRegisterModelButton().should('be.disabled');
+    modelCatalog.findRegisterModelButton().should('have.attr', 'aria-disabled', 'true');
+    modelCatalog.findRegisterModelButton().trigger('mouseenter');
+    modelCatalog
+      .findRegisterCatalogModelTooltip()
+      .should('be.visible')
+      .and('contain.text', 'Model access is required to deploy or register this model.');
     modelCatalog.findAccessLabelGatedDenied().should('be.visible');
+  });
+
+  it('shows generic gated access guidance when hfUsername is unavailable', () => {
+    interceptSources([
+      ...defaultSources(),
+      mockCatalogSource({
+        id: 'hugging_face_source',
+        name: 'Hugging face source',
+        labels: [],
+      }),
+    ]);
+
+    modelCatalog.visitModelDetails('hugging_face_source', 'meta-llama/Llama-3.1-8B-Instruct-INT8');
+
+    modelCatalog.findGatedAccessRequiredState().should('be.visible');
+    modelCatalog
+      .findGatedAccessRequiredState()
+      .should(
+        'contain.text',
+        'This model is gated on Hugging Face. Request access on Hugging Face.',
+      );
+    modelCatalog
+      .findGatedAccessRequiredState()
+      .should('not.contain.text', 'Log in to the Hugging Face account');
   });
 });

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalog/modelCatalogDetails.cy.ts
@@ -4,14 +4,15 @@ import { modelCatalog } from '~/__tests__/cypress/cypress/pages/modelCatalog';
 import { appChrome } from '~/__tests__/cypress/cypress/pages/appChrome';
 import { mockModelRegistry } from '~/__mocks__/mockModelRegistry';
 import {
-  defaultSources,
-  interceptSources,
+  GATED_DENIED_DETAILS_MODEL_NAME,
+  GATED_DENIED_DETAILS_SOURCE_ID,
+  setupGatedDeniedDetailsIntercepts,
   setupModelCatalogIntercepts,
   setupValidatedModelIntercepts,
   interceptArtifactsList,
   interceptPerformanceArtifactsList,
 } from '~/__tests__/cypress/cypress/support/interceptHelpers/modelCatalog';
-import { mockCatalogModelArtifact, mockCatalogModel, mockCatalogSource } from '~/__mocks__';
+import { mockCatalogModelArtifact, mockCatalogModel } from '~/__mocks__';
 import { mockRegisteredModelList } from '~/__mocks__/mockRegisteredModelsList';
 import { ModelRegistryMetadataType } from '~/app/types';
 import {
@@ -531,58 +532,10 @@ describe('Model Catalog Registration - Model Type Field', () => {
 });
 
 describe('Model Catalog Details Page - Gated access denied', () => {
-  const gatedDeniedModel = mockCatalogModel({
-    name: 'meta-llama/Llama-3.1-8B-Instruct-INT8',
-    provider: 'Meta',
-    description: '',
-    readme: '',
-    source_id: 'hugging_face_source',
-    customProperties: {
-      hf_access_type: {
-        string_value: 'gated_auto',
-        metadataType: ModelRegistryMetadataType.STRING,
-      },
-      hf_gated_access_granted: {
-        string_value: 'false',
-        metadataType: ModelRegistryMetadataType.STRING,
-      },
-    },
-  });
-
-  beforeEach(() => {
-    cy.intercept('GET', '/model-registry/api/v1/model_registry*', [
-      mockModelRegistry({ name: 'modelregistry-sample' }),
-    ]).as('getModelRegistries');
-
-    setupModelCatalogIntercepts({
-      sources: [
-        ...defaultSources(),
-        mockCatalogSource({
-          id: 'hugging_face_source',
-          name: 'Hugging face source',
-          labels: [],
-          hfUsername: 'alice',
-          hasApiKey: true,
-          authenticated: true,
-        }),
-      ],
-    });
-    cy.interceptApi(
-      `GET /api/:apiVersion/model_catalog/sources/:sourceId/models/:modelName`,
-      {
-        path: {
-          apiVersion: MODEL_CATALOG_API_VERSION,
-          sourceId: 'hugging_face_source',
-          modelName: 'meta-llama%2FLlama-3.1-8B-Instruct-INT8',
-        },
-      },
-      gatedDeniedModel,
-    );
-    interceptArtifactsList({ items: [], size: 0, pageSize: 10, nextPageToken: '' });
-  });
-
   it('shows gated access required state instead of model details', () => {
-    modelCatalog.visitModelDetails('hugging_face_source', 'meta-llama/Llama-3.1-8B-Instruct-INT8');
+    setupGatedDeniedDetailsIntercepts({ hfUsername: 'alice' });
+
+    modelCatalog.visitModelDetails(GATED_DENIED_DETAILS_SOURCE_ID, GATED_DENIED_DETAILS_MODEL_NAME);
     appChrome.waitForA11y();
 
     modelCatalog.findGatedAccessRequiredState().should('be.visible');
@@ -604,16 +557,9 @@ describe('Model Catalog Details Page - Gated access denied', () => {
   });
 
   it('shows generic gated access guidance when hfUsername is unavailable', () => {
-    interceptSources([
-      ...defaultSources(),
-      mockCatalogSource({
-        id: 'hugging_face_source',
-        name: 'Hugging face source',
-        labels: [],
-      }),
-    ]);
+    setupGatedDeniedDetailsIntercepts();
 
-    modelCatalog.visitModelDetails('hugging_face_source', 'meta-llama/Llama-3.1-8B-Instruct-INT8');
+    modelCatalog.visitModelDetails(GATED_DENIED_DETAILS_SOURCE_ID, GATED_DENIED_DETAILS_MODEL_NAME);
 
     modelCatalog.findGatedAccessRequiredState().should('be.visible');
     modelCatalog

--- a/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
+++ b/clients/ui/frontend/src/__tests__/cypress/cypress/tests/mocked/modelCatalogSettings/modelCatalogSettings.cy.ts
@@ -1009,6 +1009,57 @@ describe('Manage Source Page', () => {
       manageSourcePage.findPreviewPanelBodyButton().should('be.disabled');
     });
 
+    it('should show warning icon for gated models without access in preview tabs', () => {
+      cy.intercept('POST', '/model-registry/api/v1/settings/model_catalog/source_preview*', {
+        data: {
+          items: [
+            {
+              name: 'sample-source/included-model-1',
+              included: true,
+              hfAccessType: 'gated_auto',
+              hfGatedAccessGranted: true,
+            },
+            {
+              name: 'sample-source/included-model-2',
+              included: true,
+              hfAccessType: 'gated_manual',
+              hfGatedAccessGranted: false,
+            },
+            {
+              name: 'meta-llama/gated-auto-denied',
+              included: false,
+              hfAccessType: 'gated_auto',
+              hfGatedAccessGranted: false,
+            },
+          ],
+          summary: { totalModels: 3, includedModels: 2, excludedModels: 1 },
+          nextPageToken: '',
+          pageSize: 20,
+          size: 3,
+        },
+      }).as('previewGatedModels');
+
+      manageSourcePage.visitAddSource({ enableTempDevCatalogHuggingFaceApiKeyFeature: true });
+      manageSourcePage.fillOrganization('Google');
+      manageSourcePage.findPreviewButton().click();
+      cy.wait('@previewGatedModels');
+
+      manageSourcePage.findPreviewModelsIncludedSummary(2, 3).should('exist');
+      manageSourcePage
+        .findPreviewModelRow('sample-source/included-model-1')
+        .findByLabelText('Included model')
+        .should('exist');
+      manageSourcePage
+        .findPreviewGatedAccessWarningIcon('sample-source/included-model-2')
+        .should('exist');
+
+      manageSourcePage.clickPreviewExcludedTab();
+      manageSourcePage.findPreviewModelsExcludedSummary(1, 3).should('exist');
+      manageSourcePage
+        .findPreviewGatedAccessWarningIcon('meta-llama/gated-auto-denied')
+        .should('exist');
+    });
+
     it('should show refresh alert with enabled link when token is typed after preview without token', () => {
       cy.intercept('POST', '/model-registry/api/v1/settings/model_catalog/source_preview*', {
         data: {

--- a/clients/ui/frontend/src/app/modelCatalogTypes.ts
+++ b/clients/ui/frontend/src/app/modelCatalogTypes.ts
@@ -457,6 +457,8 @@ export type CatalogSourcePreviewRequest = {
 export type CatalogSourcePreviewModel = {
   name: string;
   included: boolean;
+  hfAccessType?: string;
+  hfGatedAccessGranted?: boolean;
 };
 
 export type CatalogSourcePreviewSummary = {

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsPage.tsx
@@ -23,10 +23,12 @@ import { ApplicationsPage } from 'mod-arch-shared';
 import {
   decodeParams,
   getModelName,
+  getSourceFromSourceId,
   hasModelArtifacts,
   isModelValidated,
   getHfAccessLabelVariant,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import { ModelCatalogContext } from '~/app/context/modelCatalog/ModelCatalogContext';
 import { useCatalogModel } from '~/app/hooks/modelCatalog/useCatalogModel';
 import { ModelRegistrySelectorContext } from '~/app/context/ModelRegistrySelectorContext';
 import { getRegisterCatalogModelRoute } from '~/app/routes/modelCatalog/catalogModelRegister';
@@ -34,7 +36,11 @@ import { CatalogModelDetailsParams } from '~/app/modelCatalogTypes';
 import { useCatalogModelArtifacts } from '~/app/hooks/modelCatalog/useCatalogModelArtifacts';
 import { modelCatalogUrl } from '~/app/routes/modelCatalog/catalogModel';
 import ScrollViewOnMount from '~/app/shared/components/ScrollViewOnMount';
-import { ModelDetailsTab, MODEL_CATALOG_POPOVER_MESSAGES } from '~/concepts/modelCatalog/const';
+import {
+  ModelDetailsTab,
+  MODEL_CATALOG_GATED_ACCESS_REQUIRED,
+  MODEL_CATALOG_POPOVER_MESSAGES,
+} from '~/concepts/modelCatalog/const';
 import { MODEL_CATALOG_TITLE } from '~/app/pages/modelCatalog/const';
 import ModelCatalogAccessLabel from '~/app/pages/modelCatalog/components/ModelCatalogAccessLabel';
 import ModelDetailsTabs from './ModelDetailsTabs';
@@ -55,6 +61,11 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
   const { modelRegistries, modelRegistriesLoadError, modelRegistriesLoaded } = React.useContext(
     ModelRegistrySelectorContext,
   );
+  const { catalogSources } = React.useContext(ModelCatalogContext);
+  const hfUsername = getSourceFromSourceId(
+    decodedParams.sourceId || '',
+    catalogSources,
+  )?.hfUsername;
 
   const [artifacts, artifactLoaded, artifactsLoadError] = useCatalogModelArtifacts(
     decodedParams.sourceId || '',
@@ -86,11 +97,7 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
 
   const registerModelButton = () => {
     if (gatedAccessDenied) {
-      return (
-        <Button variant="primary" isDisabled data-testid="register-model-button">
-          Register model
-        </Button>
-      );
+      return registerButtonTooltip('', MODEL_CATALOG_GATED_ACCESS_REQUIRED.REGISTER_BUTTON_TOOLTIP);
     }
 
     if (!modelRegistriesLoaded || modelRegistriesLoadError) {
@@ -218,6 +225,7 @@ const ModelDetailsPage: React.FC<ModelDetailsPageProps> = ({ tab }) => {
             artifactLoaded={artifactLoaded}
             artifactsLoadError={artifactsLoadError}
             gatedAccessDenied={gatedAccessDenied}
+            hfUsername={hfUsername}
           />
         )}
       </ApplicationsPage>

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsTabs.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelDetailsTabs.tsx
@@ -20,6 +20,7 @@ type ModelDetailsTabsProps = {
   artifactLoaded: boolean;
   artifactsLoadError: Error | undefined;
   gatedAccessDenied: boolean;
+  hfUsername?: string;
 };
 
 const ModelDetailsTabs = ({
@@ -29,6 +30,7 @@ const ModelDetailsTabs = ({
   artifactLoaded,
   artifactsLoadError,
   gatedAccessDenied,
+  hfUsername,
 }: ModelDetailsTabsProps): React.JSX.Element => {
   const navigate = useNavigate();
 
@@ -40,7 +42,7 @@ const ModelDetailsTabs = ({
         data-testid="model-overview-tab-content"
         padding={{ default: 'noPadding' }}
       >
-        <ModelGatedAccessRequiredView model={model} />
+        <ModelGatedAccessRequiredView model={model} hfUsername={hfUsername} />
       </PageSection>
     );
   }

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView.tsx
@@ -9,6 +9,7 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import type { CatalogModel } from '~/app/modelCatalogTypes';
+import { renderGatedAccessRequiredDescription } from '~/app/pages/modelCatalog/utils/gatedAccessRequiredUtils';
 import { getHuggingFaceModelUrl } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import ExternalLink from '~/app/shared/components/ExternalLink';
 import { MODEL_CATALOG_GATED_ACCESS_REQUIRED } from '~/concepts/modelCatalog/const';
@@ -30,17 +31,7 @@ const ModelGatedAccessRequiredView: React.FC<ModelGatedAccessRequiredViewProps> 
       variant={EmptyStateVariant.lg}
       data-testid="model-gated-access-required"
     >
-      <EmptyStateBody>
-        {hfUsername ? (
-          <>
-            This model is gated on Hugging Face. Log in to the Hugging Face account{' '}
-            <strong>{hfUsername}</strong> and request access. After access is granted on Hugging
-            Face, it might take a few hours for this model to show as available in the catalog.
-          </>
-        ) : (
-          MODEL_CATALOG_GATED_ACCESS_REQUIRED.DESCRIPTION_WITHOUT_USERNAME
-        )}
-      </EmptyStateBody>
+      <EmptyStateBody>{renderGatedAccessRequiredDescription(hfUsername)}</EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>
           <ExternalLink

--- a/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/screens/ModelGatedAccessRequiredView.tsx
@@ -15,9 +15,13 @@ import { MODEL_CATALOG_GATED_ACCESS_REQUIRED } from '~/concepts/modelCatalog/con
 
 type ModelGatedAccessRequiredViewProps = {
   model: CatalogModel;
+  hfUsername?: string;
 };
 
-const ModelGatedAccessRequiredView: React.FC<ModelGatedAccessRequiredViewProps> = ({ model }) => (
+const ModelGatedAccessRequiredView: React.FC<ModelGatedAccessRequiredViewProps> = ({
+  model,
+  hfUsername,
+}) => (
   <PageSection hasBodyWrapper={false} isFilled padding={{ default: 'noPadding' }}>
     <EmptyState
       headingLevel="h2"
@@ -26,7 +30,17 @@ const ModelGatedAccessRequiredView: React.FC<ModelGatedAccessRequiredViewProps> 
       variant={EmptyStateVariant.lg}
       data-testid="model-gated-access-required"
     >
-      <EmptyStateBody>{MODEL_CATALOG_GATED_ACCESS_REQUIRED.DESCRIPTION}</EmptyStateBody>
+      <EmptyStateBody>
+        {hfUsername ? (
+          <>
+            This model is gated on Hugging Face. Log in to the Hugging Face account{' '}
+            <strong>{hfUsername}</strong> and request access. After access is granted on Hugging
+            Face, it might take a few hours for this model to show as available in the catalog.
+          </>
+        ) : (
+          MODEL_CATALOG_GATED_ACCESS_REQUIRED.DESCRIPTION_WITHOUT_USERNAME
+        )}
+      </EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>
           <ExternalLink

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/hfAccessUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/__tests__/hfAccessUtils.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import { render } from '@testing-library/react';
 import { CatalogModel } from '~/app/modelCatalogTypes';
 import { CatalogModelCustomPropertyKey, HfAccessType } from '~/concepts/modelCatalog/const';
 import { ModelRegistryMetadataType } from '~/app/types';
@@ -8,7 +9,13 @@ import {
   getHfGatedAccessGranted,
   getHuggingFaceModelUrl,
   isHfGatedAccessDenied,
+  isHfGatedAccessDeniedFromFields,
 } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
+import {
+  getGatedAccessRequiredDescriptionText,
+  renderGatedAccessRequiredDescription,
+} from '~/app/pages/modelCatalog/utils/gatedAccessRequiredUtils';
+import { isPreviewModelGatedAccessDenied } from '~/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils';
 import { createHfAccessCatalogModel } from '~/__tests__/utils/createHfAccessModel';
 
 describe('HF access utilities', () => {
@@ -93,5 +100,60 @@ describe('HF access utilities', () => {
     expect(getHuggingFaceModelUrl(model)).toBe(
       'https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct-INT8',
     );
+  });
+});
+
+describe('isHfGatedAccessDeniedFromFields', () => {
+  it('returns true for gated models without granted access', () => {
+    expect(isHfGatedAccessDeniedFromFields('gated_auto', false)).toBe(true);
+    expect(isHfGatedAccessDeniedFromFields('gated_manual', undefined)).toBe(true);
+  });
+
+  it('returns false for gated models with granted access', () => {
+    expect(isHfGatedAccessDeniedFromFields('gated_auto', true)).toBe(false);
+  });
+
+  it('returns false for non-gated access types', () => {
+    expect(isHfGatedAccessDeniedFromFields('public', false)).toBe(false);
+    expect(isHfGatedAccessDeniedFromFields(undefined, false)).toBe(false);
+  });
+});
+
+describe('gated access required description', () => {
+  it('formats generic and personalized descriptions from shared copy', () => {
+    expect(getGatedAccessRequiredDescriptionText()).toBe(
+      'This model is gated on Hugging Face. Request access on Hugging Face. After access is granted on Hugging Face, it might take a few hours for this model to show as available in the catalog.',
+    );
+    expect(getGatedAccessRequiredDescriptionText('johndoe')).toBe(
+      'This model is gated on Hugging Face. Log in to the Hugging Face account johndoe and request access. After access is granted on Hugging Face, it might take a few hours for this model to show as available in the catalog.',
+    );
+  });
+
+  it('renders personalized description with bold username', () => {
+    const { container } = render(renderGatedAccessRequiredDescription('alice'));
+    expect(container.textContent).toContain('Log in to the Hugging Face account');
+    expect(container.querySelector('strong')?.textContent).toBe('alice');
+  });
+});
+
+describe('isPreviewModelGatedAccessDenied', () => {
+  it('uses the shared gated access rule for preview fields', () => {
+    expect(
+      isPreviewModelGatedAccessDenied({
+        name: 'sample-source/included-model-2',
+        included: true,
+        hfAccessType: 'gated_manual',
+        hfGatedAccessGranted: false,
+      }),
+    ).toBe(true);
+
+    expect(
+      isPreviewModelGatedAccessDenied({
+        name: 'sample-source/included-model-1',
+        included: true,
+        hfAccessType: 'gated_auto',
+        hfGatedAccessGranted: true,
+      }),
+    ).toBe(false);
   });
 });

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/gatedAccessRequiredUtils.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/gatedAccessRequiredUtils.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY } from '~/concepts/modelCatalog/const';
+
+export const getGatedAccessRequiredDescriptionText = (hfUsername?: string): string => {
+  const { INTRO, GENERIC_ACTION, USERNAME_PROMPT, USERNAME_ACTION, OUTRO } =
+    MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY;
+
+  if (!hfUsername) {
+    return `${INTRO} ${GENERIC_ACTION} ${OUTRO}`;
+  }
+
+  return `${INTRO} ${USERNAME_PROMPT} ${hfUsername} ${USERNAME_ACTION} ${OUTRO}`;
+};
+
+export const renderGatedAccessRequiredDescription = (hfUsername?: string): React.ReactNode => {
+  const { INTRO, USERNAME_PROMPT, USERNAME_ACTION, OUTRO } =
+    MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY;
+
+  if (!hfUsername) {
+    return getGatedAccessRequiredDescriptionText();
+  }
+
+  return (
+    <>
+      {INTRO} {USERNAME_PROMPT} <strong>{hfUsername}</strong> {USERNAME_ACTION} {OUTRO}
+    </>
+  );
+};

--- a/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalog/utils/modelCatalogUtils.ts
@@ -156,7 +156,18 @@ export const hasPerformanceArtifacts = (artifacts: CatalogArtifacts[]): boolean 
 
 export type HfAccessLabelVariant = 'private' | 'gated' | 'gated-denied';
 
-const isGatedAccessType = (accessType: string): boolean => accessType.startsWith('gated');
+export const isGatedAccessType = (accessType: string): boolean => accessType.startsWith('gated');
+
+export const isHfGatedAccessDeniedFromFields = (
+  accessType?: string | null,
+  gatedAccessGranted?: boolean | null,
+): boolean => {
+  if (!accessType || !isGatedAccessType(accessType)) {
+    return false;
+  }
+
+  return gatedAccessGranted !== true;
+};
 
 export const getHfGatedAccessGranted = (model: CatalogModel): boolean => {
   if (!model.customProperties) {
@@ -202,15 +213,25 @@ export const getHfAccessLabelVariant = (model: CatalogModel): HfAccessLabelVaria
     return 'private';
   }
 
+  if (isHfGatedAccessDeniedFromFields(accessType, getHfGatedAccessGranted(model))) {
+    return 'gated-denied';
+  }
+
   if (isGatedAccessType(accessType)) {
-    return getHfGatedAccessGranted(model) ? 'gated' : 'gated-denied';
+    return 'gated';
   }
 
   return null;
 };
 
-export const isHfGatedAccessDenied = (model: CatalogModel): boolean =>
-  getHfAccessLabelVariant(model) === 'gated-denied';
+export const isHfGatedAccessDenied = (model: CatalogModel): boolean => {
+  const accessType = getHfAccessType(model);
+  if (!accessType) {
+    return false;
+  }
+
+  return isHfGatedAccessDeniedFromFields(accessType, getHfGatedAccessGranted(model));
+};
 
 // TODO: this needs to be updated with the customProperties of the model, where we will have the HF link
 export const getHuggingFaceModelUrl = (model: CatalogModel): string =>

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/components/PreviewPanel.tsx
@@ -17,13 +17,16 @@ import {
   Spinner,
   Button,
   AlertActionLink,
+  Icon,
 } from '@patternfly/react-core';
-import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon, ExclamationTriangleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 import {
   PAGE_TITLES,
   ERROR_MESSAGES,
   EMPTY_STATE_TEXT,
 } from '~/app/pages/modelCatalogSettings/constants';
+import { isPreviewModelGatedAccessDenied } from '~/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils';
+import { CatalogSourcePreviewModel } from '~/app/modelCatalogTypes';
 import { UseSourcePreviewResult } from '~/app/pages/modelCatalogSettings/useSourcePreview';
 import { CatalogSettingsPreviewTab } from '~/app/shared/catalogSettings/hooks/previewTypes';
 import PreviewButton from './PreviewButton';
@@ -54,6 +57,22 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
     handleTabChange(
       tabIndex === 0 ? CatalogSettingsPreviewTab.INCLUDED : CatalogSettingsPreviewTab.EXCLUDED,
     );
+  };
+
+  const renderModelIcon = (model: CatalogSourcePreviewModel) => {
+    if (isPreviewModelGatedAccessDenied(model)) {
+      return (
+        <Icon status="warning">
+          <ExclamationTriangleIcon aria-label="Gated access warning" />
+        </Icon>
+      );
+    }
+
+    if (model.included) {
+      return <CheckCircleIcon color="green" aria-label="Included model" />;
+    }
+
+    return <TimesCircleIcon color="red" aria-label="Excluded model" />;
   };
 
   const renderEmptyState = () => {
@@ -150,16 +169,7 @@ const PreviewPanel: React.FC<PreviewPanelProps> = ({ preview }) => {
               </strong>
               <List isPlain className="pf-v6-u-mt-md">
                 {items.map((model) => (
-                  <ListItem
-                    key={model.name}
-                    icon={
-                      model.included ? (
-                        <CheckCircleIcon color="green" />
-                      ) : (
-                        <TimesCircleIcon color="red" />
-                      )
-                    }
-                  >
+                  <ListItem key={model.name} icon={renderModelIcon(model)}>
                     {model.name}
                   </ListItem>
                 ))}

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/utils/__tests__/modelCatalogSettingsUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/utils/__tests__/modelCatalogSettingsUtils.spec.ts
@@ -3,7 +3,6 @@ import { CatalogSourceType } from '~/app/modelCatalogTypes';
 import {
   catalogSourceConfigToFormData,
   getPayloadForConfig,
-  isPreviewModelGatedAccessDenied,
   transformFormDataToConfig,
   resolveHuggingFaceApiKeyField,
 } from '~/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils';
@@ -275,39 +274,5 @@ describe('resolveHuggingFaceApiKeyField', () => {
         forPreview: false,
       }),
     ).toEqual({ apiKey: '' });
-  });
-});
-
-describe('isPreviewModelGatedAccessDenied', () => {
-  it('returns true for gated models without granted access', () => {
-    expect(
-      isPreviewModelGatedAccessDenied({
-        name: 'meta-llama/gated-auto-denied',
-        included: false,
-        hfAccessType: 'gated_auto',
-        hfGatedAccessGranted: false,
-      }),
-    ).toBe(true);
-  });
-
-  it('returns false for gated models with granted access', () => {
-    expect(
-      isPreviewModelGatedAccessDenied({
-        name: 'meta-llama/gated-auto-granted',
-        included: true,
-        hfAccessType: 'gated_auto',
-        hfGatedAccessGranted: true,
-      }),
-    ).toBe(false);
-  });
-
-  it('returns false for non-gated models', () => {
-    expect(
-      isPreviewModelGatedAccessDenied({
-        name: 'hf-mock/public-model',
-        included: true,
-        hfAccessType: 'public',
-      }),
-    ).toBe(false);
   });
 });

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/utils/__tests__/modelCatalogSettingsUtils.spec.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/utils/__tests__/modelCatalogSettingsUtils.spec.ts
@@ -3,6 +3,7 @@ import { CatalogSourceType } from '~/app/modelCatalogTypes';
 import {
   catalogSourceConfigToFormData,
   getPayloadForConfig,
+  isPreviewModelGatedAccessDenied,
   transformFormDataToConfig,
   resolveHuggingFaceApiKeyField,
 } from '~/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils';
@@ -274,5 +275,39 @@ describe('resolveHuggingFaceApiKeyField', () => {
         forPreview: false,
       }),
     ).toEqual({ apiKey: '' });
+  });
+});
+
+describe('isPreviewModelGatedAccessDenied', () => {
+  it('returns true for gated models without granted access', () => {
+    expect(
+      isPreviewModelGatedAccessDenied({
+        name: 'meta-llama/gated-auto-denied',
+        included: false,
+        hfAccessType: 'gated_auto',
+        hfGatedAccessGranted: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for gated models with granted access', () => {
+    expect(
+      isPreviewModelGatedAccessDenied({
+        name: 'meta-llama/gated-auto-granted',
+        included: true,
+        hfAccessType: 'gated_auto',
+        hfGatedAccessGranted: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for non-gated models', () => {
+    expect(
+      isPreviewModelGatedAccessDenied({
+        name: 'hf-mock/public-model',
+        included: true,
+        hfAccessType: 'public',
+      }),
+    ).toBe(false);
   });
 });

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils.ts
@@ -4,18 +4,13 @@ import {
   CatalogSourcePreviewModel,
   CatalogSourceType,
 } from '~/app/modelCatalogTypes';
+import { isHfGatedAccessDeniedFromFields } from '~/app/pages/modelCatalog/utils/modelCatalogUtils';
 import { ManageSourceFormData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
 import { generateSourceIdFromName } from '~/app/shared/catalogSettings/utils/generateSourceIdFromName';
 import { parseCommaSeparatedList } from '~/app/shared/catalogSettings/utils/parseCommaSeparatedList';
 
-export const isPreviewModelGatedAccessDenied = (model: CatalogSourcePreviewModel): boolean => {
-  const accessType = model.hfAccessType;
-  if (!accessType?.startsWith('gated')) {
-    return false;
-  }
-
-  return model.hfGatedAccessGranted !== true;
-};
+export const isPreviewModelGatedAccessDenied = (model: CatalogSourcePreviewModel): boolean =>
+  isHfGatedAccessDeniedFromFields(model.hfAccessType, model.hfGatedAccessGranted);
 
 export const catalogSourceConfigToFormData = (
   sourceConfig: CatalogSourceConfig,

--- a/clients/ui/frontend/src/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils.ts
+++ b/clients/ui/frontend/src/app/pages/modelCatalogSettings/utils/modelCatalogSettingsUtils.ts
@@ -1,11 +1,21 @@
 import {
   CatalogSourceConfig,
   CatalogSourceConfigPayload,
+  CatalogSourcePreviewModel,
   CatalogSourceType,
 } from '~/app/modelCatalogTypes';
 import { ManageSourceFormData } from '~/app/pages/modelCatalogSettings/useManageSourceData';
 import { generateSourceIdFromName } from '~/app/shared/catalogSettings/utils/generateSourceIdFromName';
 import { parseCommaSeparatedList } from '~/app/shared/catalogSettings/utils/parseCommaSeparatedList';
+
+export const isPreviewModelGatedAccessDenied = (model: CatalogSourcePreviewModel): boolean => {
+  const accessType = model.hfAccessType;
+  if (!accessType?.startsWith('gated')) {
+    return false;
+  }
+
+  return model.hfGatedAccessGranted !== true;
+};
 
 export const catalogSourceConfigToFormData = (
   sourceConfig: CatalogSourceConfig,

--- a/clients/ui/frontend/src/app/shared/types/catalogTypes.ts
+++ b/clients/ui/frontend/src/app/shared/types/catalogTypes.ts
@@ -20,6 +20,7 @@ export type CatalogSource = {
   assetType?: CatalogAssetType;
   hasApiKey?: boolean;
   authenticated?: boolean;
+  hfUsername?: string;
 };
 
 export type PaginationParams = {

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -260,10 +260,18 @@ export enum ModelCatalogTensorType {
   MXFP4 = 'MXFP4',
 }
 
+export const MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY = {
+  INTRO: 'This model is gated on Hugging Face.',
+  USERNAME_PROMPT: 'Log in to the Hugging Face account',
+  USERNAME_ACTION: 'and request access.',
+  GENERIC_ACTION: 'Request access on Hugging Face.',
+  OUTRO:
+    'After access is granted on Hugging Face, it might take a few hours for this model to show as available in the catalog.',
+} as const;
+
 export const MODEL_CATALOG_GATED_ACCESS_REQUIRED = {
   TITLE: 'Model access required',
-  DESCRIPTION_WITHOUT_USERNAME:
-    'This model is gated on Hugging Face. Request access on Hugging Face. After access is granted on Hugging Face, it might take a few hours for this model to show as available in the catalog.',
+  ...MODEL_CATALOG_GATED_ACCESS_REQUIRED_COPY,
   REQUEST_ACCESS_LINK_TEXT: 'Request access on Hugging Face',
   REGISTER_BUTTON_TOOLTIP: 'Model access is required to deploy or register this model.',
 } as const;

--- a/clients/ui/frontend/src/concepts/modelCatalog/const.ts
+++ b/clients/ui/frontend/src/concepts/modelCatalog/const.ts
@@ -262,9 +262,10 @@ export enum ModelCatalogTensorType {
 
 export const MODEL_CATALOG_GATED_ACCESS_REQUIRED = {
   TITLE: 'Model access required',
-  DESCRIPTION:
-    'You do not have access to this model, so it cannot be deployed or registered. Go to Hugging Face to request permission for this model.',
+  DESCRIPTION_WITHOUT_USERNAME:
+    'This model is gated on Hugging Face. Request access on Hugging Face. After access is granted on Hugging Face, it might take a few hours for this model to show as available in the catalog.',
   REQUEST_ACCESS_LINK_TEXT: 'Request access on Hugging Face',
+  REGISTER_BUTTON_TOOLTIP: 'Model access is required to deploy or register this model.',
 } as const;
 
 export const HUGGING_FACE_BASE_URL = 'https://huggingface.co';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR aims to add warning icon for the gated models and update error state in model details page with HF username

<img width="1153" height="531" alt="Screenshot 2026-09-11 at 7 49 41 PM" src="https://github.com/user-attachments/assets/5c7def75-b2a4-46ab-a25e-3e8acf3e3eaf" />
<img width="421" height="520" alt="Screenshot 2026-09-11 at 7 49 54 PM" src="https://github.com/user-attachments/assets/db1bd58b-ae46-40fc-aa96-697eada5478b" />
<img width="377" height="358" alt="Screenshot 2026-09-11 at 7 50 00 PM" src="https://github.com/user-attachments/assets/3b31218b-8924-4378-9c1a-315b22783e34" />

## How Has This Been Tested?
Run the application in mock mode,
check the hugging face source to see the gated models with warning icon on both included and excluded section
Go to model catalog and check for the gated models that the error state has the HF user name 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
- All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] The commits have meaningful messages
- [x] Automated tests are provided as part of the PR for major new functionalities; testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work.
- [x] Code changes follow the [kubeflow contribution guidelines](https://www.kubeflow.org/docs/about/contributing/).
- [ ] **For first time contributors**: Please reach out to the [Reviewers](https://github.com/kubeflow/hub/blob/main/OWNERS) to ensure all tests are being run, ensuring the label `ok-to-test` has been added to the PR.

If you have UI changes

<!--- You can ignore these if you are doing Go Model Registry REST server, MR Python client, manifest, controller, internal logic, etc changes; aka non-UI / visual changes -->
- [x] The developer has added tests or explained why testing cannot be added.
- [x] Included any necessary screenshots or gifs if it was a UI change.
- [ ] Verify that UI/UX changes conform the UX guidelines for Kubeflow.
